### PR TITLE
feat(react): horizontalrule component

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -25,10 +25,6 @@ export default class Container extends Component {
           data-floating-menu-container=""
           role="main"
           style={{
-            padding: '3em',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
             backgroundColor: bgColor,
           }}>
           {story()}

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -26,12 +26,11 @@ const { prefix } = settings;
  */
 const HorizontalRule = ({ type, length, color, width }) => (
   <hr
-    noshade
     className={classnames(
       `${prefix}--hr`,
-      `${prefix}--hr__${type}`,
+      `${prefix}--hr__${type}__${color}`,
+      { [`${prefix}--hr__dashed`]: type === 'dashed' },
       `${prefix}--hr__${length}`,
-      `${prefix}--hr__${color}`,
       `${prefix}--hr__${width}`
     )}
   />

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+import { settings } from 'carbon-components';
+
+import '@ibmdotcom/styles/scss/components/horizontalrule/_horizontalrule.scss';
+
+const { prefix } = settings;
+/**
+ * Horizontal Rule component
+ *
+ * @param {object} props props object
+ * @param {string} props.type type of rule (solid or dashed)
+ * @param {string} props.length length of rule
+ * @returns {*} Horizontal Rule component
+ * @class
+ */
+const HorizontalRule = ({ type, length }) => (
+  <hr
+    className={classnames(`${prefix}--hr__${type}`, `${prefix}--hr__${length}`)}
+  />
+);
+
+HorizontalRule.propTypes = {
+  type: PropTypes.string,
+  length: PropTypes.string,
+};
+
+HorizontalRule.defaultProps = {
+  type: 'solid',
+  length: 'small',
+};
+
+export default HorizontalRule;

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -18,24 +18,37 @@ const { prefix } = settings;
  *
  * @param {object} props props object
  * @param {string} props.type type of rule (solid or dashed)
+ * @param {string} props.color color of the rule
+ * @param {string} props.width width of the rule
  * @param {string} props.length length of rule
  * @returns {*} Horizontal Rule component
  * @class
  */
-const HorizontalRule = ({ type, length }) => (
+const HorizontalRule = ({ type, length, color, width }) => (
   <hr
-    className={classnames(`${prefix}--hr__${type}`, `${prefix}--hr__${length}`)}
+    noshade
+    className={classnames(
+      `${prefix}--hr`,
+      `${prefix}--hr__${type}`,
+      `${prefix}--hr__${length}`,
+      `${prefix}--hr__${color}`,
+      `${prefix}--hr__${width}`
+    )}
   />
 );
 
 HorizontalRule.propTypes = {
   type: PropTypes.string,
   length: PropTypes.string,
+  color: PropTypes.string,
+  width: PropTypes.string,
 };
 
 HorizontalRule.defaultProps = {
   type: 'solid',
   length: 'small',
+  color: 'medium-contrast',
+  width: 'thin',
 };
 
 export default HorizontalRule;

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
+import settings from 'carbon-components/es/globals/js/settings';
 
 import '@ibmdotcom/styles/scss/components/horizontalrule/_horizontalrule.scss';
 

--- a/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
+++ b/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import HorizontalRule from '../HorizontalRule';
+
+storiesOf('HorizontalRule', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    const types = {
+      solid: 'solid',
+      dashed: 'dashed',
+    };
+
+    const lengths = {
+      small: 'small',
+      medium: 'medium',
+      large: 'large',
+      inset: 'inset',
+    };
+
+    return (
+      <div className="hr--container">
+        <HorizontalRule
+          type={select('type', types, 'solid')}
+          length={select('length', lengths, 'small')}
+        />
+      </div>
+    );
+  });

--- a/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
+++ b/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
@@ -16,13 +16,29 @@ storiesOf('HorizontalRule', module)
       medium: 'medium',
       large: 'large',
       inset: 'inset',
+      overhung: 'overhung',
+    };
+
+    const colors = {
+      low: 'low-contrast',
+      medium: 'medium-contrast',
+      high: 'high-contrast',
+    };
+
+    const widths = {
+      thin: 'thin',
+      thick: 'thick',
     };
 
     return (
-      <div className="hr--container">
+      <div
+        className="bx--grid bx--grid--full-width"
+        style={{ marginTop: '50px' }}>
         <HorizontalRule
           type={select('type', types, 'solid')}
           length={select('length', lengths, 'small')}
+          color={select('color', colors, 'medium-contrast')}
+          width={select('width', widths, 'thin')}
         />
       </div>
     );

--- a/packages/react/src/components/HorizontalRule/index.js
+++ b/packages/react/src/components/HorizontalRule/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as HorizontalRule } from './HorizontalRule';

--- a/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
+++ b/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
@@ -13,28 +13,64 @@
 @import '~carbon-components/scss/globals/scss/css--reset';
 
 @mixin horizontalrule {
-    .#{$prefix}--hr__dashed {
-        border-top-style: dashed;
-    }
+    .#{$prefix}--hr {
+        margin: $spacing-05 0;
+        border-top-width: 1px;
 
-    .#{$prefix}--hr__solid {
-        border-top-style: solid;
-    }
+        &__thick {
+            border-top-width: 2px;
+        }
 
-    .#{$prefix}--hr__small {
-        width: $layout-03;
-    }
+        &__dashed {
+            border-top-style: dashed;
+        }
+    
+        &__small {
+            width: $layout-03;
+        }
+    
+        &__medium {
+            width: $layout-04;
+        }
+    
+        &__large {
+            width: $layout-05;
+        }
+    
+        &__inset {
+            width: 100%;
+        }
 
-    .#{$prefix}--hr__medium {
-        width: $layout-04;
-    }
+        &__overhung {
+            width: auto;
 
-    .#{$prefix}--hr__large {
-        width: $layout-05;
-    }
+            @include carbon--breakpoint('sm') {
+                margin-left: -$spacing-05;
+                margin-right: -$spacing-05;
+            }
 
-    .#{$prefix}--hr__inset {
-        width: 100%;
+            @include carbon--breakpoint('md') {
+                margin-left: -$spacing-07;
+                margin-right: -$spacing-07;
+            }
+
+            @include carbon--breakpoint('max') {
+                margin-left: -$spacing-08;
+                margin-right: -$spacing-08;
+            }
+        }
+
+        &__low-contrast {
+            border-top-color: $ui-03;
+        }
+
+        &__medium-contrast {
+            border-top-color: $ui-04;
+        }
+
+        &__high-contrast {
+            border-top-color: $ui-05;
+        }
     }
 }
 

--- a/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
+++ b/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
@@ -15,14 +15,11 @@
 @mixin horizontalrule {
     .#{$prefix}--hr {
         margin: $spacing-05 0;
-        border-top-width: 1px;
+        border: none;
+        height: 1px;
 
         &__thick {
-            border-top-width: 2px;
-        }
-
-        &__dashed {
-            border-top-style: dashed;
+            height: 2px;
         }
     
         &__small {
@@ -59,21 +56,40 @@
                 margin-right: -$spacing-08;
             }
         }
+    }
 
+    .#{$prefix}--hr__solid {
         &__low-contrast {
-            border-top-color: $ui-03;
+            background: $ui-03;
         }
 
         &__medium-contrast {
-            border-top-color: $ui-04;
+            background: $ui-04;
         }
 
         &__high-contrast {
-            border-top-color: $ui-05;
+            background: $ui-05;
+        }
+    }
+
+    .#{$prefix}--hr__dashed {
+        background-size: $spacing-05 1px;
+        background-repeat: repeat-x;
+
+        &__low-contrast {
+            background-image: linear-gradient(to right, $ui-03 50%, transparent 50%);
+        }
+
+        &__medium-contrast {
+            background-image: linear-gradient(to right, $ui-04 50%, transparent 50%);
+        }
+
+        &__high-contrast {
+            background-image: linear-gradient(to right, $ui-05 50%, transparent 50%);
         }
     }
 }
 
 @include exports('horizontalrule') {
     @include horizontalrule;
-  }
+}

--- a/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
+++ b/packages/styles/scss/components/horizontalrule/_horizontalrule.scss
@@ -1,0 +1,43 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '~@carbon/themes/scss/themes';
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/layout';
+@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+@import '~carbon-components/scss/globals/scss/css--reset';
+
+@mixin horizontalrule {
+    .#{$prefix}--hr__dashed {
+        border-top-style: dashed;
+    }
+
+    .#{$prefix}--hr__solid {
+        border-top-style: solid;
+    }
+
+    .#{$prefix}--hr__small {
+        width: $layout-03;
+    }
+
+    .#{$prefix}--hr__medium {
+        width: $layout-04;
+    }
+
+    .#{$prefix}--hr__large {
+        width: $layout-05;
+    }
+
+    .#{$prefix}--hr__inset {
+        width: 100%;
+    }
+}
+
+@include exports('horizontalrule') {
+    @include horizontalrule;
+  }


### PR DESCRIPTION
### Related Ticket(s)

Develop the Horizontal Rules component: https://github.ibm.com/webstandards/digital-design/issues/1088
Horizontal rule: spec for dev: https://github.ibm.com/webstandards/digital-design/issues/1281
Designs: https://github.ibm.com/webstandards/digital-design/issues/1098

### Description

Adding Horizontal Rule component with color, width, length, type props

(with dash type - the dashes needed to be 8px long so used `linear-gradient()` to customize the dash and spacing)

### Changelog

**New**

- HorizontalRule

**Removed**

- storybook container styling in order to test the overhung/full bleed styling of the hr

<img width="1451" alt="Screen Shot 2019-08-22 at 4 13 35 PM" src="https://user-images.githubusercontent.com/54281166/63546442-d7eb5080-c4f7-11e9-8e58-2a4f11dfb919.png">

<img width="1457" alt="Screen Shot 2019-08-22 at 4 13 23 PM" src="https://user-images.githubusercontent.com/54281166/63546448-d9b51400-c4f7-11e9-8d3c-922b31ead009.png">

