### PR TITLE
fix(translation): set footer and masthead pull from html lang attr

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -121,7 +121,7 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
       const response = await LocaleAPI.getLang();
       if (response) {
         dispatch({ type: 'setLc', payload: { lc: response.lc } });
-        dispatch({ type: 'setLc', payload: { cc: response.cc } });
+        dispatch({ type: 'setCc', payload: { cc: response.cc } });
       }
     })();
   }, []);

--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -68,7 +68,8 @@ class LocaleAPI {
     const lang = this.getLang();
     // grab locale from the html lang attribute
     if (lang) {
-      return await this.getList(lang);
+      await this.getList(lang);
+      return lang;
     }
     // grab the locale from the cookie
     else if (cookie && cookie.cc && cookie.lc) {


### PR DESCRIPTION
### Related Ticket(s)

[Carbon footer is not using lang from html to localize footer links and labels #632](https://github.com/carbon-design-system/ibm-dotcom-library/issues/632)

### Description

Return the `lang` object when detected from the html `lang` attr so that it can be used for the network call.

#### How to Test
You can easily test by setting the `lang` html attribute for the iframe in storybook like so

<img width="1002" alt="Screen Shot 2019-11-06 at 4 24 35 PM" src="https://user-images.githubusercontent.com/54281166/68339160-09fd5f00-00b2-11ea-8987-4331464e2d98.png">

Toggle between components and then switch back to `DotcomShell` or `Masthead` or `Footer` and you will see the components will be translated according to the `lang` attr.

**Note** For some languages like mexico spanish (es-MX) the masthead will break - that is a separate issue that we have a ticket for ([Masthead (and DotcomShell) briefly renders and disappears #634](https://github.com/carbon-design-system/ibm-dotcom-library/issues/634))

### Changelog

**Changed**

- return `lang` object from `getLocale()`
- set the corresponding action type for setting cc

