### PR TITLE
Release/v0.5.2

### DIFF
--- a/packages/eslint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/eslint-config-ibmdotcom/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@carbon/eslint-config-ibmdotcom@0.5.1...@carbon/eslint-config-ibmdotcom@0.5.2) (2019-09-17)
+
+**Note:** Version bump only for package @carbon/eslint-config-ibmdotcom
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@carbon/eslint-config-ibmdotcom@0.5.0...@carbon/eslint-config-ibmdotcom@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/eslint-config-ibmdotcom

--- a/packages/eslint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/eslint-config-ibmdotcom/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@carbon/eslint-config-ibmdotcom@0.5.1...@carbon/eslint-config-ibmdotcom@0.5.2) (2019-09-17)
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/eslint-config-ibmdotcom@0.5.1...@carbon/eslint-config-ibmdotcom@0.5.2) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/eslint-config-ibmdotcom
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@carbon/eslint-config-ibmdotcom@0.5.0...@carbon/eslint-config-ibmdotcom@0.5.1) (2019-09-17)
+## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/eslint-config-ibmdotcom@0.5.0...@carbon/eslint-config-ibmdotcom@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/eslint-config-ibmdotcom
 
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@carbon/eslint-config-ibmdotcom@0.5.0-rc.0...@carbon/eslint-config-ibmdotcom@0.5.0) (2019-09-17)
+# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/eslint-config-ibmdotcom@0.5.0-rc.0...@carbon/eslint-config-ibmdotcom@0.5.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/eslint-config-ibmdotcom
 
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@carbon/eslint-config-ibmdotcom@0.4.0...@carbon/eslint-config-ibmdotcom@0.5.0-rc.0) (2019-09-17)
+# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/eslint-config-ibmdotcom@0.4.0...@carbon/eslint-config-ibmdotcom@0.5.0-rc.0) (2019-09-17)
 
 # 0.4.0 (2019-09-10)
 
@@ -46,34 +46,34 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **release:** reset versions to rc.0 temporarily
-  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/e7c46ce))
+  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e7c46ce))
 - **eslint:** adding additional eslint checks for react components
-  ([#54](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/issues/54))
-  ([040153b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/040153b))
+  ([#54](https://github.com/carbon-design-system/ibm-dotcom-library/issues/54))
+  ([040153b](https://github.com/carbon-design-system/ibm-dotcom-library/commit/040153b))
 - **packages:** renamed lint packages to be consistent
-  ([f5d8149](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/f5d8149))
+  ([f5d8149](https://github.com/carbon-design-system/ibm-dotcom-library/commit/f5d8149))
 
 ### Features
 
 - **carbon:** switched to carbon ibmdotcom packages
-  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/b541b73))
+  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b541b73))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0) (2019-08-29)
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0) (2019-08-29)
 
-# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0-rc.0) (2019-08-28)
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/eslint-config-ibmdotcom@0.1.0...@ibmdotcom/eslint-config-ibmdotcom@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes
 
 - **eslint:** adding additional eslint checks for react components
-  ([#54](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/issues/54))
-  ([040153b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/040153b))
+  ([#54](https://github.com/carbon-design-system/ibm-dotcom-library/issues/54))
+  ([040153b](https://github.com/carbon-design-system/ibm-dotcom-library/commit/040153b))
 
 ### Features
 
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
 # 0.2.0 (2019-08-05)
 
@@ -86,15 +86,15 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **eslint:** removed unused eslint configurations
-  ([848f52b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/848f52b))
+  ([848f52b](https://github.com/carbon-design-system/ibm-dotcom-library/commit/848f52b))
 - **lerna:** added fixes to private package.json to prevent publishing
-  ([4df6797](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/4df6797))
+  ([4df6797](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4df6797))
 - **lerna:** reverting private package version names
-  ([ee1cdef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/ee1cdef))
+  ([ee1cdef](https://github.com/carbon-design-system/ibm-dotcom-library/commit/ee1cdef))
 - **lerna:** reverting private package version names
-  ([8ad8461](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/8ad8461))
+  ([8ad8461](https://github.com/carbon-design-system/ibm-dotcom-library/commit/8ad8461))
 
 ### Features
 
 - **jsdoc:** added jsdoc generation from services
-  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom/commit/d2089e4))
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d2089e4))

--- a/packages/eslint-config-ibmdotcom/package.json
+++ b/packages/eslint-config-ibmdotcom/package.json
@@ -5,7 +5,7 @@
   "description": "ESLint configuration for the IBM.com Library",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/eslint-config-ibmdotcom",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "keywords": [
     "ibm",

--- a/packages/eslint-config-ibmdotcom/package.json
+++ b/packages/eslint-config-ibmdotcom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/eslint-config-ibmdotcom",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "ESLint configuration for the IBM.com Library",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/patterns-react/CHANGELOG.md
+++ b/packages/patterns-react/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/compare/@carbon/ibmdotcom-patterns-react@0.1.1...@carbon/ibmdotcom-patterns-react@0.1.2) (2019-09-17)
+## [0.1.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-patterns-react@0.1.1...@carbon/ibmdotcom-patterns-react@0.1.2) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-patterns-react
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/compare/@carbon/ibmdotcom-patterns-react@0.1.0...@carbon/ibmdotcom-patterns-react@0.1.1) (2019-09-17)
+## [0.1.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-patterns-react@0.1.0...@carbon/ibmdotcom-patterns-react@0.1.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-patterns-react
 
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.1.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/compare/@carbon/ibmdotcom-patterns-react@0.1.0-rc.0...@carbon/ibmdotcom-patterns-react@0.1.0) (2019-09-17)
+# [0.1.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-patterns-react@0.1.0-rc.0...@carbon/ibmdotcom-patterns-react@0.1.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-patterns-react
 
@@ -35,17 +35,17 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **patterns:** fixed build name references for patterns
-  ([5aea1de](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/commit/5aea1de))
+  ([5aea1de](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5aea1de))
 - **patterns:** fixed initial release version of patterns react
-  ([f9efb31](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/commit/f9efb31))
+  ([f9efb31](https://github.com/carbon-design-system/ibm-dotcom-library/commit/f9efb31))
 - **patterns:** fixed README for react patterns
-  ([84de1cc](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/commit/84de1cc))
+  ([84de1cc](https://github.com/carbon-design-system/ibm-dotcom-library/commit/84de1cc))
 - **storybook:** removed commented code
-  ([23d5968](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/commit/23d5968))
+  ([23d5968](https://github.com/carbon-design-system/ibm-dotcom-library/commit/23d5968))
 - **storybook:** various fixes to the storybook configuration
-  ([a7cc11a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/commit/a7cc11a))
+  ([a7cc11a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a7cc11a))
 
 ### Features
 
 - **translation:** switching name to patterns-react
-  ([b035c10](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/commit/b035c10))
+  ([b035c10](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b035c10))

--- a/packages/patterns-react/CHANGELOG.md
+++ b/packages/patterns-react/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/compare/@carbon/ibmdotcom-patterns-react@0.1.1...@carbon/ibmdotcom-patterns-react@0.1.2) (2019-09-17)
+
+**Note:** Version bump only for package @carbon/ibmdotcom-patterns-react
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.1.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react/compare/@carbon/ibmdotcom-patterns-react@0.1.0...@carbon/ibmdotcom-patterns-react@0.1.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-patterns-react

--- a/packages/patterns-react/package.json
+++ b/packages/patterns-react/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "files": [
     "lib/**/*",

--- a/packages/patterns-react/package.json
+++ b/packages/patterns-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibmdotcom-patterns-react",
   "description": "IBM.com Library React Patterns",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,32 +3,32 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@carbon/ibmdotcom-react@0.5.1...@carbon/ibmdotcom-react@0.5.2) (2019-09-17)
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@0.5.1...@carbon/ibmdotcom-react@0.5.2) (2019-09-17)
 
 ### Bug Fixes
 
 - **react:** exports DotcomShell; fixes
-  [#94](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/94)
-  ([d2e2fdb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d2e2fdb))
+  [#94](https://github.com/carbon-design-system/ibm-dotcom-library/issues/94)
+  ([d2e2fdb](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d2e2fdb))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@carbon/ibmdotcom-react@0.5.0...@carbon/ibmdotcom-react@0.5.1) (2019-09-17)
+## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@0.5.0...@carbon/ibmdotcom-react@0.5.1) (2019-09-17)
 
 ### Bug Fixes
 
 - **hr:** export hr in components
-  ([e2736a8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/e2736a8))
+  ([e2736a8](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e2736a8))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@carbon/ibmdotcom-react@0.5.0-rc.0...@carbon/ibmdotcom-react@0.5.0) (2019-09-17)
+# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@0.5.0-rc.0...@carbon/ibmdotcom-react@0.5.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-react
 
@@ -37,43 +37,43 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@carbon/ibmdotcom-react@0.4.0...@carbon/ibmdotcom-react@0.5.0-rc.0) (2019-09-17)
+# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@0.4.0...@carbon/ibmdotcom-react@0.5.0-rc.0) (2019-09-17)
 
 ### Bug Fixes
 
 - **jest:** various jest test fixes
-  ([0c93cf1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/0c93cf1))
+  ([0c93cf1](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0c93cf1))
 - **storybook:** removed commented code
-  ([23d5968](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/23d5968))
+  ([23d5968](https://github.com/carbon-design-system/ibm-dotcom-library/commit/23d5968))
 - **storybook:** various fixes to the storybook configuration
-  ([a7cc11a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/a7cc11a))
+  ([a7cc11a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a7cc11a))
 
 ### Features
 
 - **component:** adds translation data to masthead
-  ([7f55815](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7f55815))
+  ([7f55815](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7f55815))
 - **footer:** fetching content from translation service
-  ([86e6d6f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/86e6d6f))
+  ([86e6d6f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/86e6d6f))
 - **masthead:** adds masthead types with translation API
-  ([60223fb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/60223fb))
+  ([60223fb](https://github.com/carbon-design-system/ibm-dotcom-library/commit/60223fb))
 - **profile:** add dynamic profile menu from translation api
-  ([68c40df](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/68c40df))
+  ([68c40df](https://github.com/carbon-design-system/ibm-dotcom-library/commit/68c40df))
 
 # 0.4.0 (2019-09-10)
 
 ### Bug Fixes
 
 - **react:** removed test Translation API call
-  ([71ae263](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/71ae263))
+  ([71ae263](https://github.com/carbon-design-system/ibm-dotcom-library/commit/71ae263))
 
 ### Features
 
 - **patterns:** added placeholder scss file for leadspace
-  ([7df5633](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7df5633))
+  ([7df5633](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7df5633))
 - **patterns:** initial patterns package (WIP)
-  ([436e5eb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/436e5eb))
+  ([436e5eb](https://github.com/carbon-design-system/ibm-dotcom-library/commit/436e5eb))
 - **translation:** switching name to patterns-react
-  ([b035c10](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/b035c10))
+  ([b035c10](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b035c10))
 
 # Change Log
 
@@ -85,144 +85,144 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **release:** reset versions to rc.0 temporarily
-  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/e7c46ce))
+  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e7c46ce))
 - **docs:** fixed typos
-  ([69e1fad](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/69e1fad))
+  ([69e1fad](https://github.com/carbon-design-system/ibm-dotcom-library/commit/69e1fad))
 - **hr:** import carbon style for storybook container and scss tweaks
-  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/64))
-  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cd0929c))
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cd0929c))
 - **lint:** fixed lint issue in Footer
-  ([4d5fa86](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/4d5fa86))
+  ([4d5fa86](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4d5fa86))
 - **netlify:** fix to point to alpha releases of services/utilities
-  ([a9fdeb4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/a9fdeb4))
+  ([a9fdeb4](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a9fdeb4))
 - **profile:** bump up alpha release for services in react
-  ([0e44093](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/0e44093))
+  ([0e44093](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0e44093))
 - **profile:** wrap profile call in promise
-  ([64f827d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/64f827d))
+  ([64f827d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/64f827d))
 - **readme:** fixed rendering of readme files in storybook
-  ([5fda9d8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5fda9d8))
+  ([5fda9d8](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5fda9d8))
 - **release:** manually updating package.json
-  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/2c21cef))
+  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/commit/2c21cef))
 - **rollup:** fixed rollup config
-  ([5a8f32a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5a8f32a))
+  ([5a8f32a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5a8f32a))
 - **search:** fixed package references for services and utilities
-  ([56fede8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/56fede8))
+  ([56fede8](https://github.com/carbon-design-system/ibm-dotcom-library/commit/56fede8))
 - **search:** fixing babel transform runtime issues
-  ([922d3d7](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/922d3d7))
+  ([922d3d7](https://github.com/carbon-design-system/ibm-dotcom-library/commit/922d3d7))
 - **storybook:** fixed issue with masthead not rendering
-  ([692a911](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/692a911))
+  ([692a911](https://github.com/carbon-design-system/ibm-dotcom-library/commit/692a911))
 - **utilities:** updated react package dependencies
-  ([d129c40](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d129c40))
+  ([d129c40](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d129c40))
 
 ### Features
 
 - **carbon:** changed npm namespace to carbon
-  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/0e0896d))
+  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0e0896d))
 - **carbon:** switched to carbon ibmdotcom packages
-  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/b541b73))
+  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b541b73))
 - **component:** adds Dotcom shell
-  ([ccd4c4b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/ccd4c4b))
+  ([ccd4c4b](https://github.com/carbon-design-system/ibm-dotcom-library/commit/ccd4c4b))
 - **component:** adds search to masthead
-  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/50))
-  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/292bd2f)),
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/292bd2f)),
   closes
-  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1214)
-  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1215)
-  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1217)
-  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1218)
-  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1212)
-  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1213)
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1213)
 - **deployments:** added and updated deployment scripts for packages
-  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/b8f8ccf))
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b8f8ccf))
 - **featureflags:** adding feature flags functionality for react
-  ([84b9fcd](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/84b9fcd))
+  ([84b9fcd](https://github.com/carbon-design-system/ibm-dotcom-library/commit/84b9fcd))
 - **jest:** adding coverage reports for jest
-  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7145a7c))
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7145a7c))
 - **profile:** add signedIn icon
-  ([7f5d0d7](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7f5d0d7))
+  ([7f5d0d7](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7f5d0d7))
 - **profile:** adds static profile component
-  ([388059f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/388059f))
+  ([388059f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/388059f))
 - **profile:** getting user status endpoint up - returning default
-  ([63c880a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/63c880a))
+  ([63c880a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/63c880a))
 - **react:** adds Dotcom ui-shell component
-  ([c392c70](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/c392c70))
+  ([c392c70](https://github.com/carbon-design-system/ibm-dotcom-library/commit/c392c70))
 - **react:** horizontalrule component
-  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/56))
-  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/507a0f3))
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/commit/507a0f3))
 - **react:** wraps up first MVP for footer
-  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/51))
-  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cc75800)),
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cc75800)),
   closes
-  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1368)
-  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1080)
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1080)
 - **search:** added highlighted test in suggestions and redirect link
-  ([#47](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/47))
-  ([67218eb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/67218eb))
+  ([#47](https://github.com/carbon-design-system/ibm-dotcom-library/issues/47))
+  ([67218eb](https://github.com/carbon-design-system/ibm-dotcom-library/commit/67218eb))
 - **search:** adding initial masthead search components (wip)
-  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bad3b8e))
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/bad3b8e))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@ibmdotcom/react@0.1.0...@ibmdotcom/react@0.3.0) (2019-08-29)
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/react@0.1.0...@ibmdotcom/react@0.3.0) (2019-08-29)
 
 # 0.3.0-rc.0 (2019-08-28)
 
 ### Bug Fixes
 
 - **hr:** import carbon style for storybook container and scss tweaks
-  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/64))
-  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cd0929c))
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cd0929c))
 - **lint:** fixed lint issue in Footer
-  ([4d5fa86](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/4d5fa86))
+  ([4d5fa86](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4d5fa86))
 - **netlify:** fix to point to alpha releases of services/utilities
-  ([a9fdeb4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/a9fdeb4))
+  ([a9fdeb4](https://github.com/carbon-design-system/ibm-dotcom-library/commit/a9fdeb4))
 - **readme:** fixed rendering of readme files in storybook
-  ([5fda9d8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5fda9d8))
+  ([5fda9d8](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5fda9d8))
 - **rollup:** fixed rollup config
-  ([5a8f32a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/5a8f32a))
+  ([5a8f32a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5a8f32a))
 - **search:** fixed package references for services and utilities
-  ([56fede8](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/56fede8))
+  ([56fede8](https://github.com/carbon-design-system/ibm-dotcom-library/commit/56fede8))
 - **search:** fixing babel transform runtime issues
-  ([922d3d7](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/922d3d7))
+  ([922d3d7](https://github.com/carbon-design-system/ibm-dotcom-library/commit/922d3d7))
 - **storybook:** fixed issue with masthead not rendering
-  ([692a911](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/692a911))
+  ([692a911](https://github.com/carbon-design-system/ibm-dotcom-library/commit/692a911))
 - **utilities:** updated react package dependencies
-  ([d129c40](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d129c40))
+  ([d129c40](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d129c40))
 
 ### Features
 
 - **component:** adds search to masthead
-  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/50))
-  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/292bd2f)),
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/292bd2f)),
   closes
-  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1214)
-  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1215)
-  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1217)
-  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1218)
-  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1212)
-  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1213)
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1213)
 - **deployments:** added and updated deployment scripts for packages
-  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/b8f8ccf))
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b8f8ccf))
 - **featureflags:** adding feature flags functionality for react
-  ([84b9fcd](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/84b9fcd))
+  ([84b9fcd](https://github.com/carbon-design-system/ibm-dotcom-library/commit/84b9fcd))
 - **jest:** adding coverage reports for jest
-  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/7145a7c))
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7145a7c))
 - **react:** horizontalrule component
-  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/56))
-  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/507a0f3))
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/commit/507a0f3))
 - **react:** wraps up first MVP for footer
-  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/51))
-  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/cc75800)),
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cc75800)),
   closes
-  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1368)
-  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/1080)
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1080)
 - **search:** added highlighted test in suggestions and redirect link
-  ([#47](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/47))
-  ([67218eb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/67218eb))
+  ([#47](https://github.com/carbon-design-system/ibm-dotcom-library/issues/47))
+  ([67218eb](https://github.com/carbon-design-system/ibm-dotcom-library/commit/67218eb))
 - **search:** adding initial masthead search components (wip)
-  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bad3b8e))
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/bad3b8e))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
 # 0.2.0 (2019-08-05)
 
@@ -231,7 +231,7 @@ All notable changes to this project will be documented in this file. See
 ### Features
 
 - **footer:** laying down the basework for the footer
-  ([bf05b3c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/bf05b3c))
+  ([bf05b3c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/bf05b3c))
 
 # 0.1.0 (2019-07-30)
 
@@ -240,21 +240,21 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **ci:** move loads.js to correct dir
-  ([584fdd5](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/584fdd5))
+  ([584fdd5](https://github.com/carbon-design-system/ibm-dotcom-library/commit/584fdd5))
 - **yarn:** add loader file for ci-check
-  ([ca02703](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/ca02703))
+  ([ca02703](https://github.com/carbon-design-system/ibm-dotcom-library/commit/ca02703))
 
 ### Features
 
 - **component:** add Masthead component stub
-  ([fee6b44](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/fee6b44))
+  ([fee6b44](https://github.com/carbon-design-system/ibm-dotcom-library/commit/fee6b44))
 - **components:** add masthead react stub
-  ([3cd2b5b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/3cd2b5b))
+  ([3cd2b5b](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3cd2b5b))
 - **jsdoc:** added jsdoc generation from services
-  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d2089e4))
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d2089e4))
 - **lerna:** adjusting initial version to 0.0.0
-  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/3f01404))
+  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3f01404))
 - **lerna:** cleaned up react package.json
-  ([fde3da3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/fde3da3))
+  ([fde3da3](https://github.com/carbon-design-system/ibm-dotcom-library/commit/fde3da3))
 - **lerna:** updated package names and versions
-  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/9929d1c))
+  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/9929d1c))

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@carbon/ibmdotcom-react@0.5.1...@carbon/ibmdotcom-react@0.5.2) (2019-09-17)
+
+### Bug Fixes
+
+- **react:** exports DotcomShell; fixes
+  [#94](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/issues/94)
+  ([d2e2fdb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/commit/d2e2fdb))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/compare/@carbon/ibmdotcom-react@0.5.0...@carbon/ibmdotcom-react@0.5.1) (2019-09-17)
 
 ### Bug Fixes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibmdotcom-react",
   "description": "IBM.com Library React Components",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -48,9 +48,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@carbon/ibmdotcom-services": "0.5.1",
-    "@carbon/ibmdotcom-styles": "0.5.1",
-    "@carbon/ibmdotcom-utilities": "0.5.1",
+    "@carbon/ibmdotcom-services": "0.5.2",
+    "@carbon/ibmdotcom-styles": "0.5.2",
+    "@carbon/ibmdotcom-utilities": "0.5.2",
     "autosuggest-highlight": "^3.1.1",
     "classnames": "2.2.6",
     "react-autosuggest": "^9.4.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "files": [
     "lib/**/*",

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@carbon/ibmdotcom-services@0.5.1...@carbon/ibmdotcom-services@0.5.2) (2019-09-17)
+
+### Bug Fixes
+
+- **services:** added axios as a dependency
+  ([d19882a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d19882a))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@carbon/ibmdotcom-services@0.5.0...@carbon/ibmdotcom-services@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -3,19 +3,19 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@carbon/ibmdotcom-services@0.5.1...@carbon/ibmdotcom-services@0.5.2) (2019-09-17)
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@0.5.1...@carbon/ibmdotcom-services@0.5.2) (2019-09-17)
 
 ### Bug Fixes
 
 - **services:** added axios as a dependency
-  ([d19882a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d19882a))
+  ([d19882a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d19882a))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@carbon/ibmdotcom-services@0.5.0...@carbon/ibmdotcom-services@0.5.1) (2019-09-17)
+## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@0.5.0...@carbon/ibmdotcom-services@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@carbon/ibmdotcom-services@0.5.0-rc.0...@carbon/ibmdotcom-services@0.5.0) (2019-09-17)
+# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@0.5.0-rc.0...@carbon/ibmdotcom-services@0.5.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-services
 
@@ -33,31 +33,31 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@carbon/ibmdotcom-services@0.4.0...@carbon/ibmdotcom-services@0.5.0-rc.0) (2019-09-17)
+# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-services@0.4.0...@carbon/ibmdotcom-services@0.5.0-rc.0) (2019-09-17)
 
 ### Bug Fixes
 
 - **jest:** fixes to the jest env settings to share across packages
-  ([30a3ec7](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/30a3ec7))
+  ([30a3ec7](https://github.com/carbon-design-system/ibm-dotcom-library/commit/30a3ec7))
 
 ### Features
 
 - **footer:** added socialFollow data to footer content
-  ([973f1af](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/973f1af))
+  ([973f1af](https://github.com/carbon-design-system/ibm-dotcom-library/commit/973f1af))
 - **masthead:** adds masthead types with translation API
-  ([60223fb](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/60223fb))
+  ([60223fb](https://github.com/carbon-design-system/ibm-dotcom-library/commit/60223fb))
 
 # 0.4.0 (2019-09-10)
 
 ### Bug Fixes
 
 - **translation:** added translation service export
-  ([726ae4e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/726ae4e))
+  ([726ae4e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/726ae4e))
 
 ### Features
 
 - **translation:** added translation service
-  ([e4f9d90](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/e4f9d90))
+  ([e4f9d90](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e4f9d90))
 
 # Change Log
 
@@ -69,50 +69,50 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **release:** reset versions to rc.0 temporarily
-  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/e7c46ce))
+  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e7c46ce))
 - **profile:** wrap profile call in promise
-  ([977f27d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/977f27d))
+  ([977f27d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/977f27d))
 - **release:** manually updating package.json
-  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/2c21cef))
+  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/commit/2c21cef))
 - **search:** fixing axios/rollup configuration
-  ([60b554c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/60b554c))
+  ([60b554c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/60b554c))
 
 ### Features
 
 - **carbon:** changed npm namespace to carbon
-  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0e0896d))
+  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0e0896d))
 - **carbon:** switched to carbon ibmdotcom packages
-  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b541b73))
+  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b541b73))
 - **deployments:** added and updated deployment scripts for packages
-  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b8f8ccf))
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b8f8ccf))
 - **jest:** adding coverage reports for jest
-  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/7145a7c))
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7145a7c))
 - **profile:** getting user status endpoint up - returning default
-  ([63c880a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/63c880a))
+  ([63c880a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/63c880a))
 - **search:** adding initial search services
-  ([72fba4f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/72fba4f))
+  ([72fba4f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/72fba4f))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0) (2019-08-29)
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0) (2019-08-29)
 
-# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0-rc.0) (2019-08-28)
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/services@0.1.0...@ibmdotcom/services@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes
 
 - **search:** fixing axios/rollup configuration
-  ([60b554c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/60b554c))
+  ([60b554c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/60b554c))
 
 ### Features
 
 - **deployments:** added and updated deployment scripts for packages
-  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b8f8ccf))
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b8f8ccf))
 - **jest:** adding coverage reports for jest
-  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/7145a7c))
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7145a7c))
 - **search:** adding initial search services
-  ([72fba4f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/72fba4f))
+  ([72fba4f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/72fba4f))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
 # 0.2.0 (2019-08-05)
 
@@ -125,19 +125,19 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **circleci:** adjustments to circle-ci check to run lint and jest
-  ([d2986b6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d2986b6))
+  ([d2986b6](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d2986b6))
 - **circleci:** removed lint from services ci-check
-  ([b981db2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/b981db2))
+  ([b981db2](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b981db2))
 
 ### Features
 
 - **jsdoc:** added jsdoc generation from services
-  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/d2089e4))
+  ([d2089e4](https://github.com/carbon-design-system/ibm-dotcom-library/commit/d2089e4))
 - **lerna:** adjusting initial version to 0.0.0
-  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/3f01404))
+  ([3f01404](https://github.com/carbon-design-system/ibm-dotcom-library/commit/3f01404))
 - **lerna:** updated package names and versions
-  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/9929d1c))
+  ([9929d1c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/9929d1c))
 - **services:** added working jest test for demo service class
-  ([0957a6a](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0957a6a))
+  ([0957a6a](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0957a6a))
 - **services:** created the initial services package architecture (WIP)
-  ([0a072e0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services/commit/0a072e0))
+  ([0a072e0](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0a072e0))

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/services",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "files": [
     "lib/**/*",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibmdotcom-services",
   "description": "IBM.com Library Services",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/stylelint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/stylelint-config-ibmdotcom/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/compare/@carbon/stylelint-config-ibmdotcom@0.4.1...@carbon/stylelint-config-ibmdotcom@0.4.2) (2019-09-17)
+
+**Note:** Version bump only for package @carbon/stylelint-config-ibmdotcom
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.4.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/compare/@carbon/stylelint-config-ibmdotcom@0.4.0...@carbon/stylelint-config-ibmdotcom@0.4.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/stylelint-config-ibmdotcom

--- a/packages/stylelint-config-ibmdotcom/CHANGELOG.md
+++ b/packages/stylelint-config-ibmdotcom/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.4.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/compare/@carbon/stylelint-config-ibmdotcom@0.4.1...@carbon/stylelint-config-ibmdotcom@0.4.2) (2019-09-17)
+## [0.4.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/stylelint-config-ibmdotcom@0.4.1...@carbon/stylelint-config-ibmdotcom@0.4.2) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/stylelint-config-ibmdotcom
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.4.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/compare/@carbon/stylelint-config-ibmdotcom@0.4.0...@carbon/stylelint-config-ibmdotcom@0.4.1) (2019-09-17)
+## [0.4.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/stylelint-config-ibmdotcom@0.4.0...@carbon/stylelint-config-ibmdotcom@0.4.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/stylelint-config-ibmdotcom
 
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.4.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/compare/@carbon/stylelint-config-ibmdotcom@0.4.0-rc.0...@carbon/stylelint-config-ibmdotcom@0.4.0) (2019-09-17)
+# [0.4.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/stylelint-config-ibmdotcom@0.4.0-rc.0...@carbon/stylelint-config-ibmdotcom@0.4.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/stylelint-config-ibmdotcom
 
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.4.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/compare/@carbon/stylelint-config-ibmdotcom@0.3.0...@carbon/stylelint-config-ibmdotcom@0.4.0-rc.0) (2019-09-17)
+# [0.4.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/stylelint-config-ibmdotcom@0.3.0...@carbon/stylelint-config-ibmdotcom@0.4.0-rc.0) (2019-09-17)
 
 # 0.4.0 (2019-09-10)
 
@@ -46,9 +46,9 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **release:** reset versions to rc.0 temporarily
-  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/commit/e7c46ce))
+  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e7c46ce))
 - **packages:** renamed lint packages to be consistent
-  ([f5d8149](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom/commit/f5d8149))
+  ([f5d8149](https://github.com/carbon-design-system/ibm-dotcom-library/commit/f5d8149))
 
 # [0.2.0](https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements/compare/@ibmdotcom/stylelint-config-elements@0.1.0...@ibmdotcom/stylelint-config-elements@0.2.0) (2019-08-29)
 

--- a/packages/stylelint-config-ibmdotcom/package.json
+++ b/packages/stylelint-config-ibmdotcom/package.json
@@ -5,7 +5,7 @@
   "description": "Stylelint configuration for the IBM.com Library",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/stylelint-config-ibmdotcom",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "keywords": [
     "ibm",

--- a/packages/stylelint-config-ibmdotcom/package.json
+++ b/packages/stylelint-config-ibmdotcom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/stylelint-config-ibmdotcom",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Stylelint configuration for the IBM.com Library",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@carbon/ibmdotcom-styles@0.5.1...@carbon/ibmdotcom-styles@0.5.2) (2019-09-17)
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-styles@0.5.1...@carbon/ibmdotcom-styles@0.5.2) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-styles
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@carbon/ibmdotcom-styles@0.5.0...@carbon/ibmdotcom-styles@0.5.1) (2019-09-17)
+## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-styles@0.5.0...@carbon/ibmdotcom-styles@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-styles
 
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@carbon/ibmdotcom-styles@0.5.0-rc.0...@carbon/ibmdotcom-styles@0.5.0) (2019-09-17)
+# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-styles@0.5.0-rc.0...@carbon/ibmdotcom-styles@0.5.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-styles
 
@@ -30,19 +30,19 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@carbon/ibmdotcom-styles@0.4.0...@carbon/ibmdotcom-styles@0.5.0-rc.0) (2019-09-17)
+# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-styles@0.4.0...@carbon/ibmdotcom-styles@0.5.0-rc.0) (2019-09-17)
 
 ### Features
 
 - **profile:** add dynamic profile menu from translation api
-  ([68c40df](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/68c40df))
+  ([68c40df](https://github.com/carbon-design-system/ibm-dotcom-library/commit/68c40df))
 
 # 0.4.0 (2019-09-10)
 
 ### Features
 
 - **patterns:** added placeholder scss file for leadspace
-  ([7df5633](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/7df5633))
+  ([7df5633](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7df5633))
 
 # Change Log
 
@@ -54,82 +54,82 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **release:** reset versions to rc.0 temporarily
-  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/e7c46ce))
+  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e7c46ce))
 - **docs:** fixed typos
-  ([69e1fad](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/69e1fad))
+  ([69e1fad](https://github.com/carbon-design-system/ibm-dotcom-library/commit/69e1fad))
 - **hr:** import carbon style for storybook container and scss tweaks
-  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/64))
-  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cd0929c))
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cd0929c))
 - **release:** manually updating package.json
-  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/2c21cef))
+  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/commit/2c21cef))
 - **search:** fixing prettier/stylelint errors
-  ([739c09d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/739c09d))
+  ([739c09d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/739c09d))
 
 ### Features
 
 - **carbon:** changed npm namespace to carbon
-  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/0e0896d))
+  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0e0896d))
 - **carbon:** switched to carbon ibmdotcom packages
-  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/b541b73))
+  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b541b73))
 - **component:** adds Dotcom shell
-  ([ccd4c4b](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/ccd4c4b))
+  ([ccd4c4b](https://github.com/carbon-design-system/ibm-dotcom-library/commit/ccd4c4b))
 - **component:** adds search to masthead
-  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/50))
-  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/292bd2f)),
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/292bd2f)),
   closes
-  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1214)
-  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1215)
-  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1217)
-  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1218)
-  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1212)
-  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1213)
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1213)
 - **profile:** adds static profile component
-  ([388059f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/388059f))
+  ([388059f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/388059f))
 - **react:** adds Dotcom ui-shell component
-  ([c392c70](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/c392c70))
+  ([c392c70](https://github.com/carbon-design-system/ibm-dotcom-library/commit/c392c70))
 - **react:** horizontalrule component
-  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/56))
-  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/507a0f3))
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/commit/507a0f3))
 - **react:** wraps up first MVP for footer
-  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/51))
-  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cc75800)),
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cc75800)),
   closes
-  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1368)
-  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1080)
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1080)
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0) (2019-08-29)
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0) (2019-08-29)
 
-# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0-rc.0) (2019-08-28)
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/styles@0.1.0...@ibmdotcom/styles@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes
 
 - **hr:** import carbon style for storybook container and scss tweaks
-  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/64))
-  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cd0929c))
+  ([#64](https://github.com/carbon-design-system/ibm-dotcom-library/issues/64))
+  ([cd0929c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cd0929c))
 - **search:** fixing prettier/stylelint errors
-  ([739c09d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/739c09d))
+  ([739c09d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/739c09d))
 
 ### Features
 
 - **component:** adds search to masthead
-  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/50))
-  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/292bd2f)),
+  ([#50](https://github.com/carbon-design-system/ibm-dotcom-library/issues/50))
+  ([292bd2f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/292bd2f)),
   closes
-  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1214)
-  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1215)
-  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1217)
-  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1218)
-  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1212)
-  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1213)
+  [#1214](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1214)
+  [#1215](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1215)
+  [#1217](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1217)
+  [#1218](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1218)
+  [#1212](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1212)
+  [#1213](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1213)
 - **react:** horizontalrule component
-  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/56))
-  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/507a0f3))
+  ([#56](https://github.com/carbon-design-system/ibm-dotcom-library/issues/56))
+  ([507a0f3](https://github.com/carbon-design-system/ibm-dotcom-library/commit/507a0f3))
 - **react:** wraps up first MVP for footer
-  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/51))
-  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/cc75800)),
+  ([#51](https://github.com/carbon-design-system/ibm-dotcom-library/issues/51))
+  ([cc75800](https://github.com/carbon-design-system/ibm-dotcom-library/commit/cc75800)),
   closes
-  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1368)
-  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/issues/1080)
+  [webstandards/digital-design#1368](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1368)
+  [webstandards/digital-design#1080](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1080)
 
 # 0.2.0 (2019-08-05)
 
@@ -138,17 +138,17 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **typo:** fix repo url typo
-  ([fcb3748](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/fcb3748))
+  ([fcb3748](https://github.com/carbon-design-system/ibm-dotcom-library/commit/fcb3748))
 
 ### Features
 
 - **styles:** added build script for styles package
-  ([aa89487](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/aa89487))
+  ([aa89487](https://github.com/carbon-design-system/ibm-dotcom-library/commit/aa89487))
 - **styles:** cleaned up gulpfile into multiple task/build files
-  ([58ea9e9](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/58ea9e9))
+  ([58ea9e9](https://github.com/carbon-design-system/ibm-dotcom-library/commit/58ea9e9))
 - **styles:** fixed exposed folders in node modules package
-  ([6f0dbf6](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/6f0dbf6))
+  ([6f0dbf6](https://github.com/carbon-design-system/ibm-dotcom-library/commit/6f0dbf6))
 - **styles:** fixed public package files
-  ([4f490fa](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/4f490fa))
+  ([4f490fa](https://github.com/carbon-design-system/ibm-dotcom-library/commit/4f490fa))
 - **styles:** moved scss folder to the root
-  ([5be4f6f](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/commit/5be4f6f))
+  ([5be4f6f](https://github.com/carbon-design-system/ibm-dotcom-library/commit/5be4f6f))

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@carbon/ibmdotcom-styles@0.5.1...@carbon/ibmdotcom-styles@0.5.2) (2019-09-17)
+
+**Note:** Version bump only for package @carbon/ibmdotcom-styles
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/compare/@carbon/ibmdotcom-styles@0.5.0...@carbon/ibmdotcom-styles@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-styles

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "main": "dist/ibm-dotcom-styles.min.css",
   "module": "src/scss",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "files": [
     "dist/**/*",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibmdotcom-styles",
   "description": "IBM.com Library Styles",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "main": "dist/ibm-dotcom-styles.min.css",
   "module": "src/scss",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@carbon/ibmdotcom-utilities@0.5.1...@carbon/ibmdotcom-utilities@0.5.2) (2019-09-17)
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-utilities@0.5.1...@carbon/ibmdotcom-utilities@0.5.2) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-utilities
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@carbon/ibmdotcom-utilities@0.5.0...@carbon/ibmdotcom-utilities@0.5.1) (2019-09-17)
+## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-utilities@0.5.0...@carbon/ibmdotcom-utilities@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-utilities
 
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@carbon/ibmdotcom-utilities@0.5.0-rc.0...@carbon/ibmdotcom-utilities@0.5.0) (2019-09-17)
+# [0.5.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-utilities@0.5.0-rc.0...@carbon/ibmdotcom-utilities@0.5.0) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-utilities
 
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@carbon/ibmdotcom-utilities@0.4.0...@carbon/ibmdotcom-utilities@0.5.0-rc.0) (2019-09-17)
+# [0.5.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-utilities@0.4.0...@carbon/ibmdotcom-utilities@0.5.0-rc.0) (2019-09-17)
 
 # 0.4.0 (2019-09-10)
 
@@ -46,46 +46,46 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - **release:** reset versions to rc.0 temporarily
-  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/e7c46ce))
+  ([e7c46ce](https://github.com/carbon-design-system/ibm-dotcom-library/commit/e7c46ce))
 - **release:** manually updating package.json
-  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/2c21cef))
+  ([2c21cef](https://github.com/carbon-design-system/ibm-dotcom-library/commit/2c21cef))
 - **utilities:** fixed utilities exports
-  ([c3e431e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/c3e431e))
+  ([c3e431e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/c3e431e))
 
 ### Features
 
 - **carbon:** changed npm namespace to carbon
-  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/0e0896d))
+  ([0e0896d](https://github.com/carbon-design-system/ibm-dotcom-library/commit/0e0896d))
 - **carbon:** switched to carbon ibmdotcom packages
-  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/b541b73))
+  ([b541b73](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b541b73))
 - **deployments:** added and updated deployment scripts for packages
-  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/b8f8ccf))
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b8f8ccf))
 - **jest:** adding coverage reports for jest
-  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/7145a7c))
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7145a7c))
 - **search:** adding initial masthead search components (wip)
-  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/bad3b8e))
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/bad3b8e))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0) (2019-08-29)
+# [0.3.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0) (2019-08-29)
 
-# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0-rc.0) (2019-08-28)
+# [0.3.0-rc.0](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@ibmdotcom/utilities@0.1.0...@ibmdotcom/utilities@0.3.0-rc.0) (2019-08-28)
 
 ### Bug Fixes
 
 - **utilities:** fixed utilities exports
-  ([c3e431e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/c3e431e))
+  ([c3e431e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/c3e431e))
 
 ### Features
 
 - **deployments:** added and updated deployment scripts for packages
-  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/b8f8ccf))
+  ([b8f8ccf](https://github.com/carbon-design-system/ibm-dotcom-library/commit/b8f8ccf))
 - **jest:** adding coverage reports for jest
-  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/7145a7c))
+  ([7145a7c](https://github.com/carbon-design-system/ibm-dotcom-library/commit/7145a7c))
 - **search:** adding initial masthead search components (wip)
-  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/bad3b8e))
+  ([bad3b8e](https://github.com/carbon-design-system/ibm-dotcom-library/commit/bad3b8e))
 - **search:** adding integration of typeahead api to autosuggest
-  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/36fb186))
+  ([36fb186](https://github.com/carbon-design-system/ibm-dotcom-library/commit/36fb186))
 
 # 0.2.0 (2019-08-05)
 
@@ -98,4 +98,4 @@ All notable changes to this project will be documented in this file. See
 ### Features
 
 - **utilities:** adding utilities package with sample utility function
-  ([12e1e16](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/commit/12e1e16))
+  ([12e1e16](https://github.com/carbon-design-system/ibm-dotcom-library/commit/12e1e16))

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.2](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@carbon/ibmdotcom-utilities@0.5.1...@carbon/ibmdotcom-utilities@0.5.2) (2019-09-17)
+
+**Note:** Version bump only for package @carbon/ibmdotcom-utilities
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [0.5.1](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities/compare/@carbon/ibmdotcom-utilities@0.5.0...@carbon/ibmdotcom-utilities@0.5.1) (2019-09-17)
 
 **Note:** Version bump only for package @carbon/ibmdotcom-utilities

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/utilities",
+  "repository": "https://github.com/carbon-design-system/ibm-dotcom-library",
   "bugs": "https://github.com/carbon-design-system/ibm-dotcom-library/issues",
   "files": [
     "lib/**/*",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibmdotcom-utilities",
   "description": "IBM.com Library Utilities",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Related Ticket(s)

https://github.ibm.com/webstandards/digital-design/issues/1723

### Description

This includes the following release:
https://github.com/carbon-design-system/ibm-dotcom-library/releases/tag/v0.5.2

In addition, fixes were made to address the autogenerated URLs in the CHANGELOGs.

### Changelog

**Changed**

- Updated CHANGELOGs and package.json version bumps
- Fixed package.json to properly set the autogenerated URLs in the CHANGELOGs
