### PR TITLE
chore(release): bump from RC to release version

### DIFF
--- a/packages/eslint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/eslint-config-ibmdotcom/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **eslint:** removed unused eslint configurations
+  ([848f52b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/848f52b))
+- **lerna:** added fixes to private package.json to prevent publishing
+  ([4df6797](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/4df6797))
+- **lerna:** reverting private package version names
+  ([ee1cdef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/ee1cdef))
+- **lerna:** reverting private package version names
+  ([8ad8461](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/8ad8461))
+
+### Features
+
+- **jsdoc:** added jsdoc generation from services
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/d2089e4))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.1.0 (2019-07-30)
 
 # 0.1.0-rc.0 (2019-07-30)

--- a/packages/eslint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/eslint-config-ibmdotcom/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **eslint:** removed unused eslint configurations
+  ([848f52b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/848f52b))
+- **lerna:** added fixes to private package.json to prevent publishing
+  ([4df6797](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/4df6797))
+- **lerna:** reverting private package version names
+  ([ee1cdef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/ee1cdef))
+- **lerna:** reverting private package version names
+  ([8ad8461](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/8ad8461))
+
+### Features
+
+- **jsdoc:** added jsdoc generation from services
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/d2089e4))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0-rc.0 (2019-08-05)
 
 # 0.1.0 (2019-07-30)

--- a/packages/eslint-config-ibmdotcom/package.json
+++ b/packages/eslint-config-ibmdotcom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/eslint-config-ibmdotcom",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-rc.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom",

--- a/packages/eslint-config-ibmdotcom/package.json
+++ b/packages/eslint-config-ibmdotcom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/eslint-config-ibmdotcom",
   "private": true,
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Features
+
+- **footer:** laying down the basework for the footer
+  ([bf05b3c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bf05b3c))
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **ci:** move loads.js to correct dir
+  ([584fdd5](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/584fdd5))
+- **yarn:** add loader file for ci-check
+  ([ca02703](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/ca02703))
+
+### Features
+
+- **component:** add Masthead component stub
+  ([fee6b44](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/fee6b44))
+- **components:** add masthead react stub
+  ([3cd2b5b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/3cd2b5b))
+- **jsdoc:** added jsdoc generation from services
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d2089e4))
+- **lerna:** adjusting initial version to 0.0.0
+  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/3f01404))
+- **lerna:** cleaned up react package.json
+  ([fde3da3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/fde3da3))
+- **lerna:** updated package names and versions
+  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/9929d1c))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0-rc.0 (2019-08-05)
 
 ### Features

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0-rc.0 (2019-08-05)
+
+### Features
+
+- **footer:** laying down the basework for the footer
+  ([bf05b3c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bf05b3c))
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **ci:** move loads.js to correct dir
+  ([584fdd5](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/584fdd5))
+- **yarn:** add loader file for ci-check
+  ([ca02703](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/ca02703))
+
+### Features
+
+- **component:** add Masthead component stub
+  ([fee6b44](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/fee6b44))
+- **components:** add masthead react stub
+  ([3cd2b5b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/3cd2b5b))
+- **jsdoc:** added jsdoc generation from services
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d2089e4))
+- **lerna:** adjusting initial version to 0.0.0
+  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/3f01404))
+- **lerna:** cleaned up react package.json
+  ([fde3da3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/fde3da3))
+- **lerna:** updated package names and versions
+  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/9929d1c))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.1.0 (2019-07-30)
 
 # 0.1.0-rc.0 (2019-07-30)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/react",
   "description": "IBM.com Library React Components",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -194,5 +194,5 @@
   "release": {
     "branch": "master"
   },
-  "gitHead": "2f315158472924e2416bc7b4eb83a0363e89ba69"
+  "gitHead": "7011e424c53bf6494178e2d22ed738e07acc64d0"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/react",
   "description": "IBM.com Library React Components",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **circleci:** adjustments to circle-ci check to run lint and jest
+  ([d2986b6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d2986b6))
+- **circleci:** removed lint from services ci-check
+  ([b981db2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b981db2))
+
+### Features
+
+- **jsdoc:** added jsdoc generation from services
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d2089e4))
+- **lerna:** adjusting initial version to 0.0.0
+  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/3f01404))
+- **lerna:** updated package names and versions
+  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/9929d1c))
+- **services:** added working jest test for demo service class
+  ([0957a6a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0957a6a))
+- **services:** created the initial services package architecture (WIP)
+  ([0a072e0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0a072e0))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0-rc.0 (2019-08-05)
 
 # 0.1.0 (2019-07-30)

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **circleci:** adjustments to circle-ci check to run lint and jest
+  ([d2986b6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d2986b6))
+- **circleci:** removed lint from services ci-check
+  ([b981db2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b981db2))
+
+### Features
+
+- **jsdoc:** added jsdoc generation from services
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d2089e4))
+- **lerna:** adjusting initial version to 0.0.0
+  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/3f01404))
+- **lerna:** updated package names and versions
+  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/9929d1c))
+- **services:** added working jest test for demo service class
+  ([0957a6a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0957a6a))
+- **services:** created the initial services package architecture (WIP)
+  ([0a072e0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0a072e0))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.1.0 (2019-07-30)
 
 # 0.1.0-rc.0 (2019-07-30)

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/services",
   "description": "IBM.com Library Services",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -133,5 +133,5 @@
   "release": {
     "branch": "master"
   },
-  "gitHead": "2f315158472924e2416bc7b4eb83a0363e89ba69"
+  "gitHead": "7011e424c53bf6494178e2d22ed738e07acc64d0"
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/services",
   "description": "IBM.com Library Services",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/stylelint-config-elements/CHANGELOG.md
+++ b/packages/stylelint-config-elements/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.1 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **lerna:** added fixes to private package.json to prevent publishing
+  ([4df6797](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/commit/4df6797))
+- **lerna:** reverting private package version names
+  ([ee1cdef](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/commit/ee1cdef))
+- **lerna:** reverting private package version names
+  ([8ad8461](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/commit/8ad8461))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## 0.1.1-rc.0 (2019-08-05)
 
 # 0.1.0 (2019-07-30)

--- a/packages/stylelint-config-elements/CHANGELOG.md
+++ b/packages/stylelint-config-elements/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.1-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Bug Fixes
+
+- **lerna:** added fixes to private package.json to prevent publishing
+  ([4df6797](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/commit/4df6797))
+- **lerna:** reverting private package version names
+  ([ee1cdef](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/commit/ee1cdef))
+- **lerna:** reverting private package version names
+  ([8ad8461](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/commit/8ad8461))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.1.0 (2019-07-30)
 
 # 0.1.0-rc.0 (2019-07-30)

--- a/packages/stylelint-config-elements/package.json
+++ b/packages/stylelint-config-elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/stylelint-config-elements",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1-rc.0",
   "description": "Stylelint configuration for Carbon Elements",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/stylelint-config-elements/package.json
+++ b/packages/stylelint-config-elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/stylelint-config-elements",
   "private": true,
-  "version": "0.1.1-rc.0",
+  "version": "0.1.1",
   "description": "Stylelint configuration for Carbon Elements",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Bug Fixes
+
+- **typo:** fix repo url typo
+  ([fcb3748](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/fcb3748))
+
+### Features
+
+- **styles:** added build script for styles package
+  ([aa89487](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/aa89487))
+- **styles:** cleaned up gulpfile into multiple task/build files
+  ([58ea9e9](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/58ea9e9))
+- **styles:** fixed exposed folders in node modules package
+  ([6f0dbf6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/6f0dbf6))
+- **styles:** fixed public package files
+  ([4f490fa](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/4f490fa))
+- **styles:** moved scss folder to the root
+  ([5be4f6f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/5be4f6f))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0-rc.0 (2019-08-05)
 
 ### Bug Fixes

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Bug Fixes
+
+- **typo:** fix repo url typo
+  ([fcb3748](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/fcb3748))
+
+### Features
+
+- **styles:** added build script for styles package
+  ([aa89487](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/aa89487))
+- **styles:** cleaned up gulpfile into multiple task/build files
+  ([58ea9e9](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/58ea9e9))
+- **styles:** fixed exposed folders in node modules package
+  ([6f0dbf6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/6f0dbf6))
+- **styles:** fixed public package files
+  ([4f490fa](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/4f490fa))
+- **styles:** moved scss folder to the root
+  ([5be4f6f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/5be4f6f))

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/styles",
   "description": "IBM.com Library Styles",
-  "version": "0.1.1",
+  "version": "0.2.0-rc.0",
   "license": "Apache-2.0",
   "main": "dist/ibm-dotcom-styles.min.css",
   "module": "src/scss",
@@ -42,5 +42,5 @@
   "release": {
     "branch": "master"
   },
-  "gitHead": "2f315158472924e2416bc7b4eb83a0363e89ba69"
+  "gitHead": "7011e424c53bf6494178e2d22ed738e07acc64d0"
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/styles",
   "description": "IBM.com Library Styles",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "dist/ibm-dotcom-styles.min.css",
   "module": "src/scss",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Features
+
+- **utilities:** adding utilities package with sample utility function
+  ([12e1e16](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/12e1e16))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0-rc.0 (2019-08-05)
 
 # 0.1.0 (2019-07-30)

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.2.0-rc.0 (2019-08-05)
+
+# 0.1.0 (2019-07-30)
+
+# 0.1.0-rc.0 (2019-07-30)
+
+### Features
+
+- **utilities:** adding utilities package with sample utility function
+  ([12e1e16](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/12e1e16))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.1.0 (2019-07-30)
 
 # 0.1.0-rc.0 (2019-07-30)

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/utilities",
   "description": "IBM.com Library Utilities",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -133,5 +133,5 @@
   "release": {
     "branch": "master"
   },
-  "gitHead": "2f315158472924e2416bc7b4eb83a0363e89ba69"
+  "gitHead": "7011e424c53bf6494178e2d22ed738e07acc64d0"
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/utilities",
   "description": "IBM.com Library Utilities",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Bump minor version from `v0.2.0-RC.0` to `v0.2.0`

#### Changelog

**Changed**

- `eslint-config-ibmdotcom`, `react`, `services`, and `styles` packages bumped from `v0.2.0-RC.0` to `v0.2.0` (kennylam@0c749eada394b25d773855d94180542112f779d2)

