### PR TITLE
fix(shell): fixed dotcom shell imports

### DIFF
--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -9,7 +9,8 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
-import { Masthead, Footer } from '@carbon/ibmdotcom-react';
+import { Masthead } from '../Masthead';
+import { Footer } from '../Footer';
 import { init } from '../../global';
 
 const { stablePrefix } = ddsSettings;


### PR DESCRIPTION
### Related Ticket(s)

No related tickets

### Description

This is a minor fix that changes the DotcomShell imports of the Masthead and Footer to be relative imports instead of the published components.

### Changelog

**Changed**

- DotcomShell imports
