### PR TITLE
fix(layout): properly set mobile columns to be sticky if set

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ coverage
 storybook-static
 .github
 jsdocs
+examples

--- a/packages/react/src/components/Layout/Layout.js
+++ b/packages/react/src/components/Layout/Layout.js
@@ -40,7 +40,9 @@ function _updateChild(type, children) {
       final.push(
         <div
           className={
-            _types[type] && _types[type][i] ? _types[type][i] : `${prefix}--col`
+            _types[type] && _types[type][i]
+              ? `${_types[type][i]} ${prefix}--layout--sticky`
+              : `${prefix}--col`
           }
           key={i}>
           {React.cloneElement(child, {

--- a/packages/react/src/components/Layout/__stories__/Layout.stories.js
+++ b/packages/react/src/components/Layout/__stories__/Layout.stories.js
@@ -63,7 +63,10 @@ storiesOf('Layout', module)
               'Sticky left column',
               ['true', 'false'],
               'true'
-            )}>
+            )}
+            style={{
+              backgroundColor: 'white',
+            }}>
             <h3>Column 1</h3>
 
             <ul className="bx--list--unordered">

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -18,8 +18,12 @@ const { prefix } = settings;
 /**
  * MastHead L1 component
  *
- * @typedef {object} navigation Object containing navigation elements
- * @returns {*} Masthead component
+ * @param {object} props React props
+ * @param {boolean} props.isShort Flag on whether L1 is short or tall
+ * @param {string} props.title Title for the L1
+ * @param {string} props.eyebrowText Eyebrow text
+ * @param {string} props.eyebrowLink URL for the Eyebrow
+ * @returns {*} MastheadL1 JSX component
  */
 const MastheadL1 = ({ isShort, title, eyebrowText, eyebrowLink }) => {
   const className = cx({


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This is a bug that was picked up while working through the TableofContents component. The sticky column was not remaining sticky in mobile views.

### Changelog

**Changed**

- Added sticky modifier class for parent div for mobile breakpoints
- Fixed lint issues with MastheadL1
- Fixed prettierignore to ignore the examples folder