### PR TITLE
feat(masthead): flag to open masthead search by default, multiple fixes

### DIFF
--- a/packages/react/.env.example
+++ b/packages/react/.env.example
@@ -1,5 +1,8 @@
 REACT_STORYBOOK_SOURCEMAPS=<Boolean to turn on/off sourcemaps in storybook>
 
+# Search Redirect
+SEARCH_REDIRECT_ENDPOINT=<endpoint for ibm.com search, e.g. https://www.ibm.com/search>
+
 # Search Typeahead
 SEARCH_TYPEAHEAD_VERSION=v1
 SEARCH_TYPEAHEAD_HOST=<host for ibm.com search, e.g. https://www-api.ibm.com>
@@ -18,6 +21,7 @@ SCROLL_TRACKING=<boolean to enable scroll tracking, e.g. false>
 FOOTER_LOCALE_BUTTON=<Boolean flag to turn on/off the locale selector>
 BUTTON_GROUP=<Boolean flag to turn on/off the ButtonGroup component>
 CARD_LINK=<Boolean flag to turn on/off the CardLink component>
+MASTHEAD_L1=<Boolean flag to turn on/off the masthead L1>
 
 # Geolocation
 GEO_API=<endpoint for getting user country by geolocation>

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -27,6 +27,7 @@ import MastheadProfile from './MastheadProfile';
 import MastheadLeftNav from './MastheadLeftNav';
 import MastheadTopNav from './MastheadTopNav';
 import cx from 'classnames';
+import { MASTHEAD_L1 } from '../../internal/FeatureFlags';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -165,7 +166,11 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
                     navigation={mastheadData}
                   />
                 )}
-                {hasSearch && <MastheadSearch />}
+                {hasSearch && (
+                  <MastheadSearch
+                    searchOpenOnload={mastheadProps.searchOpenOnload}
+                  />
+                )}
               </div>
 
               {hasProfile && (
@@ -194,7 +199,7 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
               )}
             </Header>
           </div>
-          {navigation && (
+          {MASTHEAD_L1 && navigation && (
             <div ref={mastheadL1Ref}>
               <MastheadL1 />
             </div>

--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -15,9 +15,16 @@ const { prefix } = settings;
  * @param {object} props Incoming props
  * @param {object} props.componentInputProps contains the input props
  * @param {Function} props.dispatch for component reducer
+ * @param {boolean} props.isActive flag to determine if the search is active
+ * @param {Function} props.searchIconClick executes when the search icon is clicked
  * @returns {*} The rendered component
  */
-const MastheadSearchInput = ({ componentInputProps, dispatch, isActive }) => {
+const MastheadSearchInput = ({
+  componentInputProps,
+  dispatch,
+  isActive,
+  searchIconClick,
+}) => {
   const searchRef = useRef();
 
   useEffect(() => {
@@ -43,9 +50,10 @@ const MastheadSearchInput = ({ componentInputProps, dispatch, isActive }) => {
         {...componentInputProps}
         data-autoid={`${stablePrefix}--header__search--input`}
         ref={searchRef}
+        name="q"
       />
       <HeaderGlobalAction
-        onClick={() => dispatch({ type: 'setSearchOpen' })}
+        onClick={searchIconClick}
         aria-label="Search all of IBM"
         className={`${prefix}--header__search--search`}
         data-autoid={`${stablePrefix}--header__search--search`}>
@@ -71,6 +79,7 @@ MastheadSearchInput.propTypes = {
   componentInputProps: PropTypes.object,
   dispatch: PropTypes.func,
   isActive: PropTypes.bool,
+  searchIconClick: PropTypes.func,
 };
 
 /**
@@ -80,6 +89,7 @@ MastheadSearchInput.propTypes = {
 MastheadSearchInput.defaultProps = {
   componentInputProps: {},
   dispatch: () => {},
+  searchIconClick: () => {},
 };
 
 export default MastheadSearchInput;

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -22,6 +22,21 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 > 💡 Don't forget to import the masthead styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
 
+#### Feature Flags
+
+To utilize the following features, set the following variable's to `true` within
+your `.env` file or your application build settings.
+
+```
+MASTHEAD_L1=true
+```
+
+> See
+> [feature-flags.md](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/react/docs/feature-flags.md)
+> and
+> [.env.example](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/react/.env.example)
+> for more information
+
 ## Navigation Types
 
 | Name      | Description                           |
@@ -37,11 +52,12 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 ## Options
 
-| Name         | Description                                                          |
-| ------------ | -------------------------------------------------------------------- |
-| `platform`   | Includes platform name (only available with `default` and `custom`). |
-| `hasProfile` | Includes IBM profile menu.                                           |
-| `hasSearch`  | Includes IBM search.                                                 |
+| Name               | Description                                                          |
+| ------------------ | -------------------------------------------------------------------- |
+| `platform`         | Includes platform name (only available with `default` and `custom`). |
+| `hasProfile`       | Includes IBM profile menu.                                           |
+| `hasSearch`        | Includes IBM search.                                                 |
+| `searchOpenOnload` | Has the search open by default                                       |
 
 ```javascript
 const topNavProps = {

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -6,6 +6,21 @@ import mastheadKnobs from './data/Masthead.stories.knobs.js';
 import readme from '../README.md';
 import '../../../../../styles/scss/components/masthead/index.scss';
 
+const standardProps = {
+  navigation: select(
+    'Navigation',
+    mastheadKnobs.navigation,
+    mastheadKnobs.navigation.default
+  ),
+  platform: select(
+    'Platform name',
+    mastheadKnobs.platform,
+    mastheadKnobs.platform.none
+  ),
+  hasProfile: boolean('Has profile', true),
+  hasSearch: boolean('Has search', true),
+};
+
 storiesOf('Masthead', module)
   .addDecorator(withKnobs)
   .addParameters({
@@ -14,20 +29,8 @@ storiesOf('Masthead', module)
     },
   })
   .add('Default', () => {
-    return (
-      <Masthead
-        navigation={select(
-          'Navigation',
-          mastheadKnobs.navigation,
-          mastheadKnobs.navigation.default
-        )}
-        platform={select(
-          'Platform name',
-          mastheadKnobs.platform,
-          mastheadKnobs.platform.none
-        )}
-        hasProfile={boolean('Has profile', true)}
-        hasSearch={boolean('Has search', true)}
-      />
-    );
+    return <Masthead {...standardProps} />;
+  })
+  .add('Search open by default', () => {
+    return <Masthead {...standardProps} searchOpenOnload={true} />;
   });

--- a/packages/react/src/internal/FeatureFlags.js
+++ b/packages/react/src/internal/FeatureFlags.js
@@ -10,6 +10,13 @@
  */
 
 /**
+ * Feature flag to turn on the Masthead L1
+ *
+ * @type {boolean}
+ */
+export const MASTHEAD_L1 = process.env.MASTHEAD_L1 === 'true' || false;
+
+/**
  * This determines if the locale selector will be rendered or not
  *
  * @type {string | boolean}
@@ -24,9 +31,8 @@ export const FOOTER_LOCALE_BUTTON =
  */
 export const BUTTON_GROUP = process.env.BUTTON_GROUP === 'true' || false;
 
-/*
+/**
  * Feature flag for CardLink component
- *
- * @type {string | boolean}
+ * @type {boolean}
  */
 export const CARD_LINK = process.env.CARD_LINK === 'true' || false;

--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -15,6 +15,17 @@ const _host = process.env.TRANSLATION_HOST || 'https://www.ibm.com';
 const _proxy = process.env.CORS_PROXY || '';
 
 /**
+ * Sets the default location if nothing is returned
+ *
+ * @type {string}
+ * @private
+ */
+const _localeDefault = {
+  lc: 'us',
+  cc: 'en',
+};
+
+/**
  * Locale API endpoint
  *
  * @type {string}
@@ -102,8 +113,9 @@ class LocaleAPI {
     if (root.document.documentElement.lang) {
       const lang = root.document.documentElement.lang.toLowerCase();
       const codes = lang.split('-');
-      const locale = { cc: codes[1], lc: codes[0] };
-      return locale;
+      return { cc: codes[1], lc: codes[0] };
+    } else {
+      return _localeDefault;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

#587, #593 

### Description

This addresses a few items in the Masthead:
- Pressing enter should trigger a search in the search field
- Clicking the search icon will trigger a search if the search bar is open
- Added the prop `searchOpenOnload` that will open the search field by default
- Added environment variable `SEARCH_REDIRECT_ENDPOINT` for changing the search redirect url if needed
- Added `MASTHEAD_L1` feature flag

### Changelog

**New**

- `MASTHEAD_L1` feature flag
- `SEARCH_REDIRECT_ENDPOINT` environment variable

**Changed**

- Fixes for the masthead search
- Hiding Masthead L1 behind a feature flag
- Option to open search on load