### PR TITLE
fix(listsection): add theme modifier to ListSection pattern

### DIFF
--- a/packages/patterns-react/src/patterns/CardsWithoutImages/__stories__/CardsWithoutImages.stories.js
+++ b/packages/patterns-react/src/patterns/CardsWithoutImages/__stories__/CardsWithoutImages.stories.js
@@ -136,7 +136,7 @@ if (DDS_CARDS_WITHOUT_IMAGES) {
       return (
         <CardsWithoutImages
           cardsGroup={object('cardsGroup', cardsGroup)}
-          theme={select('theme', themes, themes['g10'])}
+          theme={select('theme', themes, themes.g10)}
         />
       );
     });

--- a/packages/patterns-react/src/patterns/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/patterns-react/src/patterns/LeadSpace/__stories__/LeadSpace.stories.js
@@ -53,7 +53,7 @@ if (LEADSPACE) {
 
       return (
         <LeadSpace
-          theme={select('theme', themes, themes['dark (g100)'])}
+          theme={select('theme', themes, themes.g100)}
           title={title}
           copy={copy}
           buttons={object('buttons', buttons)}
@@ -110,7 +110,7 @@ if (LEADSPACE) {
 
       return (
         <LeadSpace
-          theme={select('theme', themes, themes['dark (g100)'])}
+          theme={select('theme', themes, themes.g100)}
           title={title}
           copy={copy}
           gradient={graident}

--- a/packages/patterns-react/src/patterns/ListSection/ListSection.js
+++ b/packages/patterns-react/src/patterns/ListSection/ListSection.js
@@ -24,15 +24,20 @@ const { prefix } = settings;
  * @param {boolean} props.border List section border
  * @param {string} props.copy List section  short copy to support the title
  * @param {Array} props.listGroup variation of the List section standard, standard with jump link and standard with card link
+ * @param {string} props.theme List section color theme
  * @param {string} props.title List section title
  * @returns {object} JSX Object
  */
-const ListSection = ({ border, copy, listGroup, title }) =>
+const ListSection = ({ border, copy, listGroup, theme, title }) =>
   featureFlag(
     LISTSECTION,
     <section
       data-autoid={`${stablePrefix}--listsection`}
-      className={classNames(`${prefix}--listsection`, _setBorder(border))}>
+      className={classNames(
+        `${prefix}--listsection`,
+        _setBorder(border),
+        _setTheme(theme)
+      )}>
       <div className={`${prefix}--listsection__container`}>
         <div className={`${prefix}--listsection__row`}>
           <div className={`${prefix}--listsection__col`}>
@@ -76,6 +81,17 @@ const _setBorder = border => {
   return withBorder;
 };
 
+/**
+ * sets the class name based on theme type
+ *
+ * @private
+ * @param {string} theme theme type ( g100 | white/default )
+ * @returns {string} theme css class names
+ */
+const _setTheme = theme => {
+  return theme && `${prefix}--listsection--${theme}`;
+};
+
 ListSection.propTypes = {
   border: PropTypes.bool,
   copy: PropTypes.string,
@@ -83,6 +99,7 @@ ListSection.propTypes = {
     title: PropTypes.string,
     lists: PropTypes.array,
   }),
+  theme: PropTypes.string,
   title: PropTypes.string.isRequired,
 };
 

--- a/packages/patterns-react/src/patterns/ListSection/__stories__/ListSection.stories.js
+++ b/packages/patterns-react/src/patterns/ListSection/__stories__/ListSection.stories.js
@@ -144,26 +144,20 @@ if (LISTSECTION) {
       ];
 
       const themes = {
-        'dark (g100)': 'g100',
-        'light (white)': '',
+        g100: 'g100',
+        white: '',
       };
 
       const withBorder = boolean('with border', true);
 
       return (
-        <div
-          className={`bx--listsection--${select(
-            'theme',
-            themes,
-            themes['light (white)']
-          )}`}>
-          <ListSection
-            title={title}
-            copy={copy}
-            border={withBorder}
-            listGroup={object('listGroup', listGroup)}
-          />
-        </div>
+        <ListSection
+          theme={select('theme', themes, themes.white)}
+          title={title}
+          copy={copy}
+          border={withBorder}
+          listGroup={object('listGroup', listGroup)}
+        />
       );
     });
 }

--- a/packages/styles/scss/patterns/listsection/README.md
+++ b/packages/styles/scss/patterns/listsection/README.md
@@ -12,9 +12,10 @@ Import the package css into the top of your main CSS file.
 
 Use these modifiers with `.bx--listsection` class.
 
-| Class                           | Description                                |
-| ------------------------------- | ------------------------------------------ |
-| `.bx--listsection--with-border` | The className for list section with border |
+| Class                           | Description                                                  |
+| ------------------------------- | ------------------------------------------------------------ |
+| `.bx--listsection--with-border` | The className for list section with border                   |
+| `.bx--listsection--g100`        | The className for use cases with Gray 100 (g100) color theme |
 
 #### Elements
 

--- a/packages/styles/scss/patterns/listsection/_listsection-item.scss
+++ b/packages/styles/scss/patterns/listsection/_listsection-item.scss
@@ -7,6 +7,21 @@
 
 @import '../../components/link-with-icon/link-with-icon';
 
+@mixin themed-items {
+  .#{$prefix}--listsection-item__link .bx--link-with-icon {
+    color: $link-01;
+
+    &:focus {
+      outline: 2px solid $focus;
+    }
+    svg {
+      path {
+        fill: $link-01;
+      }
+    }
+  }
+}
+
 @mixin listsection-item {
   .#{$prefix}--listsection-item {
     &__title {
@@ -20,22 +35,21 @@
     &__link {
       margin-top: $carbon--layout-01;
       .bx--link-with-icon {
-        color: $link-01;
         span {
           @include carbon--type-style('body-short-02');
         }
         &:hover {
           cursor: pointer;
         }
-        &:focus {
-          outline: 2px solid $focus;
-        }
-        svg {
-          path {
-            fill: $link-01;
-          }
-        }
       }
+    }
+
+    @include themed-items;
+  }
+
+  .#{$prefix}--listsection--g100 {
+    @include carbon--theme($carbon--theme--g100) {
+      @include themed-items;
     }
   }
 }

--- a/packages/styles/scss/patterns/listsection/_listsection.scss
+++ b/packages/styles/scss/patterns/listsection/_listsection.scss
@@ -5,10 +5,17 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@mixin themed-items {
+  color: $text-01;
+  background: $ui-background;
+
+  &.#{$prefix}--listsection--with-border .#{$prefix}--listsection__divider {
+    border-bottom: 1px solid $ui-04;
+  }
+}
+
 @mixin listsection {
   .#{$prefix}--listsection {
-    color: $text-01;
-    background: $ui-background;
     &__container {
       @include carbon--make-container;
     }
@@ -33,11 +40,6 @@
       margin-right: -$carbon--spacing-05;
       &__col {
         @include carbon--make-col-ready;
-      }
-    }
-    &--with-border {
-      .#{$prefix}--listsection__divider {
-        border-bottom: 1px solid $ui-04;
       }
     }
     @include carbon--breakpoint('md') {
@@ -72,6 +74,14 @@
       &__col {
         max-width: carbon--rem(640px);
       }
+    }
+
+    @include themed-items;
+  }
+
+  .#{$prefix}--listsection--g100 {
+    @include carbon--theme($carbon--theme--g100) {
+      @include themed-items;
     }
   }
 }

--- a/packages/styles/scss/patterns/listsection/index.scss
+++ b/packages/styles/scss/patterns/listsection/index.scss
@@ -3,10 +3,6 @@
 @import './listsection-group';
 @import './listsection-item';
 
-.#{$prefix}--listsection--g100 {
-  @include carbon--theme($carbon--theme--g100) {
-    @include listsection;
-    @include listsection-group;
-    @include listsection-item;
-  }
-}
+@include listsection;
+@include listsection-group;
+@include listsection-item;

--- a/packages/styles/scss/patterns/listsection/index.scss
+++ b/packages/styles/scss/patterns/listsection/index.scss
@@ -2,7 +2,3 @@
 @import './listsection';
 @import './listsection-group';
 @import './listsection-item';
-
-@include listsection;
-@include listsection-group;
-@include listsection-item;


### PR DESCRIPTION
### Related Ticket(s)

[[ListSection] Update styles to apply color theme as a container modifier #735](https://github.com/carbon-design-system/ibm-dotcom-library/issues/735)

### Description

Add theme modifier class to ListSection pattern

### Changelog

**Changed**

- pass `theme` as prop to ListSection pattern
- set `themed-items` mixin for styles that are using color tokens
