### PR TITLE
fix(eslint): adding additional eslint checks for react components

### DIFF
--- a/packages/eslint-config-ibmdotcom/index.js
+++ b/packages/eslint-config-ibmdotcom/index.js
@@ -28,6 +28,18 @@ module.exports = {
     ],
     'react/jsx-uses-vars': 1,
     'react/jsx-uses-react': 1,
+
+    // Require ES6 class declarations over React.createClass
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
+    'react/prefer-es6-class': ['error', 'always'],
+
+    // Require stateless functions when not using lifecycle methods, setState or ref
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
+    'react/prefer-stateless-function': [
+      'error',
+      { ignorePureComponents: true },
+    ],
+
     'react/no-find-dom-node': 1,
     'react/no-typos': 2,
     'react/no-unused-prop-types': 2,


### PR DESCRIPTION
### Description

By default the eslint configurations are on for AirBNB:

- [react/prefer-es6-class](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md)
- [react/prefer-stateless-function](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md)

This is described in the following documentation:

https://github.com/airbnb/javascript/tree/master/react#class-vs-reactcreateclass-vs-stateless

Essentially, if a component is not managing internal state, lifecycles, or refs, it should be created as stateless for performance.

### Changelog

**Changed**

- Added additional react eslint checks
