### PR TITLE
fix(services): added axios as a dependency

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -34,6 +34,7 @@
     "jsdoc": "rimraf docs && jsdoc -c ./jsdoc.json ./README.md"
   },
   "dependencies": {
+    "axios": "^0.19.0",
     "jsonp": "^0.2.1",
     "window-or-global": "^1.0.1"
   },
@@ -48,7 +49,6 @@
     "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "^7.4.3",
     "all-contributors-cli": "^5.2.1",
-    "axios": "^0.19.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/92

### Description

This switches `axios` from a devDependency to an actual dependency.

### Changelog

**Changed**

- Changed `axios` dependency in package.json
