### PR TITLE
Release/v0.3.0

### DIFF
--- a/packages/eslint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/eslint-config-ibmdotcom/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0) (2019-08-29)
+
+# 0.3.0-rc.0 (2019-08-28)
+
+### Bug Fixes
+
+- **eslint:** adding additional eslint checks for react components
+  ([#54](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/issues/54))
+  ([040153b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/040153b))
+
+### Features
+
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/36fb186))
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes

--- a/packages/eslint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/eslint-config-ibmdotcom/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0-rc.0) (2019-08-28)
+
+### Bug Fixes
+
+- **eslint:** adding additional eslint checks for react components
+  ([#54](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/issues/54))
+  ([040153b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/040153b))
+
+### Features
+
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/36fb186))
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0 (2019-08-05)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/eslint-config-ibmdotcom/package.json
+++ b/packages/eslint-config-ibmdotcom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/eslint-config-ibmdotcom",
   "private": true,
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom",

--- a/packages/eslint-config-ibmdotcom/package.json
+++ b/packages/eslint-config-ibmdotcom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/eslint-config-ibmdotcom",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0-rc.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,81 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@ibmdotcom/react@0.1.0...@ibmdotcom/react@0.3.0) (2019-08-29)
+
+# 0.3.0-rc.0 (2019-08-28)
+
+### Bug Fixes
+
+- **hr:** import carbon style for storybook container and scss tweaks
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cd0929c))
+- **lint:** fixed lint issue in Footer
+  ([4d5fa86](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/4d5fa86))
+- **netlify:** fix to point to alpha releases of services/utilities
+  ([a9fdeb4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/a9fdeb4))
+- **readme:** fixed rendering of readme files in storybook
+  ([5fda9d8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5fda9d8))
+- **rollup:** fixed rollup config
+  ([5a8f32a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5a8f32a))
+- **search:** fixed package references for services and utilities
+  ([56fede8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/56fede8))
+- **search:** fixing babel transform runtime issues
+  ([922d3d7](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/922d3d7))
+- **storybook:** fixed issue with masthead not rendering
+  ([692a911](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/692a911))
+- **utilities:** updated react package dependencies
+  ([d129c40](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d129c40))
+
+### Features
+
+- **component:** adds search to masthead
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/292bd2f)),
+  closes
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1213)
+- **deployments:** added and updated deployment scripts for packages
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/b8f8ccf))
+- **featureflags:** adding feature flags functionality for react
+  ([84b9fcd](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/84b9fcd))
+- **jest:** adding coverage reports for jest
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7145a7c))
+- **react:** horizontalrule component
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/507a0f3))
+- **react:** wraps up first MVP for footer
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cc75800)),
+  closes
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1080)
+- **search:** added highlighted test in suggestions and redirect link
+  ([#47](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/47))
+  ([67218eb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/67218eb))
+- **search:** adding initial masthead search components (wip)
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bad3b8e))
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/36fb186))
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Features
+
+- **footer:** laying down the basework for the footer
+  ([bf05b3c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bf05b3c))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@ibmdotcom/react@0.1.0...@ibmdotcom/react@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,79 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@ibmdotcom/react@0.1.0...@ibmdotcom/react@0.3.0-rc.0) (2019-08-28)
+
+### Bug Fixes
+
+- **hr:** import carbon style for storybook container and scss tweaks
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cd0929c))
+- **lint:** fixed lint issue in Footer
+  ([4d5fa86](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/4d5fa86))
+- **netlify:** fix to point to alpha releases of services/utilities
+  ([a9fdeb4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/a9fdeb4))
+- **readme:** fixed rendering of readme files in storybook
+  ([5fda9d8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5fda9d8))
+- **rollup:** fixed rollup config
+  ([5a8f32a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5a8f32a))
+- **search:** fixed package references for services and utilities
+  ([56fede8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/56fede8))
+- **search:** fixing babel transform runtime issues
+  ([922d3d7](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/922d3d7))
+- **storybook:** fixed issue with masthead not rendering
+  ([692a911](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/692a911))
+- **utilities:** updated react package dependencies
+  ([d129c40](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d129c40))
+
+### Features
+
+- **component:** adds search to masthead
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/292bd2f)),
+  closes
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1213)
+- **deployments:** added and updated deployment scripts for packages
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/b8f8ccf))
+- **featureflags:** adding feature flags functionality for react
+  ([84b9fcd](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/84b9fcd))
+- **jest:** adding coverage reports for jest
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7145a7c))
+- **react:** horizontalrule component
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/507a0f3))
+- **react:** wraps up first MVP for footer
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cc75800)),
+  closes
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1080)
+- **search:** added highlighted test in suggestions and redirect link
+  ([#47](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/47))
+  ([67218eb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/67218eb))
+- **search:** adding initial masthead search components (wip)
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bad3b8e))
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/36fb186))
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Features
+
+- **footer:** laying down the basework for the footer
+  ([bf05b3c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bf05b3c))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0 (2019-08-05)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/react",
   "description": "IBM.com Library React Components",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0) (2019-08-29)
+
+# 0.3.0-rc.0 (2019-08-28)
+
+### Bug Fixes
+
+- **search:** fixing axios/rollup configuration
+  ([60b554c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/60b554c))
+
+### Features
+
+- **deployments:** added and updated deployment scripts for packages
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b8f8ccf))
+- **jest:** adding coverage reports for jest
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/7145a7c))
+- **search:** adding initial search services
+  ([72fba4f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/72fba4f))
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/36fb186))
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0-rc.0) (2019-08-28)
+
+### Bug Fixes
+
+- **search:** fixing axios/rollup configuration
+  ([60b554c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/60b554c))
+
+### Features
+
+- **deployments:** added and updated deployment scripts for packages
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b8f8ccf))
+- **jest:** adding coverage reports for jest
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/7145a7c))
+- **search:** adding initial search services
+  ([72fba4f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/72fba4f))
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/36fb186))
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0 (2019-08-05)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/services",
   "description": "IBM.com Library Services",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/stylelint-config-elements/CHANGELOG.md
+++ b/packages/stylelint-config-elements/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.2.0](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/compare/@ibmdotcom/stylelint-config-elements@0.1.0...@ibmdotcom/stylelint-config-elements@0.2.0) (2019-08-29)
+
+# 0.3.0-rc.0 (2019-08-28)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+**Note:** Version bump only for package @ibmdotcom/stylelint-config-elements
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # [0.2.0-rc.0](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/compare/@ibmdotcom/stylelint-config-elements@0.1.0...@ibmdotcom/stylelint-config-elements@0.2.0-rc.0) (2019-08-28)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/stylelint-config-elements/CHANGELOG.md
+++ b/packages/stylelint-config-elements/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file. See
 
 # [0.2.0](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/compare/@ibmdotcom/stylelint-config-elements@0.1.0...@ibmdotcom/stylelint-config-elements@0.2.0) (2019-08-29)
 
-# 0.3.0-rc.0 (2019-08-28)
-
 # 0.2.0-rc.0 (2019-08-05)
 
 **Note:** Version bump only for package @ibmdotcom/stylelint-config-elements

--- a/packages/stylelint-config-elements/CHANGELOG.md
+++ b/packages/stylelint-config-elements/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.2.0-rc.0](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/compare/@ibmdotcom/stylelint-config-elements@0.1.0...@ibmdotcom/stylelint-config-elements@0.2.0-rc.0) (2019-08-28)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+**Note:** Version bump only for package @ibmdotcom/stylelint-config-elements
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## 0.1.1 (2019-08-05)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/stylelint-config-elements/package.json
+++ b/packages/stylelint-config-elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/stylelint-config-elements",
   "private": true,
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "description": "Stylelint configuration for Carbon Elements",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/stylelint-config-elements/package.json
+++ b/packages/stylelint-config-elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/stylelint-config-elements",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0-rc.0",
   "description": "Stylelint configuration for Carbon Elements",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,67 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0) (2019-08-29)
+
+# 0.3.0-rc.0 (2019-08-28)
+
+### Bug Fixes
+
+- **hr:** import carbon style for storybook container and scss tweaks
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cd0929c))
+- **search:** fixing prettier/stylelint errors
+  ([739c09d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/739c09d))
+
+### Features
+
+- **component:** adds search to masthead
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/292bd2f)),
+  closes
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1213)
+- **react:** horizontalrule component
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/507a0f3))
+- **react:** wraps up first MVP for footer
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cc75800)),
+  closes
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1080)
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Bug Fixes
+
+- **typo:** fix repo url typo
+  ([fcb3748](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/fcb3748))
+
+### Features
+
+- **styles:** added build script for styles package
+  ([aa89487](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/aa89487))
+- **styles:** cleaned up gulpfile into multiple task/build files
+  ([58ea9e9](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/58ea9e9))
+- **styles:** fixed exposed folders in node modules package
+  ([6f0dbf6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/6f0dbf6))
+- **styles:** fixed public package files
+  ([4f490fa](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/4f490fa))
+- **styles:** moved scss folder to the root
+  ([5be4f6f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/5be4f6f))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,65 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0-rc.0) (2019-08-28)
+
+### Bug Fixes
+
+- **hr:** import carbon style for storybook container and scss tweaks
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cd0929c))
+- **search:** fixing prettier/stylelint errors
+  ([739c09d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/739c09d))
+
+### Features
+
+- **component:** adds search to masthead
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/292bd2f)),
+  closes
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1213)
+- **react:** horizontalrule component
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/507a0f3))
+- **react:** wraps up first MVP for footer
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cc75800)),
+  closes
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1080)
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+### Bug Fixes
+
+- **typo:** fix repo url typo
+  ([fcb3748](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/fcb3748))
+
+### Features
+
+- **styles:** added build script for styles package
+  ([aa89487](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/aa89487))
+- **styles:** cleaned up gulpfile into multiple task/build files
+  ([58ea9e9](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/58ea9e9))
+- **styles:** fixed exposed folders in node modules package
+  ([6f0dbf6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/6f0dbf6))
+- **styles:** fixed public package files
+  ([4f490fa](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/4f490fa))
+- **styles:** moved scss folder to the root
+  ([5be4f6f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/5be4f6f))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0 (2019-08-05)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/styles",
   "description": "IBM.com Library Styles",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "main": "dist/ibm-dotcom-styles.min.css",
   "module": "src/scss",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0-rc.0) (2019-08-28)
+
+### Bug Fixes
+
+- **utilities:** fixed utilities exports
+  ([c3e431e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/c3e431e))
+
+### Features
+
+- **deployments:** added and updated deployment scripts for packages
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/b8f8ccf))
+- **jest:** adding coverage reports for jest
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/7145a7c))
+- **search:** adding initial masthead search components (wip)
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/bad3b8e))
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/36fb186))
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # 0.2.0 (2019-08-05)
 
 # 0.2.0-rc.0 (2019-08-05)

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0) (2019-08-29)
+
+# 0.3.0-rc.0 (2019-08-28)
+
+### Bug Fixes
+
+- **utilities:** fixed utilities exports
+  ([c3e431e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/c3e431e))
+
+### Features
+
+- **deployments:** added and updated deployment scripts for packages
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/b8f8ccf))
+- **jest:** adding coverage reports for jest
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/7145a7c))
+- **search:** adding initial masthead search components (wip)
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/bad3b8e))
+- **search:** adding integration of typeahead api to autosuggest
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/36fb186))
+
+# 0.2.0 (2019-08-05)
+
+# 0.2.0-rc.0 (2019-08-05)
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 # [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ibmdotcom/utilities",
   "description": "IBM.com Library Utilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -23,7 +23,7 @@ release_rc1plus () {
 
 # Full minor release
 release_full_minor () {
-  ./node_modules/.bin/lerna publish minor --exact --conventional-commits --no-git-tag-version
+  ./node_modules/.bin/lerna publish minor --exact --conventional-commits --no-git-tag-version --force-publish=*
 }
 
 # Full major release


### PR DESCRIPTION
### Related Ticket(s)

Closes https://github.ibm.com/webstandards/digital-design/issues/1441

### Description

This pull request releases `v0.3.0` including new components like the `masthead`, `horizontalRule`, and `footer`.

### Changelog

See the [release notes](https://github.com/carbon-design-system/ibm-dotcom-library/releases/tag/v0.3.0)
