### PR TITLE
fix(footer): ssr - add prop for navigation content for footer

### DIFF
--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -27,11 +27,12 @@ const { prefix } = settings;
  * Footer component
  *
  * @param {object} props react proptypes
+ * @param {object} props.navigation footer navigation object
  * @returns {object} JSX object
  */
-const Footer = ({ type }) => {
-  const [footerMenuData, setFooterMenuData] = useState([]);
-  const [footerLegalData, setFooterLegalData] = useState([]);
+const Footer = ({ type, navigation }) => {
+  let [footerMenuData, setFooterMenuData] = useState([]);
+  let [footerLegalData, setFooterLegalData] = useState([]);
 
   useEffect(() => {
     // initialize global execution calls
@@ -39,12 +40,19 @@ const Footer = ({ type }) => {
   }, []);
 
   useEffect(() => {
-    (async () => {
-      const response = await TranslationAPI.getTranslation();
-      setFooterMenuData(response.footerMenu);
-      setFooterLegalData(response.footerThin);
-    })();
-  }, []);
+    if (!navigation) {
+      (async () => {
+        const response = await TranslationAPI.getTranslation();
+        setFooterMenuData(response.footerMenu);
+        setFooterLegalData(response.footerThin);
+      })();
+    }
+  }, [navigation]);
+
+  if (navigation) {
+    footerMenuData = navigation.footerMenu;
+    footerLegalData = navigation.footerThin;
+  }
 
   /**
    * method to handle when country/region has been selected
@@ -108,6 +116,7 @@ function setFooterType(type) {
 }
 
 Footer.propTypes = {
+  navigation: PropTypes.object,
   type: PropTypes.string,
 };
 

--- a/packages/react/src/components/Footer/README.md
+++ b/packages/react/src/components/Footer/README.md
@@ -71,6 +71,23 @@ A cors proxy can be configured using the following
 
 `CORS_PROXY=https://myproxy.com/`
 
+## Server Side Rendering
+
+To server side render the footer, the `Translation` service call needs to be
+made to retrieve navigation links
+
+```javascript
+import { TranslationAPI } from '@carbon/ibmdotcom-services';
+import { Footer } from '@carbon/ibmdotcom-react';
+
+server.get('/', async (req, res) => {
+  const response = await TranslationAPI.getTranslation();
+  const body = renderToString(<Footer navigation={response} />);
+
+  res.send(body);
+});
+```
+
 ## 🙌 Contributing
 
 We're always looking for contributors to help us fix bugs, build new features,

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, select } from '@storybook/addon-knobs';
+import { withKnobs, select, object } from '@storybook/addon-knobs';
 import { Footer } from '../';
+import footerMenu from '../__data__/footer-menu.json';
+import footerThin from '../__data__/footer-legal.json';
 import readme from '../README.md';
 
 import '../../../../../styles/scss/components/footer/index.scss';
@@ -19,8 +21,14 @@ storiesOf('Footer', module)
       short: 'short',
     };
 
+    const navigation = object('custom navigation', {
+      footerMenu: footerMenu.data,
+      footerThin: footerThin.data,
+    });
+
     return (
       <Footer
+        navigation={navigation}
         type={select('type', footerTypeOptions, footerTypeOptions.tall)}
       />
     );

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, select, object } from '@storybook/addon-knobs';
+import { withKnobs, select, object, boolean } from '@storybook/addon-knobs';
 import { Footer } from '../';
 import footerMenu from '../__data__/footer-menu.json';
 import footerThin from '../__data__/footer-legal.json';
@@ -26,9 +26,11 @@ storiesOf('Footer', module)
       footerThin: footerThin.data,
     });
 
+    let isCustom = boolean('show custom navigation', true);
+
     return (
       <Footer
-        navigation={navigation}
+        navigation={isCustom && navigation}
         type={select('type', footerTypeOptions, footerTypeOptions.tall)}
       />
     );


### PR DESCRIPTION
### Related Ticket(s)

[[Footer] SSR enabled footer #616](https://github.com/carbon-design-system/ibm-dotcom-library/issues/616)

### Description

Add prop for navigation content to be loaded by the Footer

### Changelog

**New**

- Add to README example of how to pass in navigation content to footer
- If `navigation` prop is not null, do not make network call to get content

