### PR TITLE
Feat/lerna scripts

### DIFF
--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,3 +1,4 @@
+.env
 coverage
 
 # Storybook

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -15,40 +15,68 @@ cd "$(dirname "$0")"
 set -e
 
 # Echo every command being executed
-set -x
+# set -x
 
 # Go to root
 cd ..
 root_path=$PWD
 
-# if [ -n "$(git status --porcelain)" ]; then
-#  echo "Your git status is not clean. Aborting.";
-#  exit 1;
-# fi
+# Check the git status first
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Your git status is not clean. Aborting.";
+  exit 1;
+fi
 
 # Go!
+PS3='Select an option and press Enter: '
+
+# Initial checks
+echo "Did you log into npm (npm login) with a user with publishing rights?"
+options_npm=(
+  "Yes"
+  "No"
+)
+select npm in "${options_npm[@]}"
+do
+    case "$npm" in
+        "Yes")
+          echo "Great!"
+          break
+          ;;
+        "No")
+          echo "Please log into npm first then re-run this script."
+          exit 1
+          ;;
+        *) echo "invalid option $REPLY";;
+    esac
+done
+
 echo "What type of release are you running?"
-options=(
+options_release=(
   "alpha release"
   "rc.0 (first release candidate)"
   ">rc.0 (subsequent release candidates)"
   "full release"
   "cancel"
 )
-select release in "${options[@]}";
+select release in "${options_release[@]}"
 do
     case "$release" in
         "alpha release")
-          ./tasks/publish.sh --canary minor --dist-tag canary --no-push --no-git-tag-version
+          echo "Creating alpha release..."
+          ./node_modules/.bin/lerna publish --canary minor --dist-tag canary --no-push --no-git-tag-version
           ;;
         "rc.0 (first release candidate)")
-          ./tasks/publish.sh preminor --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
+          echo "Creating rc.0 release..."
+          ./node_modules/.bin/lerna publish preminor --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
           ;;
         ">rc.0 (subsequent release candidates)")
-          ./tasks/publish.sh --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
+          echo "Creating rc.1+ release..."
+          ./node_modules/.bin/lerna publish --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
           ;;
         "full release")
-          ./tasks/publish.sh --exact --conventional-commits --conventional-graduate --no-git-tag-version
+          echo "Creating full release..."
+          ./node_modules/.bin/lerna publish --exact --conventional-commits --conventional-graduate --no-git-tag-version
           ;;
         "cancel")
           break

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -22,10 +22,10 @@ cd ..
 root_path=$PWD
 
 # Check the git status first
-if [ -n "$(git status --porcelain)" ]; then
-  echo "Your git status is not clean. Aborting.";
-  exit 1;
-fi
+#if [ -n "$(git status --porcelain)" ]; then
+#  echo "Your git status is not clean. Aborting.";
+#  exit 1;
+#fi
 
 # Go!
 PS3='Select an option and press Enter: '
@@ -65,21 +65,25 @@ do
         "alpha release")
           echo "Creating alpha release..."
           ./node_modules/.bin/lerna publish --canary minor --dist-tag canary --no-push --no-git-tag-version
+          exit 1
           ;;
         "rc.0 (first release candidate)")
           echo "Creating rc.0 release..."
           ./node_modules/.bin/lerna publish preminor --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
+          exit 1
           ;;
         ">rc.0 (subsequent release candidates)")
           echo "Creating rc.1+ release..."
           ./node_modules/.bin/lerna publish --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
+          exit 1
           ;;
         "full release")
           echo "Creating full release..."
           ./node_modules/.bin/lerna publish --exact --conventional-commits --conventional-graduate --no-git-tag-version
+          exit 1
           ;;
         "cancel")
-          break
+          exit 1
           ;;
         *) echo "invalid option $REPLY";;
     esac

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -64,21 +64,25 @@ do
     case "$release" in
         "alpha release")
           echo "Creating alpha release..."
+          set -x
           ./node_modules/.bin/lerna publish --canary minor --dist-tag canary --no-push --no-git-tag-version
           exit 1
           ;;
         "rc.0 (first release candidate)")
           echo "Creating rc.0 release..."
+          set -x
           ./node_modules/.bin/lerna publish preminor --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
           exit 1
           ;;
         ">rc.0 (subsequent release candidates)")
           echo "Creating rc.1+ release..."
+          set -x
           ./node_modules/.bin/lerna publish --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
           exit 1
           ;;
         "full release")
           echo "Creating full release..."
+          set -x
           ./node_modules/.bin/lerna publish --exact --conventional-commits --conventional-graduate --no-git-tag-version
           exit 1
           ;;

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -21,10 +21,38 @@ set -x
 cd ..
 root_path=$PWD
 
-if [ -n "$(git status --porcelain)" ]; then
-  echo "Your git status is not clean. Aborting.";
-  exit 1;
-fi
+# if [ -n "$(git status --porcelain)" ]; then
+#  echo "Your git status is not clean. Aborting.";
+#  exit 1;
+# fi
 
 # Go!
-./node_modules/.bin/lerna publish "$@"
+echo "What type of release are you running?"
+options=(
+  "alpha release"
+  "rc.0 (first release candidate)"
+  ">rc.0 (subsequent release candidates)"
+  "full release"
+  "cancel"
+)
+select release in "${options[@]}";
+do
+    case "$release" in
+        "alpha release")
+          ./tasks/publish.sh --canary minor --dist-tag canary --no-push --no-git-tag-version
+          ;;
+        "rc.0 (first release candidate)")
+          ./tasks/publish.sh preminor --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
+          ;;
+        ">rc.0 (subsequent release candidates)")
+          ./tasks/publish.sh --exact --conventional-commits --conventional-prerelease --preid rc --no-git-tag-version
+          ;;
+        "full release")
+          ./tasks/publish.sh --exact --conventional-commits --conventional-graduate --no-git-tag-version
+          ;;
+        "cancel")
+          break
+          ;;
+        *) echo "invalid option $REPLY";;
+    esac
+done


### PR DESCRIPTION
There is no ticket for this, but I cleaned up the publish script so that you make a selection instead of having to write in the command manually.

The command to run now is simple `./tasks/publish.sh`. The follow flow will run:

1. This will do the same check if the git status is clean
2. It will then ask if you have logged into npm (yes will continue, no will exit)
3. It will ask if you are the current cycle's release manager. Yes will present you with multiple options, and No will build an alpha release.
4. If you are the release manager, the following options will be presented to you:
   -  alpha release
   - rc.0 (first release candidate)
   - rc.1+ (subsequent release candidates)
   - full release

![publish](https://user-images.githubusercontent.com/1641214/62796512-75ca2e80-baa7-11e9-88a0-ff7f3dda18f9.gif)

#### Changelog

**Changed**

- `./tasks/publish.sh` now has menu selections
