### PR TITLE
fix(react): open by default blur shouldnt close search

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -150,7 +150,10 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
    * @param {event} event The callback event
    */
   function onBlur(event) {
-    if (!event.currentTarget.contains(event.relatedTarget)) {
+    if (
+      !searchOpenOnload &&
+      !event.currentTarget.contains(event.relatedTarget)
+    ) {
       dispatch({ type: 'setSearchClosed' });
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

Fixes #607 

### Description

This quick-fix prevents the search input field from being closed when you navigate away from the input field if it's been opened by default.

### Changelog

**Changed**

- Check for `!searchOpenOnload` before closing on blur
