### PR TITLE
feat(content-array-with-pictograms): content array w/ pictograms pattern

### DIFF
--- a/packages/patterns-react/package.json
+++ b/packages/patterns-react/package.json
@@ -50,6 +50,7 @@
     "@carbon/ibmdotcom-react": "^1.1.1",
     "@carbon/ibmdotcom-styles": "1.1.1",
     "@carbon/ibmdotcom-utilities": "1.1.1",
+    "@carbon/pictograms-react": "^10.7.0",
     "classnames": "2.2.6",
     "window-or-global": "^1.0.1"
   },

--- a/packages/patterns-react/src/internal/FeatureFlags.js
+++ b/packages/patterns-react/src/internal/FeatureFlags.js
@@ -39,3 +39,13 @@ export const LISTSECTION =
  */
 export const SIMPLELONGFORM =
   process.env.SIMPLELONGFORM === 'true' || DDS_FLAGS_ALL || false;
+
+/**
+ * This determines if the contentarraywithpictograms will be rendered or not
+ *
+ * @type {string | boolean}
+ */
+export const DDS_CONTENTARRAYWITHPICTOGRAMS =
+  process.env.DDS_CONTENTARRAYWITHPICTOGRAMS === 'true' ||
+  DDS_FLAGS_ALL ||
+  false;

--- a/packages/patterns-react/src/patterns/ContentArrayWithPictograms/ContentArrayWithPictograms.js
+++ b/packages/patterns-react/src/patterns/ContentArrayWithPictograms/ContentArrayWithPictograms.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
+import { DDS_CONTENTARRAYWITHPICTOGRAMS } from '../../internal/FeatureFlags';
+import ContentArrayWithPictogramsItem from './ContentArrayWithPictogramsItem';
+
+const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
+
+/**
+ * Content Array with Pictograms
+ *
+ * @param {object} props props object
+ * @param {string} props.title List section title
+ * @param {Array} props.contentGroup variation of the List section standard, standard with jump link and standard with card link
+ * @returns {*}  Contennt array with pictograms JSX Component
+ */
+const ContentArrayWithPictograms = ({ title, contentGroup }) =>
+  featureFlag(
+    DDS_CONTENTARRAYWITHPICTOGRAMS,
+    <section
+      data-autoid={`${stablePrefix}--contentarraywithpictograms`}
+      className={`${prefix}--contentarraywithpictograms`}>
+      <div className={`${prefix}--contentarraywithpictograms__container`}>
+        <div className={`${prefix}--contentarraywithpictograms__row`}>
+          <div className={`${prefix}--contentarraywithpictograms__col`}>
+            <h2 className={`${prefix}--contentarraywithpictograms__title`}>
+              {title}
+            </h2>
+            {_renderArray(contentGroup)}
+          </div>
+          <div
+            className={`${prefix}--contentarraywithpictograms__divider__col`}>
+            <div
+              className={`${prefix}--contentarraywithpictograms__divider`}></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+
+/**
+ * Render the content in array list
+ *
+ * @private
+ * @param {Array} contentArray contentGroup object array
+ * @returns {object} JSX Object
+ */
+const _renderArray = contentArray =>
+  contentArray.map(contentItem => (
+    <ContentArrayWithPictogramsItem
+      title={contentItem.title}
+      pictogram={contentItem.pictogram}
+      copy={contentItem.copy}
+      link={contentItem.link}
+    />
+  ));
+
+ContentArrayWithPictograms.propTypes = {
+  title: PropTypes.string.isRequired,
+  contentGroup: PropTypes.shape({
+    title: PropTypes.string,
+    copy: PropTypes.string,
+    pictogram: PropTypes.string,
+    link: PropTypes.shape({
+      href: PropTypes.string,
+      text: PropTypes.string,
+      target: PropTypes.string,
+    }),
+  }),
+};
+
+export default ContentArrayWithPictograms;

--- a/packages/patterns-react/src/patterns/ContentArrayWithPictograms/ContentArrayWithPictogramsItem.js
+++ b/packages/patterns-react/src/patterns/ContentArrayWithPictograms/ContentArrayWithPictogramsItem.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
+import PropTypes from 'prop-types';
+import { ArrowRight20 } from '@carbon/icons-react';
+import { LinkWithIcon } from '@carbon/ibmdotcom-react';
+import * as Icons from '@carbon/pictograms-react';
+
+const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
+
+/**
+ * Content with pictogram component
+ *
+ * @param {object} props props object {title, copy, pictogram, link}
+ * @param {string} props.title Content with pictogram component title property
+ * @param {string} props.copy Content with pictogram component copy property
+ * @param {object} props.link Content with pictogram component link object
+ * @param {object} props.link.href Content with pictogram component link object href property
+ * @param {object} props.link.text Content with pictogram component link object text property
+ * @param {object} props.link.target Content with pictogram component link object target property
+ * @returns {*} Content array with pictograms item JSX Component
+ */
+const ContentArrayWithPictogramsItem = ({ title, copy, pictogram, link }) => (
+  <div
+    data-autoid={`${stablePrefix}--contentarraywithpictograms-item`}
+    className={`${prefix}--contentarraywithpictograms-item`}>
+    <div className={`${prefix}--contentarraywithpictograms__row`}>
+      <div className={`${prefix}--contentarraywithpictograms__col`}>
+        {_renderPictogram(
+          pictogram,
+          `${prefix}--contentarraywithpictograms-item__pictogram`
+        )}
+      </div>
+      <div className={`${prefix}--contentarraywithpictograms__col`}>
+        <h3 className={`${prefix}--contentarraywithpictograms-item__title`}>
+          {title}
+        </h3>
+        <div className={`${prefix}--contentarraywithpictograms-item__content`}>
+          {copy}
+        </div>
+        <div className={`${prefix}--contentarraywithpictograms-item__link`}>
+          <LinkWithIcon href={link.href} target={link.target}>
+            <span>{link.text}</span>
+            <ArrowRight20 />
+          </LinkWithIcon>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+/**
+ * Renders the selected pictogram from the @carbon/icons-react module
+ *
+ * @param {string} pictogram Pictogram name
+ * @param {string} identifier Component className
+ * @returns {*} JSX Component
+ */
+const _renderPictogram = (pictogram, identifier) => {
+  const Icon = Icons;
+  const Pictogram = Icon[pictogram];
+  return (
+    <Pictogram
+      width="80"
+      height="80"
+      viewBox="8 8 32 32"
+      className={identifier}
+    />
+  );
+};
+
+ContentArrayWithPictogramsItem.propTypes = {
+  title: PropTypes.string,
+  copy: PropTypes.string,
+  pictogram: PropTypes.string,
+  link: PropTypes.shape({
+    href: PropTypes.string,
+    text: PropTypes.string,
+    target: PropTypes.string,
+  }),
+};
+
+export default ContentArrayWithPictogramsItem;

--- a/packages/patterns-react/src/patterns/ContentArrayWithPictograms/__stories__/ContentArrayWithPictograms.stories.js
+++ b/packages/patterns-react/src/patterns/ContentArrayWithPictograms/__stories__/ContentArrayWithPictograms.stories.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { DDS_CONTENTARRAYWITHPICTOGRAMS } from '../../../internal/FeatureFlags';
+import { withKnobs, text, object } from '@storybook/addon-knobs';
+import '../../../../../styles/scss/patterns/contentarraywithpictograms/index.scss';
+import ContentArrayWithPictograms from '../ContentArrayWithPictograms';
+// import readme from '../README.md';
+
+if (DDS_CONTENTARRAYWITHPICTOGRAMS) {
+  storiesOf('Content array with pictograms', module)
+    .addDecorator(withKnobs)
+    // .addParameters({
+    //   readme: {
+    //     sidebar: readme,
+    //   },
+    // })
+    .add('Default', () => {
+      const title = text(
+        'title (required)',
+        'Curabitur malesuada varius mi eu posuere'
+      );
+
+      const contentGroup = [
+        {
+          title: 'Aliquam condimentum interdum',
+          copy:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+          pictogram: 'Airplane',
+          link: {
+            href: 'https://www.example.com',
+            text: 'Learn more',
+            target: '_self',
+          },
+        },
+        {
+          title: 'Aliquam condimentum interdum',
+          copy:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+          pictogram: 'Airplane',
+          link: {
+            href: 'https://www.example.com',
+            text: 'Learn more',
+            target: '_self',
+          },
+        },
+        {
+          title: 'Aliquam condimentum interdum',
+          copy:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+          pictogram: 'Airplane',
+          link: {
+            href: 'https://www.example.com',
+            text: 'Learn more',
+            target: '_self',
+          },
+        },
+      ];
+
+      return (
+        <div>
+          <ContentArrayWithPictograms
+            title={title}
+            contentGroup={object('contentGroup', contentGroup)}
+          />
+        </div>
+      );
+    });
+}

--- a/packages/patterns-react/src/patterns/ContentArrayWithPictograms/index.js
+++ b/packages/patterns-react/src/patterns/ContentArrayWithPictograms/index.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {
+  default as ContentArrayWithPictograms,
+} from './ContentArrayWithPictograms';

--- a/packages/patterns-react/src/patterns/ListSection/ListSection.js
+++ b/packages/patterns-react/src/patterns/ListSection/ListSection.js
@@ -25,7 +25,7 @@ const { prefix } = settings;
  * @param {string} props.copy List section  short copy to support the title
  * @param {string} props.border List section border
  * @param {object} props.listGroup variation of the List section standard, standard with jump link and standard with card link
- * @returns {object} JSX Object
+ * @returns {*} JSX Object
  */
 const ListSection = ({ title, copy, border, listGroup }) =>
   featureFlag(
@@ -80,7 +80,7 @@ ListSection.propTypes = {
   title: PropTypes.string.isRequired,
   copy: PropTypes.string,
   border: PropTypes.bool,
-  listGroupItems: PropTypes.shape({
+  listGroup: PropTypes.shape({
     title: PropTypes.string,
     lists: PropTypes.array,
   }),

--- a/packages/styles/scss/patterns/contentarraywithpictograms/_contentarraywithpictograms-item.scss
+++ b/packages/styles/scss/patterns/contentarraywithpictograms/_contentarraywithpictograms-item.scss
@@ -1,0 +1,61 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../components/link-with-icon/link-with-icon';
+
+@mixin contentarraywithpictograms-item {
+  .#{$prefix}--contentarraywithpictograms-item {
+    margin-top: $carbon--layout-05;
+    &__title {
+      @include carbon--type-style('heading-02');
+    }
+    &__content {
+      @include carbon--type-style('body-long-02');
+    }
+    &__link {
+      margin-top: $carbon--layout-01;
+      .bx--link-with-icon {
+        span {
+          @include carbon--type-style('body-short-02');
+        }
+        &:hover {
+          cursor: pointer;
+        }
+      }
+    }
+    .#{$prefix}--contentarraywithpictograms__col {
+      margin-left: 0;
+      flex: none;
+      @include carbon--breakpoint('sm') {
+        &:first-of-type {
+          max-width: 100%;
+          width: 100%;
+        }
+        .#{$prefix}--contentarraywithpictograms-item__pictogram {
+          margin-bottom: $carbon--layout-03;
+        }
+
+        max-width: 100%;
+      }
+      @include carbon--breakpoint('md') {
+        max-width: 80%;
+        &:first-of-type {
+          max-width: 20%;
+        }
+        .#{$prefix}--contentarraywithpictograms-item__pictogram {
+          margin-bottom: 0;
+        }
+        .#{$prefix}--contentarraywithpictograms-item__content {
+          width: 95%;
+        }
+      }
+    }
+  }
+}
+@include exports('contentarraywithpictograms-item') {
+  @include contentarraywithpictograms-item;
+}

--- a/packages/styles/scss/patterns/contentarraywithpictograms/_contentarraywithpictograms.scss
+++ b/packages/styles/scss/patterns/contentarraywithpictograms/_contentarraywithpictograms.scss
@@ -1,0 +1,71 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@mixin contentarraywithpictograms {
+  .#{$prefix}--contentarraywithpictograms {
+    color: $text-01;
+    background: $ui-background;
+    &__container {
+      @include carbon--make-container;
+    }
+    &__row {
+      @include carbon--make-row;
+    }
+    &__col {
+      @include carbon--make-col-ready;
+    }
+    &__title {
+      margin-top: $carbon--spacing-07;
+      @include carbon--type-style('expressive-heading-04');
+    }
+    &__divider {
+      margin-top: $carbon--layout-05;
+      margin-left: -$carbon--spacing-05;
+      margin-right: -$carbon--spacing-05;
+      &__col {
+        @include carbon--make-col-ready;
+      }
+    }
+    @include carbon--breakpoint('md') {
+      &__title {
+        margin-top: $carbon--layout-05;
+        margin-bottom: $carbon--spacing-09;
+      }
+      &__col {
+        @include carbon--make-col(7, 8);
+
+        padding-left: $carbon--layout-01;
+        padding-right: $carbon--layout-01;
+      }
+      &__divider {
+        margin-top: $carbon--layout-06;
+      }
+    }
+    @include carbon--breakpoint('lg') {
+      &__col {
+        @include carbon--make-col-offset(4, 16);
+        @include carbon--make-col(7, 16);
+      }
+      &__divider {
+        margin-top: $carbon--layout-07;
+        &__col {
+          @include carbon--make-col-offset(4, 16);
+          @include carbon--make-col(12, 16);
+        }
+      }
+    }
+    @include carbon--breakpoint('max') {
+      &__col {
+        max-width: carbon--rem(640px);
+      }
+    }
+  }
+}
+
+@include exports('contentarraywithpictograms') {
+  @include contentarraywithpictograms;
+}

--- a/packages/styles/scss/patterns/contentarraywithpictograms/index.scss
+++ b/packages/styles/scss/patterns/contentarraywithpictograms/index.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../globals/imports';
+@import './contentarraywithpictograms';
+@import './contentarraywithpictograms-item';


### PR DESCRIPTION
### Related Ticket(s)

Related to issue #703 

### Description

Created the alpha version of the Content array with pictograms pattern.
The list of supported pictograms can be found at:
https://www.carbondesignsystem.com/guidelines/pictograms/library
Name must be camel case in element props.

<img width="1453" alt="Screen Shot 2019-11-26 at 15 45 58" src="https://user-images.githubusercontent.com/30945011/69662880-f0718680-1063-11ea-9dc1-65362525e049.png">
### Changelog

**Changed**

- Added @carbon/pictograms-react as a dependency.
- Added new feature flag for the created component.

