### PR TITLE
fix(storybook): render with styles on SSR/reload

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import './polyfills';
 import './_container.scss';
 import { settings } from 'carbon-components';
+import '@carbon/ibmdotcom-styles';
 
 const { prefix } = settings;
 export default class Container extends Component {


### PR DESCRIPTION
### Related Ticket(s)

[DotcomShell flashes at page load (briefly renders without styles) #642 ](https://github.com/carbon-design-system/ibm-dotcom-library/issues/642)

### Description

In storybook, when refreshing - the DotcomShell/Masthead/Footer renders first without styles

BEFORE:
![style issue](https://user-images.githubusercontent.com/54281166/68702463-dc536280-0556-11ea-93b2-a6083164dcc5.gif)

AFTER:
![with styles](https://user-images.githubusercontent.com/54281166/68702532-ff7e1200-0556-11ea-9fe9-74a42e4e7f30.gif)

### Changelog

**New**

- import styles in the `Container.js` file

