### PR TITLE
fix(jest): silence act errors from testing to unblock pre-commit hook

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,6 +2,7 @@
   "**/*.js": [
     "prettier --write",
     "eslint packages",
+    "yarn test",
     "git add"
   ],
   "packages/components/**/*.scss": [

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   moduleFileExtensions: ['js', 'json'],
   reporters: ['default', 'jest-junit'],
   setupFiles: ['./tasks/jest/setup.js'],
+  setupFilesAfterEnv: ['./tasks/jest/setupafter.js'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testMatch: [
     '<rootDir>/**/__tests__/**/*.js?(x)',

--- a/tasks/jest/setupafter.js
+++ b/tasks/jest/setupafter.js
@@ -1,0 +1,9 @@
+const consoleError = console.error;
+
+global.beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation((...args) => {
+    if (!args[0].includes('was not wrapped in act')) {
+      consoleError(...args);
+    }
+  });
+});


### PR DESCRIPTION
### Related Ticket(s)

[lint-stage "yarn test" failing even though running manually passes #1701](https://github.ibm.com/webstandards/digital-design/issues/1701)

### Description

filter out any `act()` errors to unblock the `yarn test` script in pre-commit hook 

### Changelog

**New**

- add jest setup file for after `setupFilesAfterEnv`