### PR TITLE
chore(circleci): upgrade circleci to 2.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.18
 jobs:
   system:
     docker:
@@ -89,7 +89,6 @@ jobs:
             fi
 
 workflows:
-  version: 2
   main:
     jobs:
       - system


### PR DESCRIPTION
### Related Ticket(s)

No related tickets

### Description

This is a test to determine if upgrading the version of CircleCI will re-enable the system checks for PRs.

### Changelog

**Changed**

- CircleCI version