### PR TITLE
fix(jest): multiple jest fixes for the footer

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,8 +2,10 @@
   "**/*.js": [
     "prettier --write",
     "eslint packages",
-    "yarn test",
     "git add"
+  ],
+  "**/*.test.js": [
+    "yarn test"
   ],
   "packages/components/**/*.scss": [
     "prettier --write",

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,10 +2,8 @@
   "**/*.js": [
     "prettier --write",
     "eslint packages",
+    "cross-env BABEL_ENV=test jest",
     "git add"
-  ],
-  "*.test.js": [
-    "yarn test"
   ],
   "packages/components/**/*.scss": [
     "prettier --write",

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -4,7 +4,7 @@
     "eslint packages",
     "git add"
   ],
-  "**/*.test.js": [
+  "*.test.js": [
     "yarn test"
   ],
   "packages/components/**/*.scss": [

--- a/packages/patterns-react/src/patterns/LeadSpace/LeadSpace.js
+++ b/packages/patterns-react/src/patterns/LeadSpace/LeadSpace.js
@@ -25,10 +25,16 @@ const { prefix } = settings;
 function renderButtons(buttons) {
   return buttons.map((button, key) => {
     if (key > 1) return;
+    const renderIcon = button.renderArrow
+      ? {
+          renderIcon: ArrowRight20,
+        }
+      : {};
     return (
       <Button
+        {...renderIcon}
+        key={key}
         data-autoid={`leadspace__cta-${key}`}
-        renderIcon={button.renderArrow && ArrowRight20}
         href={button.link}
         kind={key === 0 ? 'primary' : 'tertiary'}>
         {button.copy}

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'html'],
   setupFiles: ['<rootDir>/config/jest/setup.js'],
+  setupFilesAfterEnv: ['../../tasks/jest/setupafter.js'],
   testMatch: [
     '<rootDir>/**/__tests__/**/*.js?(x)',
     '<rootDir>/**/?(*-)(spec|test).js?(x)',

--- a/packages/react/src/components/Footer/FooterNav.js
+++ b/packages/react/src/components/Footer/FooterNav.js
@@ -45,13 +45,26 @@ function renderGroups(groups) {
   ));
 }
 
+/**
+ * @property propTypes
+ * @description Defined property types for component
+ * @type {{groups: shim}}
+ */
 FooterNav.propTypes = {
   groups: PropTypes.arrayOf(
     PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      links: PropTypes.array.isRequired,
-    }).isRequired
-  ).isRequired,
+      title: PropTypes.string,
+      links: PropTypes.array,
+    })
+  ),
+};
+
+/**
+ * @property defaultProps
+ * @type {{groups: Array}}
+ */
+FooterNav.defaultProps = {
+  groups: null,
 };
 
 export default FooterNav;

--- a/packages/react/src/components/Footer/FooterNavGroup.js
+++ b/packages/react/src/components/Footer/FooterNavGroup.js
@@ -59,14 +59,28 @@ function renderListItems(links) {
   });
 }
 
+/**
+ * @property propTypes
+ * @description Defined property types for component
+ * @type {{links: shim, title: shim}}
+ */
 FooterNavGroup.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   links: PropTypes.arrayOf(
     PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired,
-    }).isRequired
-  ).isRequired,
+      title: PropTypes.string,
+      url: PropTypes.string,
+    })
+  ),
+};
+
+/**
+ * @property defaultProps
+ * @type {{links: Array, title: null}}
+ */
+FooterNavGroup.defaultProps = {
+  title: null,
+  links: null,
 };
 
 export default FooterNavGroup;

--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -76,10 +76,18 @@ function renderListItems(links) {
 LegalNav.propTypes = {
   links: PropTypes.arrayOf(
     PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired,
-    }).isRequired
-  ).isRequired,
+      title: PropTypes.string,
+      url: PropTypes.string,
+    })
+  ),
+};
+
+/**
+ * @property defaultProps
+ * @type {{groups: Array}}
+ */
+LegalNav.defaultProps = {
+  links: null,
 };
 
 export default LegalNav;

--- a/packages/react/src/components/Footer/__tests__/Footer.test.js
+++ b/packages/react/src/components/Footer/__tests__/Footer.test.js
@@ -51,11 +51,8 @@ describe('<Footer />', () => {
     expect(footer.querySelectorAll('.bx--footer-nav-group')).toHaveLength(
       MOCK_DATA.footerMenu.length
     );
-    expect(footer.querySelectorAll('.bx--footer-nav-group')).toHaveLength(
-      MOCK_DATA.footerMenu.length
-    );
     expect(footer.querySelectorAll('.bx--legal-nav__list-item')).toHaveLength(
-      MOCK_DATA.footerThin.length
+      MOCK_DATA.footerThin.length + 1
     );
   });
 

--- a/packages/react/src/components/Footer/__tests__/LegalNav.test.js
+++ b/packages/react/src/components/Footer/__tests__/LegalNav.test.js
@@ -37,7 +37,7 @@ describe('<LegalNav />', () => {
 
     expect(legalNav.exists('.bx--legal-nav')).toBeTruthy();
     expect(legalNav.find('.bx--legal-nav__list-item')).toHaveLength(
-      FOOTER_NAV_DATA.length - 1
+      FOOTER_NAV_DATA.length
     );
   });
 
@@ -48,7 +48,7 @@ describe('<LegalNav />', () => {
 
     expect(legalNav.exists('.bx--legal-nav')).toBeTruthy();
     expect(legalNav.find('.bx--legal-nav__list-item')).toHaveLength(
-      FOOTER_NAV_DATA.length - 1
+      FOOTER_NAV_DATA.length
     );
   });
 
@@ -57,7 +57,7 @@ describe('<LegalNav />', () => {
 
     expect(legalNav.exists('.bx--legal-nav')).toBeTruthy();
     expect(legalNav.find('.bx--legal-nav__list-item')).toHaveLength(
-      FOOTER_NAV_DATA.length
+      FOOTER_NAV_DATA.length + 1
     );
   });
 });

--- a/packages/react/src/components/Footer/__tests__/LegalNav.test.js
+++ b/packages/react/src/components/Footer/__tests__/LegalNav.test.js
@@ -36,6 +36,8 @@ describe('<LegalNav />', () => {
     const legalNav = shallow(<LegalNav links={MOCK_DATA} />);
 
     expect(legalNav.exists('.bx--legal-nav')).toBeTruthy();
+
+    // adding an additional LI to legalNav for the `dds-privacy-cp` placeholder
     expect(legalNav.find('.bx--legal-nav__list-item')).toHaveLength(
       FOOTER_NAV_DATA.length
     );
@@ -47,6 +49,8 @@ describe('<LegalNav />', () => {
     const legalNav = shallow(<LegalNav links={MOCK_DATA} />);
 
     expect(legalNav.exists('.bx--legal-nav')).toBeTruthy();
+
+    // adding an additional LI to legalNav for the `dds-privacy-cp` placeholder
     expect(legalNav.find('.bx--legal-nav__list-item')).toHaveLength(
       FOOTER_NAV_DATA.length
     );
@@ -56,6 +60,8 @@ describe('<LegalNav />', () => {
     const legalNav = shallow(<LegalNav links={MOCK_DATA} />);
 
     expect(legalNav.exists('.bx--legal-nav')).toBeTruthy();
+
+    // adding an additional LI to legalNav for the `dds-privacy-cp` placeholder
     expect(legalNav.find('.bx--legal-nav__list-item')).toHaveLength(
       FOOTER_NAV_DATA.length + 1
     );

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -39,7 +39,7 @@ const MastheadL1 = () => {
           Stock Charts
         </span>
       </div>
-      <HeaderNavigation className={`${prefix}--masthead__l1-nav`}>
+      <HeaderNavigation className={`${prefix}--masthead__l1-nav`} aria-label="">
         <HeaderMenuItem href="#">Link 1</HeaderMenuItem>
         <HeaderMenuItem href="#">Link 2</HeaderMenuItem>
         <HeaderMenuItem href="#">Link 3</HeaderMenuItem>

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -74,10 +74,10 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
 /**
  * @property propTypes
  * @description Defined property types for component
- * @type {{isSideNavExpanded: boolean, navigation: {}}}
+ * @type {{isSideNavExpanded: boolean, navigation: []}}
  */
 MastheadLeftNav.propTypes = {
-  navigation: PropTypes.object,
+  navigation: PropTypes.array,
   isSideNavExpanded: PropTypes.bool,
 };
 

--- a/packages/react/src/components/Masthead/MastheadProfile.js
+++ b/packages/react/src/components/Masthead/MastheadProfile.js
@@ -56,7 +56,7 @@ const MastheadProfile = ({
 MastheadProfile.propTypes = {
   overflowMenuProps: PropTypes.object,
   overflowMenuItemProps: PropTypes.object,
-  profileMenu: PropTypes.object,
+  profileMenu: PropTypes.array,
 };
 
 export default MastheadProfile;

--- a/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
+++ b/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
@@ -67,7 +67,7 @@ const MastheadSearchSuggestion = ({
  * @type {{isHighlighted: shim, suggestion: shim, query: shim, getSuggestionValue: shim}}
  */
 MastheadSearchSuggestion.propTypes = {
-  suggestion: PropTypes.object,
+  suggestion: PropTypes.array,
   query: PropTypes.string,
   isHighlighted: PropTypes.bool,
   getSuggestionValue: PropTypes.func,
@@ -78,7 +78,7 @@ MastheadSearchSuggestion.propTypes = {
  * @type {{isHighlighted: boolean, suggestion: {}, query: string, getSuggestionValue: MastheadSearchSuggestion.defaultProps.getSuggestionValue}}
  */
 MastheadSearchSuggestion.defaultProps = {
-  suggestion: {},
+  suggestion: [],
   query: '',
   isHighlighted: false,
   getSuggestionValue: () => {},

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -81,7 +81,7 @@ const MastheadTopNav = ({ navigation, ...topNavprops }) => {
  * @type {{navigation: {}}}
  */
 MastheadTopNav.propTypes = {
-  navigation: PropTypes.object,
+  navigation: PropTypes.array,
 };
 
 export default MastheadTopNav;

--- a/packages/react/src/components/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1417,9 +1417,11 @@ Array [
               </span>
             </div>
             <nav
+              aria-label=""
               className="bx--header__nav bx--masthead__l1-nav"
             >
               <ul
+                aria-label=""
                 className="bx--header__menu-bar"
                 role="menubar"
               >


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This fixes a number of jest test issues. With most of them, the footer nav links did not account for the additional placeholder element for the truste module so incremented it by 1.

The other thing is to remove the required PropTypes for the various footer components. I felt it wasn't necessary since the component itself already renders null if no items are passed in, and the shape of the props are already covered and should throw console logs accordingly.

### Changelog

**Changed**

- Jest fixes for the footer
