### PR TITLE
feat(cookie): add secure flag for set cookies

### DIFF
--- a/packages/utilities/src/utilities/ipcinfoCookie/ipcinfoCookie.js
+++ b/packages/utilities/src/utilities/ipcinfoCookie/ipcinfoCookie.js
@@ -56,7 +56,12 @@ class ipcinfoCookie {
   static set({ cc, lc }) {
     const info = `cc=${cc};lc=${lc}`;
 
-    Cookies.set(_cookieName, encodeURIComponent(info), { expires: 365 });
+    Cookies.set(
+      _cookieName,
+      encodeURIComponent(info),
+      { expires: 365 },
+      { secure: true }
+    );
   }
 }
 


### PR DESCRIPTION
### Description

Adds `secure` attribute to cookies set with `SameSite=None` (which ours have). This is in anticipation of future versions of Chrome rejecting insecure cookies with `SameSite=None`.

Chrome info: https://www.chromestatus.com/feature/5633521622188032
`js-cookie` documentation: https://github.com/js-cookie/js-cookie#secure

### Changelog

**Changed**

- adds `secure` attribute to cookies
