### PR TITLE
Fix masthead tabbing and focus

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -51,6 +51,7 @@ const MastheadSearchInput = ({
         data-autoid={`${stablePrefix}--header__search--input`}
         ref={searchRef}
         name="q"
+        tabIndex={isActive ? null : '-1'}
       />
       <HeaderGlobalAction
         onClick={searchIconClick}

--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -26,6 +26,11 @@ const MastheadSearchInput = ({
   searchIconClick,
 }) => {
   const searchRef = useRef();
+  const searchIconRef = document.querySelector(
+    `.${prefix}--header__search--search`
+  );
+
+  // console.log(searchRef.current.querySelector('bx--header__search--search'));
 
   /**
    * Clear search and clear input when called
@@ -37,6 +42,14 @@ const MastheadSearchInput = ({
       payload: { val: '' },
     });
   }, [dispatch]);
+
+  /**
+   * closeBtnAction resets and sets focus after search is closed
+   */
+  function closeBtnAction() {
+    resetSearch();
+    searchIconRef && searchIconRef.focus();
+  }
 
   useEffect(() => {
     if (isActive) {
@@ -61,7 +74,7 @@ const MastheadSearchInput = ({
         <Search20 />
       </HeaderGlobalAction>
       <HeaderGlobalAction
-        onClick={resetSearch}
+        onClick={closeBtnAction}
         aria-label="Close"
         className={`${prefix}--header__search--close`}
         data-autoid={`${stablePrefix}--header__search--close`}>

--- a/packages/react/src/components/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/components/__tests__/__snapshots__/storyshots.test.js.snap
@@ -142,6 +142,7 @@ Array [
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           placeholder="Search all of IBM"
+                          tabIndex="-1"
                           type="text"
                           value=""
                         />
@@ -1303,6 +1304,7 @@ Array [
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           placeholder="Search all of IBM"
+                          tabIndex="-1"
                           type="text"
                           value=""
                         />
@@ -1595,6 +1597,7 @@ Array [
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           placeholder="Search all of IBM"
+                          tabIndex={null}
                           type="text"
                           value=""
                         />

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -129,6 +129,7 @@
 
       .#{$prefix}--header__search--close {
         width: $spacing-09;
+        display: block;
       }
 
       .#{$prefix}--header__search--close,
@@ -209,6 +210,7 @@
     transition: 120ms;
     border-bottom: 1px solid $ui-03;
     padding: 0;
+    // transition: visibility .2s ease-in;
 
     &::placeholder {
       position: relative;

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -210,7 +210,6 @@
     transition: 120ms;
     border-bottom: 1px solid $ui-03;
     padding: 0;
-    // transition: visibility .2s ease-in;
 
     &::placeholder {
       position: relative;

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -58,6 +58,7 @@ $search-transition-timing: 95ms;
 
     &__logo {
       height: 100%;
+
       a {
         display: flex;
         height: 100%;
@@ -65,6 +66,7 @@ $search-transition-timing: 95ms;
         padding: 0 $spacing-07;
         border: solid 2px transparent;
         transition: $button-transition;
+        outline: none;
 
         &:hover {
           background-color: $ui-01;
@@ -266,6 +268,7 @@ $search-transition-timing: 95ms;
       overflow: hidden;
       width: 0;
       border: none;
+      display: none;
 
       svg {
         position: relative;


### PR DESCRIPTION
### Related Ticket(s)

fixes #627

### Description

This pull request removes invisible items from the tabbing order, applies focus onto the search button after it's closed, and removes the default outline from the logo.

### Changelog

**New**

- Focuses search button after the search is closed

**Removed**

- Removed search input and search close button from tabbing index
- Removed default browser outline from IBM logo on focus
