### PR TITLE
fix(leadspace): leadspace theme modifier background color

### DIFF
--- a/packages/styles/scss/patterns/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/leadspace/_leadspace.scss
@@ -30,6 +30,7 @@ $btn-min-width: 26;
     background-color: rgba($ui-background, 0.75);
 
     @include carbon--breakpoint(md) {
+      background-color: transparent;
       background-image: linear-gradient(
         to right,
         rgba($ui-background, 0.95),
@@ -79,14 +80,8 @@ $btn-min-width: 26;
       max-width: none;
     }
 
-    &--gradient {
-      background-color: rgba($ui-background, 0.75);
-    }
-
     .#{$prefix}--leadspace__title {
       @include carbon--type-style(display-01, true);
-
-      color: $text-01;
     }
 
     &__title,
@@ -102,8 +97,6 @@ $btn-min-width: 26;
     .#{$prefix}--leadspace__desc {
       @include carbon--type-style(expressive-heading-03, true);
       @include carbon--make-col(3, 4);
-
-      color: $text-01;
     }
 
     &__ctas {
@@ -112,11 +105,7 @@ $btn-min-width: 26;
       margin-top: $layout-01;
     }
 
-    .#{$prefix}--btn {
-      width: 100%;
-      margin-top: $layout-01;
-      min-width: carbon--mini-units($btn-min-width);
-    }
+    @include themed-items;
   }
 
   .#{$prefix}--leadspace--g100 {
@@ -132,15 +121,6 @@ $btn-min-width: 26;
   @include carbon--breakpoint(md) {
     .#{$prefix}--leadspace {
       padding-top: aspectratio(400px, 672px);
-
-      &--gradient {
-        background-color: transparent;
-        background-image: linear-gradient(
-          to right,
-          rgba($ui-background, 0.95),
-          transparent 75%
-        );
-      }
 
       .#{$prefix}--leadspace__title {
         @include carbon--make-col(7, 8);


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Forgot to set background color to transparent in the `themed-items` mixin

<img width="1145" alt="Screen Shot 2019-12-02 at 4 38 16 PM" src="https://user-images.githubusercontent.com/54281166/69997532-5bb6cf00-1522-11ea-8f92-9460d6b86595.png">

AFTER:
<img width="1122" alt="Screen Shot 2019-12-02 at 4 38 09 PM" src="https://user-images.githubusercontent.com/54281166/69997536-5d809280-1522-11ea-94d1-413da0d51b4a.png">


### Changelog
**Changed**

- set background-color to transparent when setting gradient color

**Removed**

- remove repetitive styles already in the `themed-items` mixin
