### PR TITLE
Search dropdown highlight fix

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -174,12 +174,12 @@
     &__suggestion {
       height: $spacing-09;
       display: flex;
-      padding: 0 $spacing-05;
 
       .#{$prefix}--container-class {
         display: flex;
         border-bottom: 1px solid $ui-01;
         flex: 1;
+        padding: 0 $spacing-05;
         align-items: center;
 
         &:focus {
@@ -193,6 +193,7 @@
         transition: $search-transition-timing;
       }
 
+      .#{$prefix}--container-highlight-class:not(:hover),
       &:focus,
       &:active {
         outline: 2px solid $focus;


### PR DESCRIPTION
### Related Ticket(s)

fixes: #588 
fixes: #135

### Description

This pull request adds the highlighting to the search suggestion as you key down and up arrows on your keyboard.

![Nov-01-2019 11-24-28](https://user-images.githubusercontent.com/3793636/68039511-45ef8900-fc9a-11e9-8b40-179adb5d5247.gif)

### Changelog

**New**

- Added `.bx--container-highlight-class` to adopt focus state
