### PR TITLE
fix(react): moved initial state inside component func

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -48,22 +48,6 @@ const _trimAndLower = valueString => valueString.toLowerCase().trim();
 const _getSuggestionValue = suggestion => suggestion[0];
 
 /**
- * Initial state of the autocomplete component
- *
- * @type {{val: string, prevSuggestions: Array, suggestions: Array, suggestionContainerVisible: boolean}}
- * @private
- */
-const _initialState = {
-  val: '',
-  suggestions: [],
-  prevSuggestions: [],
-  suggestionContainerVisible: false,
-  isSearchOpen: false,
-  lc: 'en',
-  cc: 'us',
-};
-
-/**
  * Reducer for the useReducer hook
  *
  * @param {object} state The state
@@ -114,9 +98,22 @@ function _reducer(state, action) {
  * @class
  */
 const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
-  if (searchOpenOnload) {
-    _initialState.isSearchOpen = true;
-  }
+  /**
+   * Initial state of the autocomplete component
+   *
+   * @type {{val: string, prevSuggestions: Array, suggestions: Array, suggestionContainerVisible: boolean}}
+   * @private
+   */
+  const _initialState = {
+    val: '',
+    suggestions: [],
+    prevSuggestions: [],
+    suggestionContainerVisible: false,
+    isSearchOpen: searchOpenOnload,
+    lc: 'en',
+    cc: 'us',
+  };
+
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
   useEffect(() => {


### PR DESCRIPTION
### Related Ticket(s)

fixes #620 

### Description

We're setting some values outside of the component's function. In storybook, in particular, this is causing problems especially when we use the object. Once the open by default is set as the initial state it's defined for all the stories. Almost like setting it in a global scope.

### Changelog

**Changed**

- moved `_initialstate` into component
