### PR TITLE
feat(analytics): scroll tracking

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,7 +2,6 @@
   "**/*.js": [
     "prettier --write",
     "eslint packages",
-    "cross-env BABEL_ENV=test jest",
     "git add"
   ],
   "packages/components/**/*.scss": [

--- a/packages/react/.env.example
+++ b/packages/react/.env.example
@@ -1,5 +1,18 @@
 REACT_STORYBOOK_SOURCEMAPS=<Boolean to turn on/off sourcemaps in storybook>
+
+# Search Typeahead
+SEARCH_TYPEAHEAD_VERSION=v1
+SEARCH_TYPEAHEAD_HOST=<host for ibm.com search, e.g. https://www-api.ibm.com>
+
+# Marketing Search
+MARKETING_SEARCH_VERSION=v3
+MARKETING_SEARCH_HOST=<host for ibm.com marketing search, e.g. https://www.ibm.com>
+
+# Translation
 CORS_PROXY=<CORS proxy server for fetching from www.ibm.com, e.g. https://yourproxy.com/>
+
+# Analytics - scroll
+SCROLL_TRACKING=<boolean to enable scroll tracking, e.g. false>
 
 #Feature Flags
 FOOTER_LOCALE_BUTTON=<Boolean flag to turn on/off the locale selector>

--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -1,20 +1,29 @@
-<meta name="keywords" content="IBM, design, system, Carbon, design system, Bluemix, styleguide, style, guide, components, library, pattern, kit, component, cloud, React, React.js">
-<meta name="description" content="A collection of IBM.com components implemented using React and Carbon Design System.">
+<meta
+  name="keywords"
+  content="IBM, design, system, Carbon, design system, Bluemix, styleguide, style, guide, components, library, pattern, kit, component, cloud, React, React.js"
+/>
+<meta
+  name="description"
+  content="A collection of IBM.com components implemented using React and Carbon Design System."
+/>
 
 <!-- Open Graph -->
-<meta property="og:title" content="IBM.com Library React">
-<meta property="og:site_name" content="IBM.com Library React">
-<meta property="og:description" content="A collection of IBM.com components implemented using React and Carbon Design System.">
-<meta property="og:image" content="https://media.github.ibm.com/user/525/files/59e3bfde-b990-11e7-87ef-072e89a87719">
-<meta property="og:url" content="https://ibmdotcom-react.netlify.com">
+<meta property="og:title" content="IBM.com Library React" />
+<meta property="og:site_name" content="IBM.com Library React" />
+<meta
+  property="og:description"
+  content="A collection of IBM.com components implemented using React and Carbon Design System."
+/>
+<meta
+  property="og:image"
+  content="https://media.github.ibm.com/user/525/files/59e3bfde-b990-11e7-87ef-072e89a87719"
+/>
+<meta property="og:url" content="https://ibmdotcom-react.netlify.com" />
 
 <!-- Social -->
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image:alt" content="IBM.com Library">
-<meta name="twitter:site" content="@_IBM">
-
-<!-- IBM Tag Management and Site Analytics -->
-<script src="//1.www.s81c.com/common/stats/ibm-common.js"></script>
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image:alt" content="IBM.com Library" />
+<meta name="twitter:site" content="@_IBM" />
 
 <!-- Storybook override -->
 <script>

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<!-- IBM Tag Management and Site Analytics -->
+<script src="//1.www.s81c.com/common/stats/ibm-common.js"></script>

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 import { Masthead, Footer } from '@carbon/ibmdotcom-react';
-import globalMethods from '../../global';
+import '../../global';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -28,10 +28,6 @@ const DotcomShell = ({
   children,
   ...mastheadProps
 }) => {
-  useEffect(() => {
-    globalMethods();
-  }, []);
-
   return (
     <>
       <Masthead navigation={navigation} {...mastheadProps} />

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -27,7 +27,7 @@ const DotcomShell = ({
   ...mastheadProps
 }) => {
   useEffect(() => {
-    AnalyticsAPI.initScrollAnalytics();
+    AnalyticsAPI.initScrollTracker();
   }, []);
 
   return (

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 import { Masthead, Footer } from '@carbon/ibmdotcom-react';
-import global from '../../global';
+import globalMethods from '../../global';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -29,7 +29,7 @@ const DotcomShell = ({
   ...mastheadProps
 }) => {
   useEffect(() => {
-    global();
+    globalMethods();
   }, []);
 
   return (

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
 import { Masthead, Footer } from '@carbon/ibmdotcom-react';
+import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
 
 const { prefix } = settings;
 
@@ -25,6 +26,10 @@ const DotcomShell = ({
   children,
   ...mastheadProps
 }) => {
+  useEffect(() => {
+    AnalyticsAPI.initScrollAnalytics();
+  }, []);
+
   return (
     <>
       <Masthead navigation={navigation} {...mastheadProps} />

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 import { Masthead, Footer } from '@carbon/ibmdotcom-react';
-import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
+import global from '../../global';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -29,7 +29,7 @@ const DotcomShell = ({
   ...mastheadProps
 }) => {
   useEffect(() => {
-    AnalyticsAPI.initScrollTracker();
+    global();
   }, []);
 
   return (

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -18,11 +18,7 @@ import {
   HeaderGlobalBar,
   SkipToContent,
 } from 'carbon-components-react';
-import {
-  ProfileAPI,
-  TranslationAPI,
-  RegisterAnalyticsEvent,
-} from '@carbon/ibmdotcom-services';
+import { ProfileAPI, TranslationAPI } from '@carbon/ibmdotcom-services';
 import MastheadL1 from './MastheadL1';
 import MastheadSearch from './MastheadSearch';
 import MastheadProfile from './MastheadProfile';
@@ -108,26 +104,8 @@ const Masthead = ({ navigation, ...mastheadProps }) => {
       }
     });
 
-    let maxScrollDepth = 0;
-
-    const scrollAnalytics = root.addEventListener('scroll', () => {
-      let scrollDepth = root.pageYOffset;
-
-      // Only fire the event at 400px intervals and at the deepest scroll depth
-      if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
-        maxScrollDepth = scrollDepth;
-        RegisterAnalyticsEvent({
-          type: 'element',
-          primaryCategory: 'SCROLL DISTANCE',
-          eventName: scrollDepth,
-          executionPath: root.innerWidth,
-          execPathReturnCode: root.innerHeight,
-        });
-      }
-    });
     return () => {
       root.removeEventListener('scroll', () => handleScroll);
-      root.removeEventListener('scroll', () => scrollAnalytics);
     };
   }, []);
 

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -18,7 +18,11 @@ import {
   HeaderGlobalBar,
   SkipToContent,
 } from 'carbon-components-react';
-import { ProfileAPI, TranslationAPI } from '@carbon/ibmdotcom-services';
+import {
+  ProfileAPI,
+  TranslationAPI,
+  RegisterAnalyticsEvent,
+} from '@carbon/ibmdotcom-services';
 import MastheadL1 from './MastheadL1';
 import MastheadSearch from './MastheadSearch';
 import MastheadProfile from './MastheadProfile';
@@ -103,8 +107,27 @@ const Masthead = ({ navigation, ...mastheadProps }) => {
         );
       }
     });
+
+    let maxScrollDepth = 0;
+
+    const scrollAnalytics = root.addEventListener('scroll', () => {
+      let scrollDepth = root.pageYOffset;
+
+      // Only fire the event at 400px intervals and at the deepest scroll depth
+      if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
+        maxScrollDepth = scrollDepth;
+        RegisterAnalyticsEvent({
+          type: 'element',
+          primaryCategory: 'SCROLL DISTANCE',
+          eventName: scrollDepth,
+          executionPath: root.innerWidth,
+          execPathReturnCode: root.innerHeight,
+        });
+      }
+    });
     return () => {
       root.removeEventListener('scroll', () => handleScroll);
+      root.removeEventListener('scroll', () => scrollAnalytics);
     };
   }, []);
 

--- a/packages/react/src/global.js
+++ b/packages/react/src/global.js
@@ -1,0 +1,11 @@
+import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
+
+/**
+ * Global methods to be used in various components
+ * including analytics scroll tracking
+ */
+const global = () => {
+  AnalyticsAPI.initScrollTracker();
+};
+
+export default global;

--- a/packages/react/src/global.js
+++ b/packages/react/src/global.js
@@ -1,11 +1,5 @@
+/* eslint-disable tree-shaking/no-side-effects-in-initialization */
 import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
 
-/**
- * Global methods to be used in various components
- */
-const globalMethods = () => {
-  // analytics scroll tracking
-  AnalyticsAPI.initScrollTracker();
-};
-
-export default globalMethods;
+// analytics scroll tracking
+AnalyticsAPI.initScrollTracker();

--- a/packages/react/src/global.js
+++ b/packages/react/src/global.js
@@ -2,10 +2,10 @@ import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
 
 /**
  * Global methods to be used in various components
- * including analytics scroll tracking
  */
-const global = () => {
+const globalMethods = () => {
+  // analytics scroll tracking
   AnalyticsAPI.initScrollTracker();
 };
 
-export default global;
+export default globalMethods;

--- a/packages/services/.env.example
+++ b/packages/services/.env.example
@@ -12,3 +12,6 @@ MARKETING_SEARCH_HOST=<host for ibm.com marketing search, e.g. https://www.ibm.c
 
 # Translation
 CORS_PROXY=<CORS proxy server for fetching from www.ibm.com, e.g. https://yourproxy.com/>
+
+# Analytics - scroll
+SCROLL_TRACKING=<boolean to enable scroll tracking, e.g. false>

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -9,16 +9,10 @@ class AnalyticsAPI {
    *
    * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
    * @returns {object} JSX object
-   * 
-   * example of eventData object expected:
-   * {
-    type: 'element',
-    primaryCategory: 'MASTHEAD',
-    eventName: 'CLICK',
-    executionPath: 'masthead__profile',
-    execPathReturnCode: 'none',
-    targetTitle: 'profile',
-  }
+   *
+   * @example
+   * {type: 'element', primaryCategory: 'MASTHEAD', eventName: 'CLICK', executionPath: 'masthead__profile', execPathReturnCode: 'none', targetTitle: 'profile'}
+   *
    *
    */
   static registerEvent(eventData) {
@@ -32,7 +26,7 @@ class AnalyticsAPI {
    * method scroll tracking
    *
    **/
-  static initScrollAnalytics() {
+  static initScrollTracker() {
     let maxScrollDepth = 0;
     const scrollAnalytics = root.addEventListener('scroll', () => {
       let scrollDepth = root.pageYOffset;

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -15,11 +15,10 @@
   }
  *
  */
-function registerAnalyticsEvent(eventData) {
+function RegisterAnalyticsEvent(eventData) {
   if (window.ibmStats) {
-    console.log('sending info', eventData);
     return window.ibmStats.event(eventData);
   }
 }
 
-export default registerAnalyticsEvent;
+export default RegisterAnalyticsEvent;

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -10,7 +10,14 @@ class AnalyticsAPI {
    * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
    *
    * @example
-   * {type: 'element', primaryCategory: 'MASTHEAD', eventName: 'CLICK', executionPath: 'masthead__profile', execPathReturnCode: 'none', targetTitle: 'profile'}
+   * const eventData = {
+   * type: 'element',
+   * primaryCategory: 'MASTHEAD',
+   * eventName: 'CLICK',
+   * executionPath: 'masthead__profile',
+   * execPathReturnCode: 'none',
+   * targetTitle: 'profile'
+   * }
    *
    *
    */
@@ -23,6 +30,7 @@ class AnalyticsAPI {
   /**
    *
    * method scroll tracking
+   * Only fires the event at 400px intervals and at the deepest scroll depth
    *
    **/
   static initScrollTracker() {
@@ -30,7 +38,6 @@ class AnalyticsAPI {
     const scrollAnalytics = root.addEventListener('scroll', () => {
       let scrollDepth = root.pageYOffset;
 
-      // Only fire the event at 400px intervals and at the deepest scroll depth
       if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
         maxScrollDepth = scrollDepth;
         this.registerEvent({

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -1,0 +1,25 @@
+/**
+ * service to fire a stats/metrics event for an action
+ *
+ * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
+ * @returns {object} JSX object
+ * 
+ * example of eventData object expected:
+ * {
+    type: 'element',
+    primaryCategory: 'MASTHEAD',
+    eventName: 'CLICK',
+    executionPath: 'masthead__profile',
+    execPathReturnCode: 'none',
+    targetTitle: 'profile',
+  }
+ *
+ */
+function registerAnalyticsEvent(eventData) {
+  if (window.ibmStats) {
+    console.log('sending info', eventData);
+    return window.ibmStats.event(eventData);
+  }
+}
+
+export default registerAnalyticsEvent;

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -8,7 +8,6 @@ class AnalyticsAPI {
    * service to fire a stats/metrics event for an action
    *
    * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
-   * @returns {object} JSX object
    *
    * @example
    * {type: 'element', primaryCategory: 'MASTHEAD', eventName: 'CLICK', executionPath: 'masthead__profile', execPathReturnCode: 'none', targetTitle: 'profile'}
@@ -17,7 +16,7 @@ class AnalyticsAPI {
    */
   static registerEvent(eventData) {
     if (root.ibmStats) {
-      return root.ibmStats.event(eventData);
+      root.ibmStats.event(eventData);
     }
   }
 

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -55,21 +55,34 @@ class AnalyticsAPI {
    **/
   static initScrollTracker() {
     if (scrollTracker) {
-      let maxScrollDepth = 0;
-      const scrollAnalytics = root.addEventListener('scroll', () => {
-        let scrollDepth = root.pageYOffset;
+      const trackingInterval = 400;
+      let trackedMarker = 0;
+      let curMarker = 0;
+      let didScroll = false;
+      const fireEvent = this.registerEvent;
 
-        if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
-          maxScrollDepth = scrollDepth;
-          this.registerEvent({
-            type: 'element',
-            primaryCategory: 'SCROLL DISTANCE',
-            eventName: scrollDepth,
-            executionPath: root.innerWidth,
-            execPathReturnCode: root.innerHeight,
-          });
-        }
+      const scrollAnalytics = root.addEventListener('scroll', () => {
+        didScroll = true;
       });
+
+      setInterval(function() {
+        if (didScroll) {
+          didScroll = false;
+          curMarker = Math.floor(root.pageYOffset / trackingInterval);
+
+          if (curMarker > trackedMarker) {
+            trackedMarker = curMarker;
+            fireEvent({
+              type: 'element',
+              primaryCategory: 'SCROLL DISTANCE',
+              eventName: trackingInterval * trackedMarker,
+              executionPath: root.innerWidth,
+              execPathReturnCode: root.innerHeight,
+            });
+          }
+        }
+      }, 50);
+
       root.removeEventListener('scroll', () => scrollAnalytics);
     }
   }

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -12,18 +12,24 @@ const scrollTracker = process.env.SCROLL_TRACKING === 'true' || false;
  */
 class AnalyticsAPI {
   /**
-   * service to fire a stats/metrics event for an action
+   * This method checks that the analytics script has been loaded
+   * and fires an event to Coremetrics
    *
    * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
    *
    * @example
-   * const eventData = {
-   * type: 'element',
-   * primaryCategory: 'MASTHEAD',
-   * eventName: 'CLICK',
-   * executionPath: 'masthead__profile',
-   * execPathReturnCode: 'none',
-   * targetTitle: 'profile'
+   * import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
+   *
+   * function fireEvent() {
+   *    const eventData = {
+   *        type: 'element',
+   *        primaryCategory: 'MASTHEAD',
+   *        eventName: 'CLICK',
+   *        executionPath: 'masthead__profile',
+   *        execPathReturnCode: 'none',
+   *        targetTitle: 'profile'
+   *    }
+   *    AnalyticsAPI.registerEvent(eventData);
    * }
    *
    *
@@ -36,9 +42,16 @@ class AnalyticsAPI {
 
   /**
    *
-   * method scroll tracking
-   * Only fires the event at 400px intervals and at the deepest scroll depth
+   * If scroll tracking is enabled, this method will fire an event for every 400px
+   * user scrolls down the page. Only the deepest depth will fire the event (e.g if
+   * user scrolls back up the page, the event will not be triggered)
    *
+   * @example
+   * import { AnalyticsAPI } from '@carbon/ibmdotcom-services';
+   *
+   * useEffect(() => {
+   *    AnalyticsAPI.initScrollTracker();
+   * },[]);
    **/
   static initScrollTracker() {
     if (scrollTracker) {

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -1,11 +1,17 @@
+import root from 'window-or-global';
 /**
- * service to fire a stats/metrics event for an action
- *
- * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
- * @returns {object} JSX object
- * 
- * example of eventData object expected:
- * {
+ * Analytics API class with methods for firing analytics events on
+ * ibm.com
+ */
+class AnalyticsAPI {
+  /**
+   * service to fire a stats/metrics event for an action
+   *
+   * @param {object} eventData Object with standard IBM metric event properties and values to send to Coremetrics
+   * @returns {object} JSX object
+   * 
+   * example of eventData object expected:
+   * {
     type: 'element',
     primaryCategory: 'MASTHEAD',
     eventName: 'CLICK',
@@ -13,12 +19,38 @@
     execPathReturnCode: 'none',
     targetTitle: 'profile',
   }
- *
- */
-function RegisterAnalyticsEvent(eventData) {
-  if (window.ibmStats) {
-    return window.ibmStats.event(eventData);
+   *
+   */
+  static registerEvent(eventData) {
+    if (root.ibmStats) {
+      return root.ibmStats.event(eventData);
+    }
+  }
+
+  /**
+   *
+   * method scroll tracking
+   *
+   **/
+  static initScrollAnalytics() {
+    let maxScrollDepth = 0;
+    const scrollAnalytics = root.addEventListener('scroll', () => {
+      let scrollDepth = root.pageYOffset;
+
+      // Only fire the event at 400px intervals and at the deepest scroll depth
+      if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
+        maxScrollDepth = scrollDepth;
+        this.registerEvent({
+          type: 'element',
+          primaryCategory: 'SCROLL DISTANCE',
+          eventName: scrollDepth,
+          executionPath: root.innerWidth,
+          execPathReturnCode: root.innerHeight,
+        });
+      }
+    });
+    root.removeEventListener('scroll', () => scrollAnalytics);
   }
 }
 
-export default RegisterAnalyticsEvent;
+export default AnalyticsAPI;

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -1,4 +1,11 @@
 import root from 'window-or-global';
+
+/**
+ * @constant {boolean} scrollTracker determines whether scroll tracking analytics is enabled
+ * @private
+ */
+const scrollTracker = process.env.SCROLL_TRACKING === 'true' || false;
+
 /**
  * Analytics API class with methods for firing analytics events on
  * ibm.com
@@ -34,22 +41,24 @@ class AnalyticsAPI {
    *
    **/
   static initScrollTracker() {
-    let maxScrollDepth = 0;
-    const scrollAnalytics = root.addEventListener('scroll', () => {
-      let scrollDepth = root.pageYOffset;
+    if (scrollTracker) {
+      let maxScrollDepth = 0;
+      const scrollAnalytics = root.addEventListener('scroll', () => {
+        let scrollDepth = root.pageYOffset;
 
-      if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
-        maxScrollDepth = scrollDepth;
-        this.registerEvent({
-          type: 'element',
-          primaryCategory: 'SCROLL DISTANCE',
-          eventName: scrollDepth,
-          executionPath: root.innerWidth,
-          execPathReturnCode: root.innerHeight,
-        });
-      }
-    });
-    root.removeEventListener('scroll', () => scrollAnalytics);
+        if (scrollDepth % 400 === 0 && scrollDepth > maxScrollDepth) {
+          maxScrollDepth = scrollDepth;
+          this.registerEvent({
+            type: 'element',
+            primaryCategory: 'SCROLL DISTANCE',
+            eventName: scrollDepth,
+            executionPath: root.innerWidth,
+            execPathReturnCode: root.innerHeight,
+          });
+        }
+      });
+      root.removeEventListener('scroll', () => scrollAnalytics);
+    }
   }
 }
 

--- a/packages/services/src/services/Analytics/index.js
+++ b/packages/services/src/services/Analytics/index.js
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export default from './Analytics';
+export { default as RegisterAnalyticsEvent } from './Analytics';

--- a/packages/services/src/services/Analytics/index.js
+++ b/packages/services/src/services/Analytics/index.js
@@ -5,8 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './MarketingSearch';
-export * from './SearchTypeahead';
-export * from './Profile';
-export * from './Translation';
-export * from './Analytics';
+export default from './Analytics';

--- a/packages/services/src/services/Analytics/index.js
+++ b/packages/services/src/services/Analytics/index.js
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { default as RegisterAnalyticsEvent } from './Analytics';
+export { default as AnalyticsAPI } from './Analytics';


### PR DESCRIPTION
### Related Ticket(s)

[Analytics: Add event triggers for scroll tracking #1602](https://github.ibm.com/webstandards/digital-design/issues/1602)

### Description

- Add event trigger for scrolling. Fires every 400px interval (only at the deepest scroll depth - does not fire if user scrolls back up)

### Changelog

**New**

- add scroll event listener
- add `RegisterAnalyticsEvent` in `services` package

**Changed**

- move analytics script to the `preview-head.html` file so that the `ibmStats` object is exposed to the iframe
