### PR TITLE
fix(footer): added overflow:hidden to accordion

### DIFF
--- a/packages/styles/scss/components/accordion/_accordion-expressive.scss
+++ b/packages/styles/scss/components/accordion/_accordion-expressive.scss
@@ -16,6 +16,8 @@
 
 @mixin accordion-expressive() {
   .#{$prefix}--accordion {
+    overflow: hidden;
+
     &__heading {
       padding: temp--padding-diff(
           $TEMP--accordion-height,

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -42,6 +42,7 @@
 
         display: block;
         column-count: 2;
+        column-gap: 0;
       }
 
       @include carbon--breakpoint('lg') {


### PR DESCRIPTION
### Related Ticket(s)

closes #170 

### Description

This pull request is simple and adds an `overflow: hidden` to the accordion. It's needed because the accordion items currently aren't hidden and so there is empty space added after the footer, and is noticeable when it's near the bottom of the page where page content doesn't create enough height for it to hide.

### Changelog

**New**

- accordion overflow hidden


**Removed**

- Removed default css multi-column gutter missed originally
