### PR TITLE
feat(analytics): adding base IBM analytics tag to storybook

### DIFF
--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -13,6 +13,9 @@
 <meta name="twitter:image:alt" content="IBM.com Library">
 <meta name="twitter:site" content="@_IBM">
 
+<!-- IBM Tag Management and Site Analytics -->
+<script src="//1.www.s81c.com/common/stats/ibm-common.js"></script>
+
 <!-- Storybook override -->
 <script>
   document.title = 'IBM.com Library React';


### PR DESCRIPTION
### Related Ticket(s)

https://github.ibm.com/webstandards/digital-design/issues/1131

### Description

This adds the global analytics tag for IBM to Storybook.

### Changelog

**New**

- Analytics script for Storybook
