### PR TITLE
docs(cors): adding cors proxy documentation for the masthead/footer

### DIFF
--- a/packages/react/src/components/Footer/README.md
+++ b/packages/react/src/components/Footer/README.md
@@ -44,6 +44,15 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 | `legal-nav`              | Component   |
 | `legal-nav__link`        | Interactive |
 
+## CORS Proxy
+
+This component makes cross-origin requests to `www.ibm.com`, which will require
+a cors proxy to be configured to make successful calls from a lower environment.
+
+A cors proxy can be configured using the following environment variable:
+
+`CORS_PROXY=https://myproxy.com/`
+
 ## 🙌 Contributing
 
 We're always looking for contributors to help us fix bugs, build new features,

--- a/packages/react/src/components/Footer/README.md
+++ b/packages/react/src/components/Footer/README.md
@@ -49,7 +49,8 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 This component makes cross-origin requests to `www.ibm.com`, which will require
 a cors proxy to be configured to make successful calls from a lower environment.
 
-A cors proxy can be configured using the following environment variable:
+A cors proxy can be configured using the following
+[environment variable](../../../docs/environment-variables.md):
 
 `CORS_PROXY=https://myproxy.com/`
 

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -61,7 +61,8 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 This component makes cross-origin requests to `www.ibm.com`, which will require
 a cors proxy to be configured to make successful calls from a lower environment.
 
-A cors proxy can be configured using the following environment variable:
+A cors proxy can be configured using the following
+[environment variable](../../../docs/environment-variables.md):
 
 `CORS_PROXY=https://myproxy.com/`
 

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -56,6 +56,15 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 | `masthead__l0-sidenav--nav-${item}`    | Interactive |
 | `masthead__l0-sidenav--subnav-${item}` | Interactive |
 
+## CORS Proxy
+
+This component makes cross-origin requests to `www.ibm.com`, which will require
+a cors proxy to be configured to make successful calls from a lower environment.
+
+A cors proxy can be configured using the following environment variable:
+
+`CORS_PROXY=https://myproxy.com/`
+
 ## 🙌 Contributing
 
 We're always looking for contributors to help us fix bugs, build new features,


### PR DESCRIPTION
### Related Ticket(s)

No related tickets

### Description

I added quick documentation on setting up a CORS proxy for the components that will need it in order to function properly. 

### Changelog

**Changed**

- Masthead/footer README files
