### PR TITLE
feat(search): expose search placeholder prop

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -169,6 +169,7 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
                 {hasSearch && (
                   <MastheadSearch
                     searchOpenOnload={mastheadProps.searchOpenOnload}
+                    placeHolderText={mastheadProps.placeHolderText}
                   />
                 )}
               </div>

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -39,11 +39,11 @@ MASTHEAD_L1=true
 
 ## Navigation Types
 
-| Name      | Description                           |
-| --------- | ------------------------------------- |
-| `default` | Default navigation data from IBM.com. |
-| `custom`  | Custom navigation data.               |
-| `none`    | No navigation.                        |
+| Name      | Description                          |
+| --------- | ------------------------------------ |
+| `default` | Default navigation data from IBM.com |
+| `custom`  | Custom navigation data               |
+| `none`    | No navigation                        |
 
 > 💡 `Custom` navigation data must follow the same structure and key names as
 > `default`. See
@@ -52,12 +52,13 @@ MASTHEAD_L1=true
 
 ## Options
 
-| Name               | Description                                                          |
-| ------------------ | -------------------------------------------------------------------- |
-| `platform`         | Includes platform name (only available with `default` and `custom`). |
-| `hasProfile`       | Includes IBM profile menu.                                           |
-| `hasSearch`        | Includes IBM search.                                                 |
-| `searchOpenOnload` | Has the search open by default                                       |
+| Name               | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| `platform`         | Includes platform name (only available with `default` and `custom`) |
+| `hasProfile`       | Includes IBM profile menu                                           |
+| `hasSearch`        | Includes IBM search                                                 |
+| `searchOpenOnload` | Has the search open by default                                      |
+| `placeHolderText`  | Placeholder value for search input                                  |
 
 ```javascript
 const topNavProps = {

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, select, boolean } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
 import Masthead from '../Masthead';
 import mastheadKnobs from './data/Masthead.stories.knobs.js';
 import readme from '../README.md';
@@ -29,8 +29,19 @@ storiesOf('Masthead', module)
     },
   })
   .add('Default', () => {
-    return <Masthead {...standardProps} />;
+    return (
+      <Masthead
+        {...standardProps}
+        placeHolderText={text('Search placeholder', 'Search all of IBM')}
+      />
+    );
   })
   .add('Search open by default', () => {
-    return <Masthead {...standardProps} searchOpenOnload={true} />;
+    return (
+      <Masthead
+        {...standardProps}
+        searchOpenOnload={true}
+        placeHolderText={text('Search placeholder', 'Search all of IBM')}
+      />
+    );
   });


### PR DESCRIPTION
### Related Ticket(s)

#631 

### Description

Exposes prop for Search placeholder value. In the future we can get this value from localized json.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/909118/68418395-265ad380-0166-11ea-87a0-134668dd981e.png">


### Changelog

**New**

- `<Masthead />` now accepts `placeHolderText` prop to change value of search input.

**Changed**

- update `Masthead` story and README

