### PR TITLE
Feat/global settings

### DIFF
--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -7,11 +7,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { settings } from '@carbon/ibmdotcom-utilities';
 import { settings as carbonSettings } from 'carbon-components';
-import { Footer } from '@carbon/ibmdotcom-react';
-import Masthead from '../Masthead/Masthead';
+import { Masthead, Footer } from '@carbon/ibmdotcom-react';
 
+const { prefix } = settings;
 const cPrefix = carbonSettings.prefix;
+
 /**
  * DotcomShell component
  *
@@ -28,8 +30,14 @@ const DotcomShell = ({
   return (
     <>
       <Masthead navigation={navigation} {...mastheadProps} />
-      <div className={`${cPrefix}--dotcom-shell`}>
-        <div className={`${cPrefix}--dotcom-shell__content`}>{children}</div>
+      <div
+        data-autoid={`${prefix}--dotcom-shell`}
+        className={`${cPrefix}--dotcom-shell`}>
+        <div
+          data-autoid={`${prefix}--dotcom-shell__content`}
+          className={`${cPrefix}--dotcom-shell__content`}>
+          {children}
+        </div>
       </div>
       <Footer type={footerType} />
     </>

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -7,12 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { Masthead, Footer } from '@carbon/ibmdotcom-react';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * DotcomShell component
@@ -31,11 +31,11 @@ const DotcomShell = ({
     <>
       <Masthead navigation={navigation} {...mastheadProps} />
       <div
-        data-autoid={`${prefix}--dotcom-shell`}
-        className={`${cPrefix}--dotcom-shell`}>
+        data-autoid={`${stablePrefix}--dotcom-shell`}
+        className={`${prefix}--dotcom-shell`}>
         <div
-          data-autoid={`${prefix}--dotcom-shell__content`}
-          className={`${cPrefix}--dotcom-shell__content`}>
+          data-autoid={`${stablePrefix}--dotcom-shell__content`}
+          className={`${prefix}--dotcom-shell__content`}>
           {children}
         </div>
       </div>

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
-import { Masthead, Footer } from '@carbon/ibmdotcom-react';
+import { settings as carbonSettings } from 'carbon-components';
+import { Footer } from '@carbon/ibmdotcom-react';
+import Masthead from '../Masthead/Masthead';
 
-const { prefix } = settings;
-
+const cPrefix = carbonSettings.prefix;
 /**
  * DotcomShell component
  *
@@ -28,8 +28,8 @@ const DotcomShell = ({
   return (
     <>
       <Masthead navigation={navigation} {...mastheadProps} />
-      <div className={`${prefix}--dotcom-shell`}>
-        <div className={`${prefix}--dotcom-shell__content`}>{children}</div>
+      <div className={`${cPrefix}--dotcom-shell`}>
+        <div className={`${cPrefix}--dotcom-shell__content`}>{children}</div>
       </div>
       <Footer type={footerType} />
     </>

--- a/packages/react/src/components/DotcomShell/README.md
+++ b/packages/react/src/components/DotcomShell/README.md
@@ -53,6 +53,13 @@ function App() {
 > [Footer](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Footer)
 > component documentation for their specific usage.
 
+## Stable selectors
+
+| Name                         | Description |
+| ---------------------------- | ----------- |
+| `dds--dotcom-shell`          | Component   |
+| `dds--dotcom-shell__content` | Component   |
+
 ## CORS Proxy
 
 This component makes cross-origin requests to `www.ibm.com`, which will require

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -7,8 +7,8 @@
 
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { TranslationAPI } from '@carbon/ibmdotcom-services';
 import classNames from 'classnames';
 import FooterLogo from './FooterLogo';
@@ -16,8 +16,8 @@ import FooterNav from './FooterNav';
 import LegalNav from './LegalNav';
 import LocaleButton from './LocaleButton';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer component
@@ -39,10 +39,10 @@ const Footer = ({ type }) => {
 
   return (
     <footer
-      data-autoid={`${prefix}--footer`}
-      className={classNames(`${cPrefix}--footer`, setFooterType(type))}>
-      <section className={`${cPrefix}--footer__main`}>
-        <div className={`${cPrefix}--footer__main-container`}>
+      data-autoid={`${stablePrefix}--footer`}
+      className={classNames(`${prefix}--footer`, setFooterType(type))}>
+      <section className={`${prefix}--footer__main`}>
+        <div className={`${prefix}--footer__main-container`}>
           <FooterLogo />
           {optionalFooterNav(type, footerMenuData)}
           <LocaleButton />
@@ -76,7 +76,7 @@ function setFooterType(type) {
   let typeClassName;
 
   if (type === 'short') {
-    typeClassName = `${cPrefix}--footer--short`;
+    typeClassName = `${prefix}--footer--short`;
   }
 
   return typeClassName;

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -7,7 +7,8 @@
 
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import { TranslationAPI } from '@carbon/ibmdotcom-services';
 import classNames from 'classnames';
 import FooterLogo from './FooterLogo';
@@ -16,6 +17,7 @@ import LegalNav from './LegalNav';
 import LocaleButton from './LocaleButton';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer component
@@ -37,10 +39,10 @@ const Footer = ({ type }) => {
 
   return (
     <footer
-      data-autoid="footer"
-      className={classNames(`${prefix}--footer`, setFooterType(type))}>
-      <section className={`${prefix}--footer__main`}>
-        <div className={`${prefix}--footer__main-container`}>
+      data-autoid={`${prefix}--footer`}
+      className={classNames(`${cPrefix}--footer`, setFooterType(type))}>
+      <section className={`${cPrefix}--footer__main`}>
+        <div className={`${cPrefix}--footer__main-container`}>
           <FooterLogo />
           {optionalFooterNav(type, footerMenuData)}
           <LocaleButton />
@@ -74,7 +76,7 @@ function setFooterType(type) {
   let typeClassName;
 
   if (type === 'short') {
-    typeClassName = `${prefix}--footer--short`;
+    typeClassName = `${cPrefix}--footer--short`;
   }
 
   return typeClassName;

--- a/packages/react/src/components/Footer/FooterLogo.js
+++ b/packages/react/src/components/Footer/FooterLogo.js
@@ -6,11 +6,11 @@
  */
 
 import React from 'react';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer logo component
@@ -20,14 +20,14 @@ const cPrefix = carbonSettings.prefix;
 const Logo = () => {
   return (
     <div
-      data-autoid={`${prefix}--footer-logo`}
-      className={`${cPrefix}--footer-logo`}>
+      data-autoid={`${stablePrefix}--footer-logo`}
+      className={`${prefix}--footer-logo`}>
       <a
-        data-autoid={`${prefix}--footer-logo__link`}
-        className={`${cPrefix}--footer-logo__link`}
+        data-autoid={`${stablePrefix}--footer-logo__link`}
+        className={`${prefix}--footer-logo__link`}
         href="https://www.ibm.com/">
         <svg
-          className={`${cPrefix}--footer-logo__logo`}
+          className={`${prefix}--footer-logo__logo`}
           viewBox="0 0 157 65"
           role="img"
           aria-labelledby="footer-logo">

--- a/packages/react/src/components/Footer/FooterLogo.js
+++ b/packages/react/src/components/Footer/FooterLogo.js
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer logo component
@@ -17,13 +19,15 @@ const { prefix } = settings;
  */
 const Logo = () => {
   return (
-    <div data-autoid="footer-logo" className={`${prefix}--footer-logo`}>
+    <div
+      data-autoid={`${prefix}--footer-logo`}
+      className={`${cPrefix}--footer-logo`}>
       <a
-        data-autoid="footer-logo__link"
-        className={`${prefix}--footer-logo__link`}
+        data-autoid={`${prefix}--footer-logo__link`}
+        className={`${cPrefix}--footer-logo__link`}
         href="https://www.ibm.com/">
         <svg
-          className={`${prefix}--footer-logo__logo`}
+          className={`${cPrefix}--footer-logo__logo`}
           viewBox="0 0 157 65"
           role="img"
           aria-labelledby="footer-logo">

--- a/packages/react/src/components/Footer/FooterNav.js
+++ b/packages/react/src/components/Footer/FooterNav.js
@@ -7,11 +7,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import { Accordion } from 'carbon-components-react';
 import FooterNavGroup from './FooterNavGroup';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer nav component
@@ -25,8 +27,10 @@ const FooterNav = ({ groups }) => {
   }
 
   return (
-    <nav data-autoid="footer-nav" className={`${prefix}--footer-nav`}>
-      <div className={`${prefix}--footer-nav__container`}>
+    <nav
+      data-autoid={`${prefix}--footer-nav`}
+      className={`${cPrefix}--footer-nav`}>
+      <div className={`${cPrefix}--footer-nav__container`}>
         <Accordion>{renderGroups(groups)}</Accordion>
       </div>
     </nav>

--- a/packages/react/src/components/Footer/FooterNav.js
+++ b/packages/react/src/components/Footer/FooterNav.js
@@ -7,13 +7,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { Accordion } from 'carbon-components-react';
 import FooterNavGroup from './FooterNavGroup';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer nav component
@@ -28,9 +28,9 @@ const FooterNav = ({ groups }) => {
 
   return (
     <nav
-      data-autoid={`${prefix}--footer-nav`}
-      className={`${cPrefix}--footer-nav`}>
-      <div className={`${cPrefix}--footer-nav__container`}>
+      data-autoid={`${stablePrefix}--footer-nav`}
+      className={`${prefix}--footer-nav`}>
+      <div className={`${prefix}--footer-nav__container`}>
         <Accordion>{renderGroups(groups)}</Accordion>
       </div>
     </nav>

--- a/packages/react/src/components/Footer/FooterNavGroup.js
+++ b/packages/react/src/components/Footer/FooterNavGroup.js
@@ -7,10 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import { AccordionItem, Link } from 'carbon-components-react';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer nav group component
@@ -25,10 +27,10 @@ const FooterNavGroup = ({ title, links }) => {
 
   return (
     <AccordionItem
-      data-autoid="footer-nav-group"
+      data-autoid={`${prefix}--footer-nav-group`}
       title={title}
-      className={`${prefix}--footer-nav-group`}>
-      <h2 className={`${prefix}--footer-nav-group__title`}>{title}</h2>
+      className={`${cPrefix}--footer-nav-group`}>
+      <h2 className={`${cPrefix}--footer-nav-group__title`}>{title}</h2>
       <ul>{renderListItems(links)}</ul>
     </AccordionItem>
   );
@@ -47,10 +49,10 @@ function renderListItems(links) {
     }
 
     return (
-      <li className={`${prefix}--footer-nav-group__item`} key={index}>
+      <li className={`${cPrefix}--footer-nav-group__item`} key={index}>
         <Link
-          className={`${prefix}--footer-nav-group__link`}
-          data-autoid="footer-nav-group__link"
+          className={`${cPrefix}--footer-nav-group__link`}
+          data-autoid={`${prefix}--footer-nav-group__link`}
           href={url}>
           {title}
         </Link>

--- a/packages/react/src/components/Footer/FooterNavGroup.js
+++ b/packages/react/src/components/Footer/FooterNavGroup.js
@@ -7,12 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { AccordionItem, Link } from 'carbon-components-react';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Footer nav group component
@@ -27,10 +27,10 @@ const FooterNavGroup = ({ title, links }) => {
 
   return (
     <AccordionItem
-      data-autoid={`${prefix}--footer-nav-group`}
+      data-autoid={`${stablePrefix}--footer-nav-group`}
       title={title}
-      className={`${cPrefix}--footer-nav-group`}>
-      <h2 className={`${cPrefix}--footer-nav-group__title`}>{title}</h2>
+      className={`${prefix}--footer-nav-group`}>
+      <h2 className={`${prefix}--footer-nav-group__title`}>{title}</h2>
       <ul>{renderListItems(links)}</ul>
     </AccordionItem>
   );
@@ -49,10 +49,10 @@ function renderListItems(links) {
     }
 
     return (
-      <li className={`${cPrefix}--footer-nav-group__item`} key={index}>
+      <li className={`${prefix}--footer-nav-group__item`} key={index}>
         <Link
-          className={`${cPrefix}--footer-nav-group__link`}
-          data-autoid={`${prefix}--footer-nav-group__link`}
+          className={`${prefix}--footer-nav-group__link`}
+          data-autoid={`${stablePrefix}--footer-nav-group__link`}
           href={url}>
           {title}
         </Link>

--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -23,7 +23,7 @@ const renderTrusteItem = () => {
   return (
     <li
       className={`${cPrefix}--legal-nav__list-item`}
-      data-autoid={`${prefix}--dds-privacy-cp`}
+      data-autoid={`${prefix}--privacy-cp`}
     />
   );
 };

--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -7,12 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { Link } from 'carbon-components-react';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Placeholder <li/> element for injection of the TrustE cookie preferences link
@@ -22,8 +22,8 @@ const cPrefix = carbonSettings.prefix;
 const renderTrusteItem = () => {
   return (
     <li
-      className={`${cPrefix}--legal-nav__list-item`}
-      data-autoid={`${prefix}--privacy-cp`}
+      className={`${prefix}--legal-nav__list-item`}
+      data-autoid={`${stablePrefix}--privacy-cp`}
     />
   );
 };
@@ -41,10 +41,10 @@ const LegalNav = ({ links }) => {
 
   return (
     <aside
-      data-autoid={`${prefix}--footer-legal-nav`}
-      className={`${cPrefix}--legal-nav__container`}>
-      <nav className={`${cPrefix}--legal-nav`}>
-        <ul className={`${cPrefix}--legal-nav__list`}>
+      data-autoid={`${stablePrefix}--footer-legal-nav`}
+      className={`${prefix}--legal-nav__container`}>
+      <nav className={`${prefix}--legal-nav`}>
+        <ul className={`${prefix}--legal-nav__list`}>
           {renderListItems(links)}
           {renderTrusteItem()}
         </ul>
@@ -66,8 +66,10 @@ function renderListItems(links) {
     }
 
     return (
-      <li className={`${cPrefix}--legal-nav__list-item`} key={index}>
-        <Link data-autoid={`${prefix}--footer-legal-nav__link`} href={url}>
+      <li className={`${prefix}--legal-nav__list-item`} key={index}>
+        <Link
+          data-autoid={`${stablePrefix}--footer-legal-nav__link`}
+          href={url}>
           {title}
         </Link>
       </li>

--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -7,10 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import { Link } from 'carbon-components-react';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Placeholder <li/> element for injection of the TrustE cookie preferences link
@@ -20,8 +22,8 @@ const { prefix } = settings;
 const renderTrusteItem = () => {
   return (
     <li
-      className={`${prefix}--legal-nav__list-item`}
-      data-autoid="dds-privacy-cp"
+      className={`${cPrefix}--legal-nav__list-item`}
+      data-autoid={`${prefix}--dds-privacy-cp`}
     />
   );
 };
@@ -39,10 +41,10 @@ const LegalNav = ({ links }) => {
 
   return (
     <aside
-      data-autoid="footer-legal-nav"
-      className={`${prefix}--legal-nav__container`}>
-      <nav className={`${prefix}--legal-nav`}>
-        <ul className={`${prefix}--legal-nav__list`}>
+      data-autoid={`${prefix}--footer-legal-nav`}
+      className={`${cPrefix}--legal-nav__container`}>
+      <nav className={`${cPrefix}--legal-nav`}>
+        <ul className={`${cPrefix}--legal-nav__list`}>
           {renderListItems(links)}
           {renderTrusteItem()}
         </ul>
@@ -64,8 +66,8 @@ function renderListItems(links) {
     }
 
     return (
-      <li className={`${prefix}--legal-nav__list-item`} key={index}>
-        <Link data-autoid="footer-legal-nav__link" href={url}>
+      <li className={`${cPrefix}--legal-nav__list-item`} key={index}>
+        <Link data-autoid={`${prefix}--footer-legal-nav__link`} href={url}>
           {title}
         </Link>
       </li>

--- a/packages/react/src/components/Footer/LocaleButton.js
+++ b/packages/react/src/components/Footer/LocaleButton.js
@@ -8,12 +8,12 @@ import {
   ModalHeader,
   ModalBody,
 } from 'carbon-components-react';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { Globe20 } from '@carbon/icons-react';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * EXPERIMENTAL: Renders the locale button
@@ -26,10 +26,10 @@ const LocaleButton = () => {
 
   return featureFlag(
     FOOTER_LOCALE_BUTTON,
-    <div className={`${cPrefix}--locale-btn__container`}>
+    <div className={`${prefix}--locale-btn__container`}>
       <Button
-        data-autoid={`${prefix}--locale-btn`}
-        className={`${cPrefix}--locale-btn`}
+        data-autoid={`${stablePrefix}--locale-btn`}
+        className={`${prefix}--locale-btn`}
         kind="secondary"
         onClick={open}
         renderIcon={Globe20}>
@@ -39,13 +39,13 @@ const LocaleButton = () => {
       <ComposedModal
         open={isOpen}
         onClose={close}
-        data-autoid={`${prefix}--locale-modal`}>
+        data-autoid={`${stablePrefix}--locale-modal`}>
         <ModalHeader
           label="United States — English"
           title="Select your region"
         />
         <ModalBody>
-          <p className={`${cPrefix}--modal-content__text`}>
+          <p className={`${prefix}--modal-content__text`}>
             Placeholder text for now
           </p>
         </ModalBody>

--- a/packages/react/src/components/Footer/LocaleButton.js
+++ b/packages/react/src/components/Footer/LocaleButton.js
@@ -8,10 +8,12 @@ import {
   ModalHeader,
   ModalBody,
 } from 'carbon-components-react';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import { Globe20 } from '@carbon/icons-react';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * EXPERIMENTAL: Renders the locale button
@@ -24,23 +26,26 @@ const LocaleButton = () => {
 
   return featureFlag(
     FOOTER_LOCALE_BUTTON,
-    <div className={`${prefix}--locale-btn__container`}>
+    <div className={`${cPrefix}--locale-btn__container`}>
       <Button
-        data-autoid="locale-btn"
-        className={`${prefix}--locale-btn`}
+        data-autoid={`${prefix}--locale-btn`}
+        className={`${cPrefix}--locale-btn`}
         kind="secondary"
         onClick={open}
         renderIcon={Globe20}>
         United States — English
       </Button>
 
-      <ComposedModal open={isOpen} onClose={close} data-autoid="locale-modal">
+      <ComposedModal
+        open={isOpen}
+        onClose={close}
+        data-autoid={`${prefix}--locale-modal`}>
         <ModalHeader
           label="United States — English"
           title="Select your region"
         />
         <ModalBody>
-          <p className={`${prefix}--modal-content__text`}>
+          <p className={`${cPrefix}--modal-content__text`}>
             Placeholder text for now
           </p>
         </ModalBody>

--- a/packages/react/src/components/Footer/README.md
+++ b/packages/react/src/components/Footer/README.md
@@ -48,18 +48,18 @@ FOOTER_LOCALE_BUTTON=true
 
 ## Stable selectors
 
-| Name                     | Description |
-| ------------------------ | ----------- |
-| `footer`                 | Component   |
-| `footer-nav`             | Component   |
-| `footer-nav-group`       | Component   |
-| `footer-nav-group__link` | Interactive |
-| `footer-logo`            | Component   |
-| `footer-logo__link`      | Interactive |
-| `footer-locale-btn`      | Interactive |
-| `legal-nav`              | Component   |
-| `legal-nav__link`        | Interactive |
-| `locale-modal`           | Component   |
+| Name                          | Description |
+| ----------------------------- | ----------- |
+| `dds--footer`                 | Component   |
+| `dds--footer-nav`             | Component   |
+| `dds--footer-nav-group`       | Component   |
+| `dds--footer-nav-group__link` | Interactive |
+| `dds--footer-logo`            | Component   |
+| `dds--footer-logo__link`      | Interactive |
+| `dds--footer-locale-btn`      | Interactive |
+| `dds--legal-nav`              | Component   |
+| `dds--legal-nav__link`        | Interactive |
+| `dds--locale-modal`           | Component   |
 
 ## CORS Proxy
 

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -7,12 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import classnames from 'classnames';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * creates modifier classnames
@@ -36,9 +36,9 @@ function hrMod(mod) {
  */
 const HorizontalRule = ({ style, size, contrast, weight }) => (
   <hr
-    data-autoid={`${prefix}--hr`}
+    data-autoid={`${stablePrefix}--hr`}
     className={classnames(
-      `${cPrefix}--hr`,
+      `${prefix}--hr`,
       hrMod(style),
       hrMod(contrast),
       hrMod(size),

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * creates modifier classnames
@@ -34,9 +36,9 @@ function hrMod(mod) {
  */
 const HorizontalRule = ({ style, size, contrast, weight }) => (
   <hr
-    data-autoid="hr"
+    data-autoid={`${prefix}--hr`}
     className={classnames(
-      `${prefix}--hr`,
+      `${cPrefix}--hr`,
       hrMod(style),
       hrMod(contrast),
       hrMod(size),

--- a/packages/react/src/components/HorizontalRule/README.md
+++ b/packages/react/src/components/HorizontalRule/README.md
@@ -54,9 +54,9 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 ## Stable selectors
 
-| Name | Description |
-| ---- | ----------- |
-| `hr` | Component   |
+| Name      | Description |
+| --------- | ----------- |
+| `dds--hr` | Component   |
 
 ## 🙌 Contributing
 

--- a/packages/react/src/components/HorizontalRule/README.md
+++ b/packages/react/src/components/HorizontalRule/README.md
@@ -54,9 +54,10 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 ## Stable selectors
 
-| Name      | Description |
-| --------- | ----------- |
-| `dds--hr` | Component   |
+| Name              | Description |
+| ----------------- | ----------- |
+| `dds--hr`         | Component   |
+| `dds--hr--${mod}` | Component   |
 
 ## 🙌 Contributing
 

--- a/packages/react/src/components/Icon/IbmLogo.js
+++ b/packages/react/src/components/Icon/IbmLogo.js
@@ -6,11 +6,11 @@
  */
 
 import React from 'react';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * IBM 8-bar Logo
@@ -20,10 +20,10 @@ const cPrefix = carbonSettings.prefix;
  */
 const IbmLogo = () => (
   <div
-    data-autoid={`${prefix}--masthead-logo`}
-    className={`${cPrefix}--header__logo`}>
+    data-autoid={`${stablePrefix}--masthead-logo`}
+    className={`${prefix}--header__logo`}>
     <a
-      data-autoid={`${prefix}--masthead-logo__link`}
+      data-autoid={`${stablePrefix}--masthead-logo__link`}
       href="https://www.ibm.com/">
       <svg width={54} height={23}>
         <path

--- a/packages/react/src/components/Icon/IbmLogo.js
+++ b/packages/react/src/components/Icon/IbmLogo.js
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * IBM 8-bar Logo
@@ -17,8 +19,12 @@ const { prefix } = settings;
  * @returns {*} IBM Logo 8-bar component
  */
 const IbmLogo = () => (
-  <div data-autoid="masthead-logo" className={`${prefix}--header__logo`}>
-    <a data-autoid="masthead-logo__link" href="https://www.ibm.com/">
+  <div
+    data-autoid={`${prefix}--masthead-logo`}
+    className={`${cPrefix}--header__logo`}>
+    <a
+      data-autoid={`${prefix}--masthead-logo__link`}
+      href="https://www.ibm.com/">
       <svg width={54} height={23}>
         <path
           d="M0 22.082v-1.386h10.471v1.386H0zm0-2.909v-1.385h10.471v1.385H0zm2.992-2.908v-1.386h4.487v1.386H2.992zm0-2.91v-1.384h4.487v1.385H2.992zm0-2.908V9.062h4.487v1.385H2.992zm0-2.908V6.153h4.487V7.54H2.992zM0 4.629V3.245h10.471V4.63H0zm0-2.908V.336h10.471v1.385H0zm11.967 16.067h16.527c-.13.49-.322.955-.566 1.385h-15.96v-1.385zm2.992-1.523v-1.386h4.488v1.386h-4.488zM26.78 11.97c.432.402.803.868 1.098 1.386h-12.92V11.97H26.78zM14.96 9.062h12.968a5.836 5.836 0 01-1.097 1.385H14.959V9.062zM28.494 4.63H11.967V3.244h15.96c.245.43.437.895.567 1.386zM26.68 1.72H11.967V.336h11.015c1.41 0 2.701.522 3.698 1.385zM14.959 7.538V6.153h4.488v1.385h-4.488zm8.703 0V6.154h5.032c0 .478-.06.941-.167 1.386h-4.865zm0 7.341h4.865c.107.445.167.908.167 1.386h-5.032v-1.386zM38.35.33l.472 1.385h-8.904V.328h8.432zm-8.431 21.753v-1.386h7.481v1.386h-7.481zm0-2.91v-1.386h7.481v1.386h-7.481zm2.992-2.91v-1.385h4.49v1.385h-4.49zm0-2.91v-1.385h4.49v1.386h-4.49zm13.468 8.73v-1.386h7.482v1.386h-7.482zm0-2.91v-1.386h7.482v1.386h-7.482zm0-2.91v-1.385h4.49v1.385h-4.49zm0-2.91v-1.385h4.49v1.386h-4.49zm0-2.909v-1.32l-.458 1.32h-3.94l.473-1.386h8.415v1.386h-4.49zm-5.053-1.385l.472 1.385h-3.94l-.458-1.32v1.32H32.91V9.058h8.415zm9.542-2.91v1.385h-7.895l.471-1.385h7.424zM45.426.328h8.434v1.386h-8.906L45.426.33zm-3.54 21.754l-.475-1.386h.956l-.481 1.386zm-1.003-2.91l-.48-1.386h2.972l-.48 1.386h-2.012zm-1.009-2.91l-.48-1.385h4.99l-.48 1.385h-4.03zm-1.008-2.91l-.48-1.385h7.006l-.48 1.386h-6.046zM32.91 7.534V6.148h7.424l.472 1.385H32.91zm11.053-2.91l.472-1.385h9.425v1.386h-9.897zm-4.62-1.385l.472 1.386h-9.898V3.238h9.426zM11.967 20.696H26.68a5.627 5.627 0 01-3.698 1.386H11.967v-1.386z"

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -7,8 +7,8 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import root from 'window-or-global';
 import { User20, UserOnline20 } from '@carbon/icons-react';
 import { IbmLogo } from '../Icon';
@@ -27,8 +27,8 @@ import MastheadLeftNav from './MastheadLeftNav';
 import MastheadTopNav from './MastheadTopNav';
 import cx from 'classnames';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * MastHead component
@@ -84,8 +84,8 @@ const Masthead = ({ navigation, ...mastheadProps }) => {
   const mastheadL1Ref = useRef(null);
 
   const mastheadSticky = cx({
-    [`${cPrefix}--masthead--sticky`]: isMastheadSticky,
-    [`${cPrefix}--masthead--sticky__l1`]: mastheadL1Ref.current != null,
+    [`${prefix}--masthead--sticky`]: isMastheadSticky,
+    [`${prefix}--masthead--sticky__l1`]: mastheadL1Ref.current != null,
   });
 
   useEffect(() => {
@@ -128,21 +128,21 @@ const Masthead = ({ navigation, ...mastheadProps }) => {
     <HeaderContainer
       render={({ isSideNavExpanded, onClickSideNavExpand }) => (
         <div
-          className={`${cPrefix}--masthead ${mastheadSticky}`}
+          className={`${prefix}--masthead ${mastheadSticky}`}
           ref={stickyRef}>
-          <div className={`${cPrefix}--masthead__l0`}>
-            <Header aria-label="IBM" data-autoid={`${prefix}--masthead`}>
+          <div className={`${prefix}--masthead__l0`}>
+            <Header aria-label="IBM" data-autoid={`${stablePrefix}--masthead`}>
               <SkipToContent />
               <HeaderMenuButton
                 aria-label="Open menu"
-                data-autoid={`${prefix}--masthead__hamburger`}
+                data-autoid={`${stablePrefix}--masthead__hamburger`}
                 onClick={onClickSideNavExpand}
                 isActive={isSideNavExpanded}
               />
 
               <IbmLogo />
 
-              <div className={`${cPrefix}--header__search`}>
+              <div className={`${prefix}--header__search`}>
                 {navigation !== false ? (
                   <MastheadTopNav
                     {...mastheadProps}

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -7,7 +7,8 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import root from 'window-or-global';
 import { User20, UserOnline20 } from '@carbon/icons-react';
 import { IbmLogo } from '../Icon';
@@ -27,6 +28,7 @@ import MastheadTopNav from './MastheadTopNav';
 import cx from 'classnames';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * MastHead component
@@ -82,8 +84,8 @@ const Masthead = ({ navigation, ...mastheadProps }) => {
   const mastheadL1Ref = useRef(null);
 
   const mastheadSticky = cx({
-    [`${prefix}--masthead--sticky`]: isMastheadSticky,
-    [`${prefix}--masthead--sticky__l1`]: mastheadL1Ref.current != null,
+    [`${cPrefix}--masthead--sticky`]: isMastheadSticky,
+    [`${cPrefix}--masthead--sticky__l1`]: mastheadL1Ref.current != null,
   });
 
   useEffect(() => {
@@ -126,21 +128,21 @@ const Masthead = ({ navigation, ...mastheadProps }) => {
     <HeaderContainer
       render={({ isSideNavExpanded, onClickSideNavExpand }) => (
         <div
-          className={`${prefix}--masthead ${mastheadSticky}`}
+          className={`${cPrefix}--masthead ${mastheadSticky}`}
           ref={stickyRef}>
-          <div className={`${prefix}--masthead__l0`}>
-            <Header aria-label="IBM" data-autoid="masthead">
+          <div className={`${cPrefix}--masthead__l0`}>
+            <Header aria-label="IBM" data-autoid={`${prefix}--masthead`}>
               <SkipToContent />
               <HeaderMenuButton
                 aria-label="Open menu"
-                data-autoid="masthead__hamburger"
+                data-autoid={`${prefix}--masthead__hamburger`}
                 onClick={onClickSideNavExpand}
                 isActive={isSideNavExpanded}
               />
 
               <IbmLogo />
 
-              <div className={`${prefix}--header__search`}>
+              <div className={`${cPrefix}--header__search`}>
                 {navigation !== false ? (
                   <MastheadTopNav
                     {...mastheadProps}

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings } from 'carbon-components';
 import {
   HeaderNavigation,
   HeaderMenu,
@@ -15,7 +15,7 @@ import {
 import { ArrowLeft16 } from '@carbon/icons-react';
 import cx from 'classnames';
 
-const cPrefix = carbonSettings.prefix;
+const { prefix } = settings;
 
 /**
  * MastHead L1 component
@@ -25,23 +25,21 @@ const cPrefix = carbonSettings.prefix;
  */
 const MastheadL1 = () => {
   const className = cx({
-    [`${cPrefix}--masthead__l1`]: true,
+    [`${prefix}--masthead__l1`]: true,
   });
 
   return (
     <div className={className}>
-      <div className={`${cPrefix}--masthead__l1-name`}>
-        <span className={`${cPrefix}--masthead__l1-name-eyebrow`}>
+      <div className={`${prefix}--masthead__l1-name`}>
+        <span className={`${prefix}--masthead__l1-name-eyebrow`}>
           <ArrowLeft16 />
           <a href="#">Eyebrow</a>
         </span>
-        <span className={`${cPrefix}--masthead__l1-name-title`}>
+        <span className={`${prefix}--masthead__l1-name-title`}>
           Stock Charts
         </span>
       </div>
-      <HeaderNavigation
-        className={`${cPrefix}--masthead__l1-nav`}
-        aria-label="">
+      <HeaderNavigation className={`${prefix}--masthead__l1-nav`} aria-label="">
         <HeaderMenuItem href="#">Link 1</HeaderMenuItem>
         <HeaderMenuItem href="#">Link 2</HeaderMenuItem>
         <HeaderMenuItem href="#">Link 3</HeaderMenuItem>

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
+import { settings as carbonSettings } from 'carbon-components';
 import {
   HeaderNavigation,
   HeaderMenu,
@@ -15,7 +15,7 @@ import {
 import { ArrowLeft16 } from '@carbon/icons-react';
 import cx from 'classnames';
 
-const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * MastHead L1 component
@@ -25,21 +25,23 @@ const { prefix } = settings;
  */
 const MastheadL1 = () => {
   const className = cx({
-    [`${prefix}--masthead__l1`]: true,
+    [`${cPrefix}--masthead__l1`]: true,
   });
 
   return (
     <div className={className}>
-      <div className={`${prefix}--masthead__l1-name`}>
-        <span className={`${prefix}--masthead__l1-name-eyebrow`}>
+      <div className={`${cPrefix}--masthead__l1-name`}>
+        <span className={`${cPrefix}--masthead__l1-name-eyebrow`}>
           <ArrowLeft16 />
           <a href="#">Eyebrow</a>
         </span>
-        <span className={`${prefix}--masthead__l1-name-title`}>
+        <span className={`${cPrefix}--masthead__l1-name-title`}>
           Stock Charts
         </span>
       </div>
-      <HeaderNavigation className={`${prefix}--masthead__l1-nav`} aria-label="">
+      <HeaderNavigation
+        className={`${cPrefix}--masthead__l1-nav`}
+        aria-label="">
         <HeaderMenuItem href="#">Link 1</HeaderMenuItem>
         <HeaderMenuItem href="#">Link 2</HeaderMenuItem>
         <HeaderMenuItem href="#">Link 3</HeaderMenuItem>

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import {
   HeaderSideNavItems,
   SideNav,
@@ -17,7 +17,7 @@ import {
   SideNavMenuItem,
 } from 'carbon-components-react';
 
-const { prefix } = settings;
+const { stablePrefix } = ddsSettings;
 
 /**
  * Masthead left nav component
@@ -42,7 +42,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
             return (
               <SideNavMenuItem
                 href={item.url}
-                data-autoid={`${prefix}--masthead__l0-sidenav--subnav-${j}`}>
+                data-autoid={`${stablePrefix}--masthead__l0-sidenav--subnav-${j}`}>
                 {item.title}
               </SideNavMenuItem>
             );
@@ -53,7 +53,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
       return (
         <SideNavLink
           href={link.url}
-          data-autoid={`${prefix}--masthead__l0-sidenav--nav-${i}`}>
+          data-autoid={`${stablePrefix}--masthead__l0-sidenav--nav-${i}`}>
           {link.title}
         </SideNavLink>
       );
@@ -65,7 +65,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
       aria-label="Side navigation"
       expanded={isSideNavExpanded}
       isPersistent={false}>
-      <div data-autoid={`${prefix}--masthead__l0-sidenav`}>
+      <div data-autoid={`${stablePrefix}--masthead__l0-sidenav`}>
         <SideNavItems>
           <HeaderSideNavItems>{sideNav}</HeaderSideNavItems>
         </SideNavItems>

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { settings } from '@carbon/ibmdotcom-utilities';
 import {
   HeaderSideNavItems,
   SideNav,
@@ -15,6 +16,8 @@ import {
   SideNavMenu,
   SideNavMenuItem,
 } from 'carbon-components-react';
+
+const { prefix } = settings;
 
 /**
  * Masthead left nav component
@@ -39,7 +42,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
             return (
               <SideNavMenuItem
                 href={item.url}
-                data-autoid={`masthead__l0-sidenav--subnav-${j}`}>
+                data-autoid={`${prefix}--masthead__l0-sidenav--subnav-${j}`}>
                 {item.title}
               </SideNavMenuItem>
             );
@@ -50,7 +53,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
       return (
         <SideNavLink
           href={link.url}
-          data-autoid={`masthead__l0-sidenav--nav-${i}`}>
+          data-autoid={`${prefix}--masthead__l0-sidenav--nav-${i}`}>
           {link.title}
         </SideNavLink>
       );
@@ -62,7 +65,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
       aria-label="Side navigation"
       expanded={isSideNavExpanded}
       isPersistent={false}>
-      <div data-autoid="masthead__l0-sidenav">
+      <div data-autoid={`${prefix}--masthead__l0-sidenav`}>
         <SideNavItems>
           <HeaderSideNavItems>{sideNav}</HeaderSideNavItems>
         </SideNavItems>

--- a/packages/react/src/components/Masthead/MastheadProfile.js
+++ b/packages/react/src/components/Masthead/MastheadProfile.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
 import {
   HeaderGlobalAction,
   OverflowMenu,

--- a/packages/react/src/components/Masthead/MastheadProfile.js
+++ b/packages/react/src/components/Masthead/MastheadProfile.js
@@ -7,14 +7,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import {
   HeaderGlobalAction,
   OverflowMenu,
   OverflowMenuItem,
 } from 'carbon-components-react';
 
-const { prefix } = settings;
+const { stablePrefix } = ddsSettings;
 
 /**
  * MastHead Profile component
@@ -46,7 +46,7 @@ const MastheadProfile = ({
   return (
     <HeaderGlobalAction
       aria-label="User Profile"
-      data-autoid={`${prefix}--masthead__profile`}
+      data-autoid={`${stablePrefix}--masthead__profile`}
       onClick={() => {}}>
       <OverflowMenu {...overflowMenuProps}>{profileNav}</OverflowMenu>
     </HeaderGlobalAction>

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -7,8 +7,8 @@
 
 import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import Autosuggest from 'react-autosuggest';
 import root from 'window-or-global';
 import { SearchTypeaheadAPI } from '@carbon/ibmdotcom-services';
@@ -17,8 +17,8 @@ import MastheadSearchInput from './MastheadSearchInput';
 import MastheadSearchSuggestion from './MastheadSearchSuggestion';
 import cx from 'classnames';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Sets up the redirect URL when a user selects a search suggestion
@@ -108,8 +108,8 @@ const MastheadSearch = ({ placeHolderText, renderValue }) => {
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
   const className = cx({
-    [`${cPrefix}--masthead__search`]: true,
-    [`${cPrefix}--masthead__search--active`]: state.isSearchOpen,
+    [`${prefix}--masthead__search`]: true,
+    [`${prefix}--masthead__search--active`]: state.isSearchOpen,
   });
 
   /**
@@ -131,7 +131,7 @@ const MastheadSearch = ({ placeHolderText, renderValue }) => {
     placeholder: placeHolderText,
     value: state.val,
     onChange,
-    className: `${cPrefix}--header__search--input`,
+    className: `${prefix}--header__search--input`,
     onBlur: () => {
       dispatch({ type: 'setSearchClosed' });
     },
@@ -240,7 +240,9 @@ const MastheadSearch = ({ placeHolderText, renderValue }) => {
   }
 
   return (
-    <div data-autoid={`${prefix}--masthead__search`} className={className}>
+    <div
+      data-autoid={`${stablePrefix}--masthead__search`}
+      className={className}>
       <Autosuggest
         suggestions={state.suggestions} // The state value of suggestion
         onSuggestionsFetchRequested={onSuggestionsFetchRequest} // Method to fetch data (should be async call)

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -7,16 +7,18 @@
 
 import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import Autosuggest from 'react-autosuggest';
 import root from 'window-or-global';
 import { SearchTypeaheadAPI } from '@carbon/ibmdotcom-services';
 import { escapeRegExp } from '@carbon/ibmdotcom-utilities';
 import MastheadSearchInput from './MastheadSearchInput';
 import MastheadSearchSuggestion from './MastheadSearchSuggestion';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Sets up the redirect URL when a user selects a search suggestion
@@ -106,8 +108,8 @@ const MastheadSearch = ({ placeHolderText, renderValue }) => {
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
   const className = cx({
-    [`${prefix}--masthead__search`]: true,
-    [`${prefix}--masthead__search--active`]: state.isSearchOpen,
+    [`${cPrefix}--masthead__search`]: true,
+    [`${cPrefix}--masthead__search--active`]: state.isSearchOpen,
   });
 
   /**
@@ -129,7 +131,7 @@ const MastheadSearch = ({ placeHolderText, renderValue }) => {
     placeholder: placeHolderText,
     value: state.val,
     onChange,
-    className: `${prefix}--header__search--input`,
+    className: `${cPrefix}--header__search--input`,
     onBlur: () => {
       dispatch({ type: 'setSearchClosed' });
     },

--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -1,13 +1,13 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
-import { settings as carbonSettings } from 'carbon-components';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import { HeaderGlobalAction } from 'carbon-components-react';
 import { Search20 } from '@carbon/icons-react';
 import { Close20 } from '@carbon/icons-react';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
-const cPrefix = carbonSettings.prefix;
 
 /**
  * Renders the input bar with the search icon
@@ -30,21 +30,21 @@ const MastheadSearchInput = ({ componentInputProps, dispatch, isActive }) => {
     <>
       <input
         {...componentInputProps}
-        data-autoid={`${prefix}--header__search--input`}
+        data-autoid={`${stablePrefix}--header__search--input`}
         ref={searchRef}
       />
       <HeaderGlobalAction
         onClick={() => dispatch({ type: 'setSearchOpen' })}
         aria-label="Search"
-        className={`${cPrefix}--header__search--search`}
-        data-autoid={`${prefix}--header__search--search`}>
+        className={`${prefix}--header__search--search`}
+        data-autoid={`${stablePrefix}--header__search--search`}>
         <Search20 />
       </HeaderGlobalAction>
       <HeaderGlobalAction
         onClick={() => dispatch({ type: 'setSearchClosed' })}
         aria-label="Close"
-        className={`${cPrefix}--header__search--close`}
-        data-autoid={`${prefix}--header__search--close`}>
+        className={`${prefix}--header__search--close`}
+        data-autoid={`${stablePrefix}--header__search--close`}>
         <Close20 />
       </HeaderGlobalAction>
     </>

--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -1,11 +1,13 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
+import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as carbonSettings } from 'carbon-components';
 import { HeaderGlobalAction } from 'carbon-components-react';
 import { Search20 } from '@carbon/icons-react';
 import { Close20 } from '@carbon/icons-react';
 
 const { prefix } = settings;
+const cPrefix = carbonSettings.prefix;
 
 /**
  * Renders the input bar with the search icon
@@ -34,14 +36,14 @@ const MastheadSearchInput = ({ componentInputProps, dispatch, isActive }) => {
       <HeaderGlobalAction
         onClick={() => dispatch({ type: 'setSearchOpen' })}
         aria-label="Search"
-        className={`${prefix}--header__search--search`}
+        className={`${cPrefix}--header__search--search`}
         data-autoid={`${prefix}--header__search--search`}>
         <Search20 />
       </HeaderGlobalAction>
       <HeaderGlobalAction
         onClick={() => dispatch({ type: 'setSearchClosed' })}
         aria-label="Close"
-        className={`${prefix}--header__search--close`}
+        className={`${cPrefix}--header__search--close`}
         data-autoid={`${prefix}--header__search--close`}>
         <Close20 />
       </HeaderGlobalAction>

--- a/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
+++ b/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
 import classNames from 'classnames';
 import parse from 'autosuggest-highlight/parse';
 
+const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 
 /**
@@ -47,10 +49,10 @@ const MastheadSearchSuggestion = ({
 
   return (
     <div
-      className={classNames('container-class', {
-        ['container-highlight-class']: isHighlighted,
+      className={classNames(`${prefix}--container-class`, {
+        [`${prefix}--container-highlight-class`]: isHighlighted,
       })}
-      data-autoid={`${prefix}--masthead__searchresults--suggestion`}>
+      data-autoid={`${stablePrefix}--masthead__searchresults--suggestion`}>
       {parts.map((part, index) => (
         <span
           key={index}

--- a/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
+++ b/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { settings } from '@carbon/ibmdotcom-utilities';
 import classNames from 'classnames';
 import parse from 'autosuggest-highlight/parse';
+
+const { prefix } = settings;
 
 /**
  * Matches a suggestion name with the query
@@ -47,7 +50,7 @@ const MastheadSearchSuggestion = ({
       className={classNames('container-class', {
         ['container-highlight-class']: isHighlighted,
       })}
-      data-autoid={`masthead__searchresults--suggestion`}>
+      data-autoid={`${prefix}--masthead__searchresults--suggestion`}>
       {parts.map((part, index) => (
         <span
           key={index}

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -7,12 +7,15 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { settings } from '@carbon/ibmdotcom-utilities';
 import {
   HeaderNavigation,
   HeaderMenu,
   HeaderMenuItem,
   HeaderName,
 } from 'carbon-components-react';
+
+const { prefix } = settings;
 
 /**
  * Masthead top nav component
@@ -33,14 +36,14 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
         <HeaderMenu
           aria-label={link.title}
           menuLinkName={link.title}
-          data-autoid={`masthead__l0-nav--nav-${i}`}>
+          data-autoid={`${prefix}--masthead__l0-nav--nav-${i}`}>
           {link.menuSections[0].menuItems[
             i
           ].megapanelContent.quickLinks.links.map((item, j) => {
             return (
               <HeaderMenuItem
                 href={item.url}
-                data-autoid={`masthead__l0-nav--subnav-${j}`}>
+                data-autoid={`${prefix}--masthead__l0-nav--subnav-${j}`}>
                 {item.title}
               </HeaderMenuItem>
             );
@@ -51,7 +54,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
       return (
         <HeaderMenuItem
           href={link.url}
-          data-autoid={`masthead__l0-nav--nav-${i}`}>
+          data-autoid={`${prefix}--masthead__l0-nav--nav-${i}`}>
           {link.title}
         </HeaderMenuItem>
       );
@@ -64,11 +67,13 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
         <HeaderName
           prefix=""
           href={topNavProps.platform.url}
-          data-autoid="masthead__platform-name">
+          data-autoid={`${prefix}--masthead__platform-name`}>
           {topNavProps.platform.name}
         </HeaderName>
       )}
-      <HeaderNavigation aria-label="IBM" data-autoid="masthead__l0-nav">
+      <HeaderNavigation
+        aria-label="IBM"
+        data-autoid={`${prefix}--masthead__l0-nav`}>
         {mastheadLinks}
       </HeaderNavigation>
     </>

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { settings } from '@carbon/ibmdotcom-utilities';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import {
   HeaderNavigation,
   HeaderMenu,
@@ -15,7 +15,7 @@ import {
   HeaderName,
 } from 'carbon-components-react';
 
-const { prefix } = settings;
+const { stablePrefix } = ddsSettings;
 
 /**
  * Masthead top nav component
@@ -36,14 +36,14 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
         <HeaderMenu
           aria-label={link.title}
           menuLinkName={link.title}
-          data-autoid={`${prefix}--masthead__l0-nav--nav-${i}`}>
+          data-autoid={`${stablePrefix}--masthead__l0-nav--nav-${i}`}>
           {link.menuSections[0].menuItems[
             i
           ].megapanelContent.quickLinks.links.map((item, j) => {
             return (
               <HeaderMenuItem
                 href={item.url}
-                data-autoid={`${prefix}--masthead__l0-nav--subnav-${j}`}>
+                data-autoid={`${stablePrefix}--masthead__l0-nav--subnav-${j}`}>
                 {item.title}
               </HeaderMenuItem>
             );
@@ -54,7 +54,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
       return (
         <HeaderMenuItem
           href={link.url}
-          data-autoid={`${prefix}--masthead__l0-nav--nav-${i}`}>
+          data-autoid={`${stablePrefix}--masthead__l0-nav--nav-${i}`}>
           {link.title}
         </HeaderMenuItem>
       );
@@ -67,13 +67,13 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
         <HeaderName
           prefix=""
           href={topNavProps.platform.url}
-          data-autoid={`${prefix}--masthead__platform-name`}>
+          data-autoid={`${stablePrefix}--masthead__platform-name`}>
           {topNavProps.platform.name}
         </HeaderName>
       )}
       <HeaderNavigation
         aria-label="IBM"
-        data-autoid={`${prefix}--masthead__l0-nav`}>
+        data-autoid={`${stablePrefix}--masthead__l0-nav`}>
         {mastheadLinks}
       </HeaderNavigation>
     </>

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -54,18 +54,18 @@ const topNavProps = {
 
 ## Stable selectors
 
-| Name                                   | Description |
-| -------------------------------------- | ----------- |
-| `masthead`                             | Component   |
-| `masthead__hamburger`                  | Interactive |
-| `masthead__logo`                       | Interactive |
-| `masthead__platform-name`              | Interactive |
-| `masthead__l0-nav`                     | Component   |
-| `masthead__l0-nav--nav-${item}`        | Interactive |
-| `masthead__l0-nav--subnav-${item}`     | Interactive |
-| `masthead__l0-sidenav`                 | Component   |
-| `masthead__l0-sidenav--nav-${item}`    | Interactive |
-| `masthead__l0-sidenav--subnav-${item}` | Interactive |
+| Name                                        | Description |
+| ------------------------------------------- | ----------- |
+| `dds--masthead`                             | Component   |
+| `dds--masthead__hamburger`                  | Interactive |
+| `dds--masthead__logo`                       | Interactive |
+| `dds--masthead__platform-name`              | Interactive |
+| `dds--masthead__l0-nav`                     | Component   |
+| `dds--masthead__l0-nav--nav-${item}`        | Interactive |
+| `dds--masthead__l0-nav--subnav-${item}`     | Interactive |
+| `dds--masthead__l0-sidenav`                 | Component   |
+| `dds--masthead__l0-sidenav--nav-${item}`    | Interactive |
+| `dds--masthead__l0-sidenav--subnav-${item}` | Interactive |
 
 ## CORS Proxy
 

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -109,7 +109,7 @@
       display: flex;
       padding: 0 $spacing-05;
 
-      .container-class {
+      .#{$prefix}--container-class {
         display: flex;
         border-bottom: 1px solid $ui-01;
         flex: 1;

--- a/packages/utilities/src/utilities/settings/index.js
+++ b/packages/utilities/src/utilities/settings/index.js
@@ -5,7 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './escaperegexp';
-export * from './featureflag';
-export * from './serialize';
-export * from './settings';
+export { default as settings } from './settings';

--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -1,0 +1,14 @@
+/**
+ * Global settings
+ *
+ * @exports ibmdotcom.settings
+ * @type Object
+ * @property {string} [prefix=dds]
+ * IBM.com Library prefix
+ *
+ */
+const settings = {
+  prefix: 'dds',
+};
+
+export default settings;

--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -8,7 +8,7 @@
  *
  */
 const settings = {
-  prefix: 'dds',
+  stablePrefix: 'dds',
 };
 
 export default settings;


### PR DESCRIPTION
### Related Ticket(s)

https://github.ibm.com/webstandards/digital-design/issues/1700

### Description

This adds global settings to the `@carbon/ibmdotcom-utilities` package.

### Changelog

**New**

- Global settings (includes `dds` prefix).

**Changed**

- Component `autoid` updated to use new `dds` prefix
- Component README updated with new `autoid` values