### PR TITLE
feat(search): adding initial search services

### DIFF
--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,2 +1,4 @@
+coverage
+
 # Storybook
 storybook-static

--- a/packages/react/.storybook/.babelrc.js
+++ b/packages/react/.storybook/.babelrc.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const path = require('path');
-const packageJson = require('../package.json');
+const babelConfigFile = require('../babel.config.js');
 
 const root = path.resolve(__dirname, '../');
-const babelConfig = Object.keys(packageJson.babel).reduce((acc, key) => {
-  const options = packageJson.babel[key].map(option => {
+const babelConfig = Object.keys(babelConfigFile).reduce((acc, key) => {
+  const options = babelConfigFile[key].map(option => {
     // If the preset/plugin is not a relative path, we can use it directly
     if (option[0] !== '.') {
       return option;

--- a/packages/react/babel.config.js
+++ b/packages/react/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: ['./scripts/env', '@babel/preset-react'],
+  plugins: [
+    'dev-expression',
+    'macros',
+    '@babel/plugin-syntax-dynamic-import',
+    '@babel/plugin-syntax-import-meta',
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-export-namespace-from',
+    '@babel/plugin-proposal-export-default-from',
+  ],
+};

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'src/components/**/*.js',
+    '!src/components/**/*-story.js',
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'html'],
+  setupFiles: ['<rootDir>/config/jest/setup.js'],
+  testMatch: [
+    '<rootDir>/**/__tests__/**/*.js?(x)',
+    '<rootDir>/**/?(*-)(spec|test).js?(x)',
+  ],
+  testRunner: 'jest-circus/runner',
+  testURL: 'http://localhost',
+  transform: {
+    '^.+\\.(js|jsx)$': '<rootDir>/config/jest/jsTransform.js',
+    '^.+\\.s?css$': '<rootDir>/config/jest/cssTransform.js',
+    '^(?!.*\\.(js|jsx|css|json)$)': '<rootDir>/config/jest/fileTransform.js',
+  },
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/examples/',
+    '/config/',
+    '/lib/',
+    '/es/',
+    '/cjs/',
+  ],
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules[/\\\\](?!(carbon-icons)).+\\.(js|jsx)$',
+  ],
+  moduleFileExtensions: ['js', 'json'],
+  snapshotSerializers: ['enzyme-to-json/serializer'],
+};

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -132,64 +132,6 @@
     "whatwg-fetch": "^2.0.3"
   },
   "sideEffects": false,
-  "babel": {
-    "presets": [
-      "./scripts/env",
-      "@babel/preset-react"
-    ],
-    "plugins": [
-      "dev-expression",
-      "macros",
-      "@babel/plugin-syntax-dynamic-import",
-      "@babel/plugin-syntax-import-meta",
-      "@babel/plugin-proposal-class-properties",
-      "@babel/plugin-proposal-export-namespace-from",
-      "@babel/plugin-proposal-export-default-from"
-    ]
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/components/**/*.js",
-      "!src/components/**/*-story.js"
-    ],
-    "coverageDirectory": "coverage",
-    "coverageReporters": [
-      "text",
-      "html"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setup.js"
-    ],
-    "testMatch": [
-      "<rootDir>/**/__tests__/**/*.js?(x)",
-      "<rootDir>/**/?(*-)(spec|test).js?(x)"
-    ],
-    "testRunner": "jest-circus/runner",
-    "testURL": "http://localhost",
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/config/jest/jsTransform.js",
-      "^.+\\.s?css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-    },
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/examples/",
-      "/config/",
-      "/lib/",
-      "/es/",
-      "/cjs/"
-    ],
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\](?!(carbon-icons)).+\\.(js|jsx)$"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
-  },
   "bundleSizeThreshold": 120000,
   "release": {
     "branch": "master"

--- a/packages/services/.env.example
+++ b/packages/services/.env.example
@@ -1,3 +1,11 @@
 # Movie Search
 THEMOVIEDB_APIKEY=<API key for themoviedb.org>
 THEMOVIEDB_HOST=<host for themoviedb.org, e.g. https://api.themoviedb.org>
+
+# Search Typeahead
+SEARCH_TYPEAHEAD_VERSION=v1
+SEARCH_TYPEAHEAD_HOST=<host for ibm.com search, e.g. https://www-api.ibm.com>
+
+# Marketing Search
+MARKETING_SEARCH_VERSION=v3
+MARKETING_SEARCH_HOST=<host for ibm.com marketing search, e.g. https://www.ibm.com>

--- a/packages/services/.gitignore
+++ b/packages/services/.gitignore
@@ -1,2 +1,3 @@
 .env
+coverage
 docs

--- a/packages/services/babel.config.js
+++ b/packages/services/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: ['./scripts/env'],
+  plugins: [
+    'dev-expression',
+    'macros',
+    '@babel/plugin-syntax-dynamic-import',
+    '@babel/plugin-syntax-import-meta',
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-export-namespace-from',
+    '@babel/plugin-proposal-export-default-from',
+  ],
+};

--- a/packages/services/config/jest/setup.js
+++ b/packages/services/config/jest/setup.js
@@ -6,4 +6,9 @@ jest.unmock('object-assign');
 
 global.__DEV__ = true;
 
+process.env.SEARCH_TYPEAHEAD_HOST = 'https://ibm.com';
+process.env.SEARCH_TYPEAHEAD_VERSION = 'v1';
+process.env.MARKETING_SEARCH_HOST = 'https://ibm.com';
+process.env.MARKETING_SEARCH_VERSION = 'v1';
+
 require('../polyfills');

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: ['src/services/**/*.js'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'html'],
+  setupFiles: ['<rootDir>/config/jest/setup.js'],
+  testMatch: [
+    '<rootDir>/**/__tests__/**/*.js?(x)',
+    '<rootDir>/**/?(*-)(spec|test).js?(x)',
+  ],
+  testRunner: 'jest-circus/runner',
+  testURL: 'http://localhost',
+  transform: {
+    '^.+\\.(js|jsx)$': '<rootDir>/config/jest/jsTransform.js',
+    '^.+\\.s?css$': '<rootDir>/config/jest/cssTransform.js',
+    '^(?!.*\\.(js|jsx|css|json)$)': '<rootDir>/config/jest/fileTransform.js',
+  },
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/examples/',
+    '/config/',
+    '/lib/',
+    '/es/',
+    '/cjs/',
+  ],
+  moduleFileExtensions: ['js', 'json'],
+  snapshotSerializers: ['enzyme-to-json/serializer'],
+};

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -76,59 +76,6 @@
     "whatwg-fetch": "^2.0.3"
   },
   "sideEffects": false,
-  "babel": {
-    "presets": [
-      "./scripts/env"
-    ],
-    "plugins": [
-      "dev-expression",
-      "macros",
-      "@babel/plugin-syntax-dynamic-import",
-      "@babel/plugin-syntax-import-meta",
-      "@babel/plugin-proposal-class-properties",
-      "@babel/plugin-proposal-export-namespace-from",
-      "@babel/plugin-proposal-export-default-from"
-    ]
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/components/**/*.js"
-    ],
-    "coverageDirectory": "coverage",
-    "coverageReporters": [
-      "text",
-      "html"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setup.js"
-    ],
-    "testMatch": [
-      "<rootDir>/**/__tests__/**/*.js?(x)",
-      "<rootDir>/**/?(*-)(spec|test).js?(x)"
-    ],
-    "testRunner": "jest-circus/runner",
-    "testURL": "http://localhost",
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/config/jest/jsTransform.js",
-      "^.+\\.s?css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-    },
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/examples/",
-      "/config/",
-      "/lib/",
-      "/es/",
-      "/cjs/"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
-  },
   "bundleSizeThreshold": 120000,
   "release": {
     "branch": "master"

--- a/packages/services/src/index.js
+++ b/packages/services/src/index.js
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './services/MovieSearch';
+export * from './services';

--- a/packages/services/src/services/MarketingSearch/MarketingSearch.js
+++ b/packages/services/src/services/MarketingSearch/MarketingSearch.js
@@ -1,0 +1,48 @@
+/**
+ * MarketingSearch API
+ *
+ * @module MarketingSearchAPI
+ */
+
+/**
+ * @constant {string | string} Host for the API calls
+ * @private
+ */
+const _host = process.env.MARKETING_SEARCH_HOST || 'https://www.ibm.com';
+
+/**
+ * @constant {string | string} API version
+ * @private
+ */
+const _version = process.env.MARKETING_SEARCH_VERSION || 'v3';
+
+/**
+ * MarketingSearch endpoint
+ *
+ * @type {string}
+ * @private
+ */
+const _endpoint = `${_host}/marketplace/api/search/${_version}/combined_suggestions`;
+
+/**
+ * MarketingSearch API class with methods of fetching search results for
+ * ibm.com
+ */
+export default class MarketingSearchAPI {
+  /**
+   * Gets search results for marketing
+   *
+   * @param {string} query Query string to pass to the service
+   * @returns {Promise<any>} Response data from ibm search
+   */
+  static async getResults(query) {
+    const lc = 'en'; // TODO: create utility for fetching lc
+    const cc = 'us'; // TODO: create utility for fetching cc
+
+    let response = await fetch(
+      `${_endpoint}?locale=${lc}-${cc}&q=${encodeURIComponent(query)}`
+    );
+
+    return await response.json();
+  }
+}

--- a/packages/services/src/services/MarketingSearch/__tests__/MarketingSearch.test.js
+++ b/packages/services/src/services/MarketingSearch/__tests__/MarketingSearch.test.js
@@ -1,0 +1,25 @@
+import MarketingSearchAPI from '../MarketingSearch';
+import fetchMock from 'fetch-mock';
+import responseSuccess from './data/response.json';
+
+const _lc = 'en'; // TODO: bake in tests where lc changes
+const _cc = 'us'; // TODO: bake in tests where cc changes
+
+describe('MarketingSearchAPI', () => {
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+
+  it('should search for ibm.com marketing results', async () => {
+    const query = 'red hat';
+    const endpoint = `${process.env.MARKETING_SEARCH_HOST}/marketplace/api/search/${process.env.MARKETING_SEARCH_VERSION}/combined_suggestions`;
+    const fetchUrl = `${endpoint}?locale=${_lc}-${_cc}&q=${encodeURIComponent(
+      query
+    )}`;
+
+    fetchMock.getOnce(fetchUrl, responseSuccess);
+    const response = await MarketingSearchAPI.getResults(query);
+    expect(response).toEqual(responseSuccess);
+  });
+});

--- a/packages/services/src/services/MarketingSearch/__tests__/data/response.json
+++ b/packages/services/src/services/MarketingSearch/__tests__/data/response.json
@@ -1,0 +1,56 @@
+{
+  "phrase-suggestions": {
+    "text": "red hat",
+    "offset": 0,
+    "length": 7,
+    "options": []
+  },
+  "product-suggestions": {
+    "results": {
+      "total": 142,
+      "max_score": 206.21886,
+      "items": [
+        {
+          "id": "5af31f850ae429daad9c8f49",
+          "type": "product",
+          "score": 206.21886,
+          "fields": {
+            "doc.name": [
+              "IBM Technology Support Services for Red Hat Products"
+            ]
+          }
+        },
+        {
+          "id": "5a4673e934b622434f8b61c5",
+          "type": "product",
+          "score": 12.559728,
+          "fields": {
+            "doc.name": [
+              "Warehouse Exchange"
+            ]
+          }
+        },
+        {
+          "id": "59c529c781d43a6d117ad573",
+          "type": "product",
+          "score": 11.368658,
+          "fields": {
+            "doc.name": [
+              "Aspera Shares"
+            ]
+          }
+        },
+        {
+          "id": "5b1839212f88100671e7ee85",
+          "type": "product",
+          "score": 10.791128,
+          "fields": {
+            "doc.name": [
+              "IBM Phytel Remind"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/services/src/services/MarketingSearch/index.js
+++ b/packages/services/src/services/MarketingSearch/index.js
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './MovieSearch';
-export * from './MarketingSearch';
-export * from './SearchTypeahead';
+export default from './MarketingSearch';

--- a/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
+++ b/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
@@ -1,0 +1,47 @@
+/**
+ * SearchTypeahead Typeahead API
+ *
+ * @module SearchTypeaheadAPI
+ */
+
+/**
+ * @constant {string | string} Host for the API calls
+ * @private
+ */
+const _host = process.env.SEARCH_TYPEAHEAD_HOST || 'https://www-api.ibm.com';
+
+/**
+ * @constant {string | string} API version
+ * @private
+ */
+const _version = process.env.SEARCH_TYPEAHEAD_VERSION || 'v1';
+
+/**
+ * SearchTypeahead Typeahead endpoint
+ *
+ * @type {string}
+ * @private
+ */
+const _endpoint = `${_host}/search/typeahead/${_version}`;
+
+/**
+ * SearchTypeahead API class with methods of fetching search results for
+ * ibm.com
+ */
+export default class SearchTypeaheadAPI {
+  /**
+   * Gets search results
+   *
+   * @param {string} query Query string to pass to the service
+   * @returns {Promise<any>} Response data from ibm search
+   */
+  static async getResults(query) {
+    const lc = 'en'; // TODO: create utility for fetching lc
+    const cc = 'us'; // TODO: create utility for fetching cc
+
+    let response = await fetch(
+      `${_endpoint}&lang=${lc}&cc=${cc}&q=${encodeURIComponent(query)}`
+    );
+    return await response.json();
+  }
+}

--- a/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
+++ b/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
@@ -1,0 +1,25 @@
+import SearchTypeaheadAPI from '../SearchTypeahead';
+import fetchMock from 'fetch-mock';
+import responseSuccess from './data/response.json';
+
+const _lc = 'en'; // TODO: bake in tests where lc changes
+const _cc = 'us'; // TODO: bake in tests where cc changes
+
+describe('SearchTypeaheadAPI', () => {
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+
+  it('should search for ibm.com results', async () => {
+    const query = 'red hat';
+    const endpoint = `${process.env.SEARCH_TYPEAHEAD_HOST}/search/typeahead/${process.env.SEARCH_TYPEAHEAD_VERSION}`;
+    const fetchUrl = `${endpoint}&lang=${_lc}&cc=${_cc}&q=${encodeURIComponent(
+      query
+    )}`;
+
+    fetchMock.getOnce(fetchUrl, responseSuccess);
+    const response = await SearchTypeaheadAPI.getResults(query);
+    expect(response).toEqual(responseSuccess);
+  });
+});

--- a/packages/services/src/services/SearchTypeahead/__tests__/data/response.json
+++ b/packages/services/src/services/SearchTypeahead/__tests__/data/response.json
@@ -1,0 +1,20 @@
+{
+  "response": [
+    [
+      "red hat",
+      "0"
+    ],
+    [
+      "red hat linux",
+      "1"
+    ],
+    [
+      "red hat enterprise linux x3500 7977",
+      "2"
+    ],
+    [
+      "red hat acquisition",
+      "3"
+    ]
+  ]
+}

--- a/packages/services/src/services/SearchTypeahead/index.js
+++ b/packages/services/src/services/SearchTypeahead/index.js
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './MovieSearch';
-export * from './MarketingSearch';
-export * from './SearchTypeahead';
+export default from './SearchTypeahead';

--- a/packages/utilities/.gitignore
+++ b/packages/utilities/.gitignore
@@ -1,1 +1,2 @@
+coverage
 docs

--- a/packages/utilities/babel.config.js
+++ b/packages/utilities/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: ['./scripts/env'],
+  plugins: [
+    'dev-expression',
+    'macros',
+    '@babel/plugin-syntax-dynamic-import',
+    '@babel/plugin-syntax-import-meta',
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-export-namespace-from',
+    '@babel/plugin-proposal-export-default-from',
+  ],
+};

--- a/packages/utilities/jest.config.js
+++ b/packages/utilities/jest.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: ['src/utilities/**/*.js'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'html'],
+  setupFiles: ['<rootDir>/config/jest/setup.js'],
+  testMatch: [
+    '<rootDir>/**/__tests__/**/*.js?(x)',
+    '<rootDir>/**/?(*-)(spec|test).js?(x)',
+  ],
+  testRunner: 'jest-circus/runner',
+  testURL: 'http://localhost',
+  transform: {
+    '^.+\\.(js|jsx)$': '<rootDir>/config/jest/jsTransform.js',
+    '^.+\\.s?css$': '<rootDir>/config/jest/cssTransform.js',
+    '^(?!.*\\.(js|jsx|css|json)$)': '<rootDir>/config/jest/fileTransform.js',
+  },
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/examples/',
+    '/config/',
+    '/lib/',
+    '/es/',
+    '/cjs/',
+  ],
+  moduleFileExtensions: ['js', 'json'],
+  snapshotSerializers: ['enzyme-to-json/serializer'],
+};

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -76,59 +76,6 @@
     "whatwg-fetch": "^2.0.3"
   },
   "sideEffects": false,
-  "babel": {
-    "presets": [
-      "./scripts/env"
-    ],
-    "plugins": [
-      "dev-expression",
-      "macros",
-      "@babel/plugin-syntax-dynamic-import",
-      "@babel/plugin-syntax-import-meta",
-      "@babel/plugin-proposal-class-properties",
-      "@babel/plugin-proposal-export-namespace-from",
-      "@babel/plugin-proposal-export-default-from"
-    ]
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/components/**/*.js"
-    ],
-    "coverageDirectory": "coverage",
-    "coverageReporters": [
-      "text",
-      "html"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setup.js"
-    ],
-    "testMatch": [
-      "<rootDir>/**/__tests__/**/*.js?(x)",
-      "<rootDir>/**/?(*-)(spec|test).js?(x)"
-    ],
-    "testRunner": "jest-circus/runner",
-    "testURL": "http://localhost",
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/config/jest/jsTransform.js",
-      "^.+\\.s?css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-    },
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/examples/",
-      "/config/",
-      "/lib/",
-      "/es/",
-      "/cjs/"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
-  },
   "bundleSizeThreshold": 120000,
   "release": {
     "branch": "master"


### PR DESCRIPTION
Closes #

https://github.ibm.com/webstandards/digital-design/issues/779

This adds the initial search classes for typeahead search. These have been separated out into two classes, as the marketing and regular searches are two completely different endpoints and are treated as such. The host and versions have been set as environment variables, which we will need to set up in CircleCI.

Will need to set up a separate utility class for getting locale/country.

Coverage Report:
<img width="1172" alt="Screen Shot 2019-08-05 at 6 15 58 PM" src="https://user-images.githubusercontent.com/1641214/62498435-26d18000-b7ad-11e9-9858-13b8beb40c0c.png">

JSDoc available in Netlify preview:
https://deploy-preview-39--ibmdotcom-services.netlify.com

#### Changelog

**New**

- SearchTypeaheadAPI
- MarketingSearchAPI