### PR TITLE
feat(masthead): adds sticky masthead to dotcom shell

### DIFF
--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -9,7 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
 import { Content } from 'carbon-components-react';
-import { Masthead, Footer } from '@carbon/ibmdotcom-react';
+import { Masthead, MastheadL1, Footer } from '@carbon/ibmdotcom-react';
 
 const { prefix } = settings;
 
@@ -25,7 +25,10 @@ const DotcomShell = ({ navigation, children }) => {
     <>
       <div className={`${prefix}--grid ${prefix}--dotcom-shell`}>
         <div className={`${prefix}--dotcom-shell__masthead`}>
-          <Masthead navigation={navigation} />
+          <>
+            <Masthead navigation={navigation} />
+            <MastheadL1 />
+          </>
         </div>
         <Content
           id={`${prefix}--dotcom-shell__content`}

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -5,8 +5,7 @@ import Masthead from '../Masthead';
 import MastheadL1 from '../MastheadL1';
 import mastheadLinks from './data/MastheadLinks.js';
 import readme from '../README.md';
-import '../../../../../styles/scss/components/masthead/_masthead.scss';
-import '../../../../../styles/scss/components/masthead/_masthead-l1.scss';
+import '../../../../../styles/scss/components/masthead/index.scss';
 
 const platformName = {
   platform: {

--- a/packages/react/src/components/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/storyshots.test.js.snap
@@ -254,6 +254,189 @@ Array [
                   </div>
                 </nav>
               </header>
+              <div
+                className="bx--masthead__l1"
+              >
+                <div
+                  className="bx--masthead__l1-name"
+                >
+                  <span
+                    className="bx--masthead__l1-name-eyebrow"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M6.7 12.3L2.9 8.5H15v-1H2.9l3.8-3.8L6 3 1 8l5 5z"
+                      />
+                    </svg>
+                    <a
+                      href="#"
+                    >
+                      Eyebrow
+                    </a>
+                  </span>
+                  <span
+                    className="bx--masthead__l1-name-title"
+                  >
+                    Stock Charts
+                  </span>
+                </div>
+                <nav
+                  className="bx--header__nav bx--masthead__l1-nav"
+                >
+                  <ul
+                    className="bx--header__menu-bar"
+                    role="menubar"
+                  >
+                    <li>
+                      <a
+                        className="bx--header__menu-item"
+                        href="#"
+                        role="menuitem"
+                        tabIndex={0}
+                      >
+                        <span
+                          className="bx--text-truncate--end"
+                        >
+                          Link 1
+                        </span>
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        className="bx--header__menu-item"
+                        href="#"
+                        role="menuitem"
+                        tabIndex={0}
+                      >
+                        <span
+                          className="bx--text-truncate--end"
+                        >
+                          Link 2
+                        </span>
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        className="bx--header__menu-item"
+                        href="#"
+                        role="menuitem"
+                        tabIndex={0}
+                      >
+                        <span
+                          className="bx--text-truncate--end"
+                        >
+                          Link 3
+                        </span>
+                      </a>
+                    </li>
+                    <li
+                      className="bx--header__submenu"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                    >
+                      <a
+                        aria-expanded={false}
+                        aria-haspopup="menu"
+                        aria-label="Link 4"
+                        className="bx--header__menu-item bx--header__menu-title"
+                        href="javascript:void(0)"
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex={0}
+                      >
+                        Link 4
+                        <svg
+                          aria-hidden={true}
+                          className="bx--header__menu-arrow"
+                          focusable="false"
+                          height={6}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 10 6"
+                          width={10}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+                          />
+                        </svg>
+                      </a>
+                      <ul
+                        aria-label="Link 4"
+                        className="bx--header__menu"
+                        role="menu"
+                      >
+                        <li
+                          role="none"
+                        >
+                          <a
+                            className="bx--header__menu-item"
+                            href="#"
+                            role="menuitem"
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--text-truncate--end"
+                            >
+                              Sub-link 1
+                            </span>
+                          </a>
+                        </li>
+                        <li
+                          role="none"
+                        >
+                          <a
+                            className="bx--header__menu-item"
+                            href="#"
+                            role="menuitem"
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--text-truncate--end"
+                            >
+                              Sub-link 2
+                            </span>
+                          </a>
+                        </li>
+                        <li
+                          role="none"
+                        >
+                          <a
+                            className="bx--header__menu-item"
+                            href="#"
+                            role="menuitem"
+                            tabIndex={0}
+                          >
+                            <span
+                              className="bx--text-truncate--end"
+                            >
+                              Sub-link 3
+                            </span>
+                          </a>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
             </div>
             <main
               className="bx--content bx--grid"

--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -18,9 +18,28 @@
 
     &__masthead {
       width: 100%;
-      position: static;
-      top: 0;
+      position: sticky;
+      top: -48px;
       z-index: 99999;
+    }
+
+    // Dotcom shell - grid overrides
+    .#{$prefix}--content {
+      @include carbon--breakpoint-down(lg) {
+        padding: 0 $spacing-05;
+      }
+    }
+
+    &.#{$prefix}--grid {
+      @include carbon--breakpoint-down(lg) {
+        padding-left: $spacing-05;
+        padding-right: $spacing-05;
+      }
+
+      @include carbon--breakpoint-down(md) {
+        padding-left: 0;
+        padding-right: 0;
+      }
     }
   }
 }

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -4,7 +4,6 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import '../../globals/imports';
 @import '@carbon/themes/scss/themes';
 
 /// @access private
@@ -16,7 +15,7 @@ $search-transition-timing: 95ms;
 @mixin masthead-l1 {
   .#{$prefix}--masthead__l1 {
     display: flex;
-    width: 100vw;
+    width: 100%;
     height: 80px;
     background-color: $ui-01;
     transition-timing-function: $search-transition;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -1,0 +1,40 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Include left navigation component
+// @access private
+// group masthead
+@mixin masthead-sidenav {
+  .#{$prefix}--side-nav__header-navigation {
+    height: 100vh;
+  }
+
+  .#{$prefix}--side-nav__submenu[aria-expanded='true'] {
+    + .#{$prefix}--side-nav__menu[role='menu'] {
+      position: absolute;
+      top: 0;
+      background: $ui-background;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
+      transform: translateX(0);
+      transition-timing-function: $search-transition;
+      transition-duration: $search-transition-timing;
+      a {
+        padding-left: $spacing-05;
+      }
+    }
+  }
+
+  .#{$prefix}--side-nav__menu[role='menu'] {
+    transform: translateX(100%);
+  }
+}
+
+@include exports('masthead-sidenav') {
+  @include masthead-sidenav;
+}

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -1,0 +1,132 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@mixin masthead-search {
+  // main nav/search container excluding
+  // profile and logo icons - TODO rename this
+  .#{$prefix}--header__search {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    position: relative;
+    height: 100%;
+  }
+
+  // search container
+  .#{$prefix}--masthead__search {
+    flex: 1;
+
+    &.#{$prefix}--masthead__search--active {
+      position: absolute;
+      z-index: 999;
+      width: 100%;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        display: block;
+        border-bottom: 2px solid $interactive-01;
+      }
+
+      @include carbon--breakpoint-down(md) {
+        width: calc(100vw - #{$spacing-05});
+        right: (-$spacing-09);
+      }
+
+      .#{$prefix}--header__search--input {
+        display: flex;
+        flex: 1;
+        padding: 0 $spacing-05;
+        outline: 2px solid transparent;
+        outline-offset: -2px;
+        background-color: $ui-01;
+        height: carbon--mini-units(6);
+
+        &::placeholder {
+          left: 0;
+          opacity: 1;
+          transition-duration: 112ms;
+          transition-delay: 200ms;
+        }
+      }
+
+      .#{$prefix}--header__search--close {
+        width: $spacing-09;
+      }
+
+      .#{$prefix}--header__action {
+        background-color: $ui-01;
+        transition-property: width;
+        transition-delay: 380ms;
+        transition-duration: 112ms;
+      }
+    }
+  }
+
+  .react-autosuggest {
+    &__container {
+      display: flex;
+      justify-content: flex-end;
+      position: relative;
+    }
+
+    &__suggestions-container {
+      position: absolute;
+      top: $spacing-09;
+      left: 0;
+      width: 100%;
+    }
+
+    &__suggestions-list {
+      background-color: $ui-background;
+      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
+    }
+
+    &__suggestion {
+      height: $spacing-09;
+      display: flex;
+      padding: 0 $spacing-05;
+
+      .container-class {
+        display: flex;
+        border-bottom: 1px solid $ui-01;
+        flex: 1;
+        align-items: center;
+      }
+
+      &:hover {
+        cursor: pointer;
+        background-color: $ui-01;
+        transition: $search-transition-timing;
+      }
+    }
+  }
+
+  .#{$prefix}--header__search--input {
+    font-size: $spacing-05;
+    line-height: 1.375rem;
+    border: none;
+    width: 0;
+    transition: 120ms;
+    border-bottom: 1px solid $ui-03;
+    padding: 0;
+
+    &::placeholder {
+      position: relative;
+      left: 5rem;
+      opacity: 0;
+    }
+  }
+}
+
+@include exports('masthead-search') {
+  @include masthead-search;
+}

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -5,12 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 @import '../../globals/imports';
-@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
-@import 'carbon-components/scss/components/ui-shell/ui-shell';
-@import 'carbon-components/scss/components/ui-shell/side-nav';
 
 /// @access private
-/// @group dotcom ui-shell
+/// @group dotcom-shell
 
 $search-transition: cubic-bezier(0.2, 0, 0.38, 0.9);
 $search-transition-timing: 95ms;
@@ -214,126 +211,6 @@ $search-transition-timing: 95ms;
   // masthead profile menu
   .#{$prefix}--overflow-menu-options__btn {
     text-decoration: none;
-  }
-
-  // main nav/search container excluding
-  // profile and logo icons - TODO rename this
-  .#{$prefix}--header__search {
-    display: flex;
-    flex: 1;
-    align-items: center;
-    position: relative;
-    height: 100%;
-  }
-
-  // search container
-  .#{$prefix}--masthead__search {
-    flex: 1;
-
-    &.#{$prefix}--masthead__search--active {
-      position: absolute;
-      z-index: 999;
-      width: 100%;
-
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        display: block;
-        border-bottom: 2px solid $interactive-01;
-      }
-
-      @include carbon--breakpoint-down(md) {
-        width: 100vw;
-        right: (-$spacing-09);
-      }
-
-      .#{$prefix}--header__search--input {
-        display: flex;
-        flex: 1;
-        padding: 0 $spacing-05;
-        outline: 2px solid transparent;
-        outline-offset: -2px;
-        background-color: $ui-01;
-        height: carbon--mini-units(6);
-
-        &::placeholder {
-          left: 0;
-          opacity: 1;
-          transition-duration: 112ms;
-          transition-delay: 200ms;
-        }
-      }
-
-      .#{$prefix}--header__search--close {
-        width: $spacing-09;
-      }
-
-      .#{$prefix}--header__action {
-        background-color: $ui-01;
-        transition-property: width;
-        transition-delay: 380ms;
-        transition-duration: 112ms;
-      }
-    }
-  }
-
-  .react-autosuggest {
-    &__container {
-      display: flex;
-      justify-content: flex-end;
-      position: relative;
-    }
-
-    &__suggestions-container {
-      position: absolute;
-      top: $spacing-09;
-      left: 0;
-      width: 100%;
-    }
-
-    &__suggestions-list {
-      background-color: $ui-background;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
-    }
-
-    &__suggestion {
-      height: $spacing-09;
-      display: flex;
-      padding: 0 $spacing-05;
-
-      .container-class {
-        display: flex;
-        border-bottom: 1px solid $ui-01;
-        flex: 1;
-        align-items: center;
-      }
-
-      &:hover {
-        cursor: pointer;
-        background-color: $ui-01;
-        transition: $search-transition-timing;
-      }
-    }
-  }
-
-  .#{$prefix}--header__search--input {
-    font-size: $spacing-05;
-    line-height: 1.375rem;
-    border: none;
-    width: 0;
-    transition: 120ms;
-    border-bottom: 1px solid $ui-03;
-    padding: 0;
-
-    &::placeholder {
-      position: relative;
-      left: 5rem;
-      opacity: 0;
-    }
   }
 }
 

--- a/packages/styles/scss/components/masthead/index.scss
+++ b/packages/styles/scss/components/masthead/index.scss
@@ -1,0 +1,19 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+@import '../../globals/imports';
+@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
+@import 'carbon-components/scss/components/ui-shell/ui-shell';
+@import 'carbon-components/scss/components/ui-shell/side-nav';
+
+// Include masthead components
+// @access private
+// @group masthead
+
+@import 'masthead';
+@import 'masthead-l1';
+@import 'masthead-search';
+@import 'masthead-leftnav';


### PR DESCRIPTION
### Related Ticket(s)

https://github.ibm.com/webstandards/digital-design/issues/1247

### Description

Adds sticky masthead functionality to `dotcom-shell` component.

### Changelog

**New**

- Sticky masthead in `dotcom-shell` component
- Dotcom shell responsive css

**Changed**

- break out `_masthead.scss` styles into their own files

