### PR TITLE
fix(search-input): set correct key in masthead search reducer

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -76,9 +76,9 @@ function _reducer(state, action) {
     case 'setSearchClosed':
       return Object.assign({}, state, { isSearchOpen: false });
     case 'setLc':
-      return Object.assign({}, state, { val: action.payload.lc });
+      return Object.assign({}, state, { lc: action.payload.lc });
     case 'setCc':
-      return Object.assign({}, state, { val: action.payload.cc });
+      return Object.assign({}, state, { cc: action.payload.cc });
     default:
       return state;
   }


### PR DESCRIPTION
### Related Ticket(s)

[Carbon footer is not using lang from html to localize footer links and labels #632](https://github.com/carbon-design-system/ibm-dotcom-library/issues/632)

### Description

Set the values in the correct state keys (`cc` & `lc`)

otherwise user will first see the lc/cc populate the input when they open the search bar
<img width="1010" alt="Screen Shot 2019-11-07 at 10 02 39 AM" src="https://user-images.githubusercontent.com/54281166/68400346-e126a980-0145-11ea-905b-31768aaf5dd2.png">


### Changelog

**Changed**

- set corresponding state keys in reducer instead of using the `val` key
