### PR TITLE
Fix/masthead json render

### DIFF
--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -36,7 +36,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
    * @returns {*} Left side navigation
    */
   const sideNav = navigation.map((link, i) => {
-    if (link.hasMenu && link.hasMegapanel) {
+    if (link.hasMenu) {
       return (
         <SideNavMenu title={link.title} key={i}>
           <SideNavMenuItem
@@ -51,19 +51,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
           <li className={`${prefix}--masthead__side-nav--submemu-title`}>
             {link.title}
           </li>
-          {link.menuSections[0].menuItems[i].megapanelContent &&
-            link.menuSections[0].menuItems[
-              i
-            ].megapanelContent.quickLinks.links.map((item, j) => {
-              return (
-                <SideNavMenuItem
-                  href={item.url}
-                  data-autoid={`${stablePrefix}--masthead__l0-sidenav--subnav-${j}`}
-                  key={j}>
-                  {item.title}
-                </SideNavMenuItem>
-              );
-            })}
+          {renderNav(link.menuSections)}
         </SideNavMenu>
       );
     } else {
@@ -91,6 +79,29 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
     </SideNav>
   );
 };
+
+/**
+ * Loops through and renders a list of links for the side nav
+ *
+ * @param {Array} sections A list of links to be rendered
+ * @returns {object} JSX object
+ */
+function renderNav(sections) {
+  const navItems = [];
+  sections.forEach((section, i) => {
+    section.menuItems.forEach((item, j) => {
+      navItems.push(
+        <SideNavMenuItem
+          href={item.url}
+          data-autoid={`${stablePrefix}--masthead__l0-sidenav--subnav-col${i}-item${j}`}
+          key={item.title}>
+          {item.title}
+        </SideNavMenuItem>
+      );
+    });
+  });
+  return navItems;
+}
 
 /**
  * @property propTypes

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -29,28 +29,15 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
    *
    * @returns {*} Top masthead navigation
    */
-
   const mastheadLinks = navigation.map((link, i) => {
-    if (link.hasMenu && link.hasMegapanel) {
+    if (link.hasMenu) {
       return (
         <HeaderMenu
           aria-label={link.title}
           menuLinkName={link.title}
           data-autoid={`${stablePrefix}--masthead__l0-nav--nav-${i}`}
           key={i}>
-          {link.menuSections[0].menuItems[i].megapanelContent &&
-            link.menuSections[0].menuItems[
-              i
-            ].megapanelContent.quickLinks.links.map((item, j) => {
-              return (
-                <HeaderMenuItem
-                  href={item.url}
-                  data-autoid={`${stablePrefix}--masthead__l0-nav--subnav-${j}`}
-                  key={j}>
-                  {item.title}
-                </HeaderMenuItem>
-              );
-            })}
+          {renderNav(link.menuSections)}
         </HeaderMenu>
       );
     } else {
@@ -83,6 +70,29 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
     </>
   );
 };
+
+/**
+ * Loops through and renders a list of links for the masthead nav
+ *
+ * @param {Array} sections A list of links to be rendered
+ * @returns {object} JSX object
+ */
+function renderNav(sections) {
+  const navItems = [];
+  sections.forEach((section, i) => {
+    section.menuItems.forEach((item, j) => {
+      navItems.push(
+        <HeaderMenuItem
+          href={item.url}
+          data-autoid={`${stablePrefix}--masthead__l0-nav--subnav-col${i}-item${j}`}
+          key={item.title}>
+          {item.title}
+        </HeaderMenuItem>
+      );
+    });
+  });
+  return navItems;
+}
 
 /**
  * @property propTypes

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -73,18 +73,18 @@ const topNavProps = {
 
 ## Stable selectors
 
-| Name                                        | Description |
-| ------------------------------------------- | ----------- |
-| `dds--masthead`                             | Component   |
-| `dds--masthead__hamburger`                  | Interactive |
-| `dds--masthead__logo`                       | Interactive |
-| `dds--masthead__platform-name`              | Interactive |
-| `dds--masthead__l0-nav`                     | Component   |
-| `dds--masthead__l0-nav--nav-${item}`        | Interactive |
-| `dds--masthead__l0-nav--subnav-${item}`     | Interactive |
-| `dds--masthead__l0-sidenav`                 | Component   |
-| `dds--masthead__l0-sidenav--nav-${item}`    | Interactive |
-| `dds--masthead__l0-sidenav--subnav-${item}` | Interactive |
+| Name                                                       | Description |
+| ---------------------------------------------------------- | ----------- |
+| `dds--masthead`                                            | Component   |
+| `dds--masthead__hamburger`                                 | Interactive |
+| `dds--masthead__logo`                                      | Interactive |
+| `dds--masthead__platform-name`                             | Interactive |
+| `dds--masthead__l0-nav`                                    | Component   |
+| `dds--masthead__l0-nav--nav-${item}`                       | Interactive |
+| `dds--masthead__l0-nav--subnav-col${item}-item${item}`     | Interactive |
+| `dds--masthead__l0-sidenav`                                | Component   |
+| `dds--masthead__l0-sidenav--nav-${item}`                   | Interactive |
+| `dds--masthead__l0-sidenav--subnav-col${item}-item${item}` | Interactive |
 
 ## CORS Proxy
 

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -93,7 +93,7 @@
             > .#{$prefix}--side-nav__link-text {
               @include carbon--type-style(body-short-01, true);
 
-              color: $text-01;
+              color: $icon-02;
             }
 
             svg {

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -77,6 +77,10 @@ $search-transition-timing: 95ms;
           border-color: $focus;
           background-color: $ui-01;
         }
+
+        @include carbon--breakpoint-down(lg) {
+          padding: 0 $spacing-05;
+        }
       }
     }
 


### PR DESCRIPTION
### Related Ticket(s)

#634 

### Description

This fixes an issue in rendering `Masthead`/`MastheadLeftNav` navigation from translation files from IBM.com. In this update, navigation subnavs are populated from top-level megamenu items. Non-megamenu subnavs are unchanged.

<img width="1082" alt="Screen Shot 2019-11-14 at 4 10 24 PM" src="https://user-images.githubusercontent.com/909118/68896384-5b809c00-06f9-11ea-8ace-cce342a16c7d.png">

<img width="481" alt="Screen Shot 2019-11-14 at 4 10 00 PM" src="https://user-images.githubusercontent.com/909118/68896378-56bbe800-06f9-11ea-97a2-17a2973aad02.png">


### Changelog

**Changed**

- Update navigation rendering to use top-level megamenu links
- Update `MastheadLeftNav` with the same render changes
- CSS updates to IBM logo padding and link color in SideNav.
