### PR TITLE
fix(storybook): configure custom properties from carbon expressive flag

### DIFF
--- a/packages/patterns-react/.storybook/webpack.config.js
+++ b/packages/patterns-react/.storybook/webpack.config.js
@@ -70,7 +70,7 @@ const styleLoaders = [
       data: `
         $feature-flags: (
           ui-shell: true,
-          enable-css-custom-properties: true
+          enable-css-custom-properties: ${useCarbonExpressive}
         );
         $dds-feature-flags: (
           carbon-expressive: ${useCarbonExpressive},

--- a/packages/react/.storybook/webpack.config.js
+++ b/packages/react/.storybook/webpack.config.js
@@ -70,7 +70,7 @@ const styleLoaders = [
         $feature-flags: (
           ui-shell: true,
           grid-columns-16: true,
-          enable-css-custom-properties: true
+          enable-css-custom-properties: ${useCarbonExpressive}
         );
         $dds-feature-flags: (
           carbon-expressive: ${useCarbonExpressive},


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This will configure custom properties by the `carbon-expressive` flag for the storybook webpack configs for `patterns-react` and `react`.

### Changelog

**Changed**

- Webpack configuration changes for style feature flags