### PR TITLE
Fix/css imports

### DIFF
--- a/packages/styles/gulp/tasks/sass.js
+++ b/packages/styles/gulp/tasks/sass.js
@@ -5,6 +5,7 @@ const gulp = require('gulp'),
   cleanCSS = require('gulp-clean-css'),
   rename = require('gulp-rename'),
   sass = require('gulp-sass'),
+  path = require('path'),
   sourcemaps = require('gulp-sourcemaps');
 
 /**
@@ -24,8 +25,8 @@ function _sass() {
     .pipe(sourcemaps.init())
     .pipe(sass({
       includePaths: [
-        'node_modules',
-        'node_modules/carbon-components/scss/globals/scss/vendor/',
+        path.resolve(__dirname, '../../', 'node_modules'),
+        path.resolve(__dirname, '../../../../', 'node_modules'),
       ]
     }).on('error', sass.logError))
     .pipe(

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@carbon/grid": "^10.6.0",
+    "@carbon/import-once": "^10.3.0",
     "@carbon/layout": "^10.5.0",
     "@carbon/themes": "^10.4.0",
     "@carbon/type": "^10.5.1"

--- a/packages/styles/scss/components/accordion/_accordion-expressive.scss
+++ b/packages/styles/scss/components/accordion/_accordion-expressive.scss
@@ -5,10 +5,10 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '~carbon-components/scss/components/accordion/accordion';
+@import 'carbon-components/scss/components/accordion/accordion';
 
-@import '../../globals/vars.scss';
-@import '../../globals/mixins.scss';
+@import '../../globals/vars';
+@import '../../globals/mixins';
 
 /// Temporary overrides for accordion's expressive moment
 /// @access private

--- a/packages/styles/scss/components/button/_button-expressive.scss
+++ b/packages/styles/scss/components/button/_button-expressive.scss
@@ -7,8 +7,8 @@
 
 @import 'carbon-components/scss/components/button/button';
 
-@import '../../globals/vars.scss';
-@import '../../globals/mixins.scss';
+@import '../../globals/vars';
+@import '../../globals/mixins';
 
 /// Temporary overrides for button's expressive moment
 /// @access private

--- a/packages/styles/scss/components/card-link/index.scss
+++ b/packages/styles/scss/components/card-link/index.scss
@@ -7,9 +7,9 @@
 
 @import '../../globals/imports';
 @import '../../globals/vars';
-@import '../../globals/mixins.scss';
+@import '../../globals/mixins';
 
-@import '~carbon-components/scss/components/tile/tile';
+@import 'carbon-components/scss/components/tile/tile';
 
 @mixin card-link {
   .#{$prefix}--card-link {

--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -6,8 +6,7 @@
 //
 @import '../../globals/imports';
 @import '../footer/index';
-@import '../masthead/masthead';
-@import '../masthead/masthead-l1';
+@import '../masthead/index';
 
 @mixin dotcom-shell {
   .#{$prefix}--dotcom-shell {

--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -6,8 +6,8 @@
 //
 
 @import '../../globals/imports';
-@import '../../globals/vars.scss';
-@import '../../globals/mixins.scss';
+@import '../../globals/vars';
+@import '../../globals/mixins';
 
 @import 'carbon-components/scss/components/modal/modal';
 

--- a/packages/styles/scss/components/footer/index.scss
+++ b/packages/styles/scss/components/footer/index.scss
@@ -6,14 +6,8 @@
 //
 
 @import '../../globals/imports';
-
-@import '~carbon-components/scss/components/combo-box/combo-box';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/grid/scss/mixins';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/type/scss/styles';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/type/scss/type';
-
-@import '../../globals/vars.scss';
-@import '../../globals/mixins.scss';
+@import '../../globals/vars';
+@import '../../globals/mixins';
 
 // /// Include footer components with g90 theme
 // /// @access private
@@ -28,4 +22,5 @@
   @import 'legal-nav';
 }
 
+@import 'carbon-components/scss/components/combo-box/combo-box';
 @import 'carbon-components/scss/components/modal/modal';

--- a/packages/styles/scss/components/link/_link-expressive.scss
+++ b/packages/styles/scss/components/link/_link-expressive.scss
@@ -5,9 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '~carbon-components/scss/components/link/link';
-@import '../../globals/vars.scss';
-@import '../../globals/mixins.scss';
+@import 'carbon-components/scss/components/link/link';
+@import '../../globals/vars';
+@import '../../globals/mixins';
 
 /// Temporary overrides for link's expressive moment
 /// @access private

--- a/packages/styles/scss/components/masthead/index.scss
+++ b/packages/styles/scss/components/masthead/index.scss
@@ -5,11 +5,11 @@
 // LICENSE file in the root directory of this source tree.
 //
 @import '../../globals/imports';
-@import '~carbon-components/scss/components/overflow-menu/overflow-menu';
-@import '~carbon-components/scss/components/ui-shell/ui-shell';
-@import '~carbon-components/scss/components/ui-shell/side-nav';
+@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
+@import 'carbon-components/scss/components/ui-shell/ui-shell';
+@import 'carbon-components/scss/components/ui-shell/side-nav';
 
-@import '../../globals/vars.scss';
+@import '../../globals/vars';
 
 // Include masthead components
 // @access private

--- a/packages/styles/scss/globals/_imports.scss
+++ b/packages/styles/scss/globals/_imports.scss
@@ -13,13 +13,13 @@
 // isolated as helper functions/mixins/utilities and should have minimal
 // effect on the final artifact size
 
-@import '~@carbon/themes/scss/themes';
-@import '~carbon-components/scss/globals/scss/vars';
-@import '~carbon-components/scss/globals/scss/helper-mixins';
-@import '~carbon-components/scss/globals/scss/layout';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/grid/mixins';
-@import '~carbon-components/scss/globals/scss/css--reset';
+@import '@carbon/themes/scss/themes';
+@import 'carbon-components/scss/globals/scss/vars';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+@import '@carbon/import-once/scss/import-once';
+@import '@carbon/grid/scss/mixins';
+@import 'carbon-components/scss/globals/scss/css--reset';
 
 @import '@carbon/type/scss/type';
 @import '@carbon/type/scss/font-face/mono';

--- a/packages/styles/scss/globals/_mixins.scss
+++ b/packages/styles/scss/globals/_mixins.scss
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import 'carbon-components/scss/globals/scss/vendor/@carbon/type/scss/styles';
+@import '@carbon/type/scss/styles';
 
 @function temp--padding-diff(
   $height,

--- a/packages/styles/scss/globals/_vars.scss
+++ b/packages/styles/scss/globals/_vars.scss
@@ -5,9 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/themes';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/mini-unit';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/breakpoint';
+@import '@carbon/layout/scss/mini-unit';
+@import '@carbon/layout/scss/breakpoint';
+@import '@carbon/themes/scss/themes';
 @import 'mixins';
 
 $TEMP--footer-nav-group-type: 'heading-02';

--- a/packages/styles/scss/ibm-dotcom-styles.scss
+++ b/packages/styles/scss/ibm-dotcom-styles.scss
@@ -9,11 +9,18 @@
 @import 'globals/mixins';
 
 // Components
-@import 'components/masthead/masthead';
-@import 'components/horizontalrule/horizontalrule';
-@import 'components/footer/index';
+@import 'components/accordion/accordion-expressive';
+@import 'components/button/button-expressive';
+@import 'components/buttongroup/buttongroup';
 @import 'components/card-link/index';
+@import 'components/dotcom-shell/dotcom-shell';
 @import 'components/expressive-modal/expressive-modal';
+@import 'components/footer/index';
+@import 'components/horizontalrule/horizontalrule';
+@import 'components/layout/layout';
+@import 'components/link/link-expressive';
+@import 'components/link-with-icon/link-with-icon';
+@import 'components/masthead/index';
 
 // Patterns
 @import 'patterns/leadspace/leadspace';

--- a/packages/styles/scss/patterns/leadspace/index.scss
+++ b/packages/styles/scss/patterns/leadspace/index.scss
@@ -1,5 +1,5 @@
 @import '../../globals/imports';
-@import '~carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/button/button';
 @import './leadspace';
 
 .#{$prefix}--leadspace--g100 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,7 +955,7 @@
   dependencies:
     "@carbon/icon-helpers" "10.4.0"
 
-"@carbon/import-once@10.3.0":
+"@carbon/import-once@10.3.0", "@carbon/import-once@^10.3.0":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@carbon/import-once/-/import-once-10.3.0.tgz#58617da4efb6d7a11352d8e6b7209da1d39f364d"
   integrity sha512-PFk3FhMe3psihYtCg3JsyPHismqglnbUqIpz1DCG5Gn/kt0HdVKhGvHdEq7E305rGoBUCKzMn/4xoY9v9mcmlg==


### PR DESCRIPTION
### Related Ticket(s)

#662, #666 

### Description

This PR removes all tildes (`~`) of imports in the styles package since that is very specific to webpack. This unblocks the rollup build creation of the styles package. 

In addition, this PR also removes the vendor imports from `carbon-components`, and pulls for the corresponding carbon package directly (e.g. `@carbon/type`, `@carbon/grid`, etc). 

### Changelog

**Changed**

- Multiple style import changes
