### PR TITLE
feat(footer): removal of feature flag for the locale selector in footer

### DIFF
--- a/packages/react/src/components/Footer/LocaleButton.js
+++ b/packages/react/src/components/Footer/LocaleButton.js
@@ -1,6 +1,3 @@
-import { DDS_FOOTER_LOCALE_BUTTON } from '../../internal/FeatureFlags.js';
-import { featureFlag } from '@carbon/ibmdotcom-utilities';
-
 import React, { useState, useEffect } from 'react';
 import {
   Button,
@@ -13,18 +10,17 @@ import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { LocaleAPI } from '@carbon/ibmdotcom-services';
 import { settings } from 'carbon-components';
 import { Globe20 } from '@carbon/icons-react';
+import PropTypes from 'prop-types';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 
 /**
- * EXPERIMENTAL: Renders the locale button
+ * Renders the locale button
  *
- * @private
- *
- * @param {Function} selectItem method to handle selected item
- *
- * @returns {object} JSX object
+ * @param {object} props props object
+ * @param {Function} props.selectItem method to handle selected item
+ * @returns {*} {object} JSX object
  */
 const LocaleButton = ({ selectItem }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -55,8 +51,7 @@ const LocaleButton = ({ selectItem }) => {
     return countryList;
   };
 
-  return featureFlag(
-    DDS_FOOTER_LOCALE_BUTTON,
+  return (
     <div className={`${prefix}--locale-btn__container`}>
       <Button
         data-autoid={`${stablePrefix}--locale-btn`}
@@ -108,6 +103,23 @@ const LocaleButton = ({ selectItem }) => {
   function close() {
     setIsOpen(false);
   }
+};
+
+/**
+ * @property propTypes
+ * @description Defined property types for component
+ * @type {{selectItem: shim}}
+ */
+LocaleButton.propTypes = {
+  selectItem: PropTypes.func,
+};
+
+/**
+ * @property defaultProps
+ * @type {{selectItem: Function}}
+ */
+LocaleButton.defaultProps = {
+  selectItem: () => {},
 };
 
 export default LocaleButton;

--- a/packages/react/src/components/Footer/__tests__/LocaleButton.test.js
+++ b/packages/react/src/components/Footer/__tests__/LocaleButton.test.js
@@ -11,12 +11,6 @@ import LocaleButton from '../LocaleButton';
 import { ComposedModal } from 'carbon-components-react';
 import mocklist from '../__data__/locale-list.json';
 
-require('../../../internal/FeatureFlags.js');
-
-jest.mock('../../../internal/FeatureFlags.js', () => ({
-  DDS_FOOTER_LOCALE_BUTTON: true,
-}));
-
 jest.mock('@carbon/ibmdotcom-services', () => ({
   LocaleAPI: {
     getLocale: jest.fn(() => Promise.resolve({ cc: 'us', lc: 'en' })),

--- a/packages/react/src/internal/FeatureFlags.js
+++ b/packages/react/src/internal/FeatureFlags.js
@@ -25,14 +25,6 @@ export const DDS_MASTHEAD_L1 =
   process.env.DDS_MASTHEAD_L1 === 'true' || DDS_FLAGS_ALL || false;
 
 /**
- * This determines if the locale selector will be rendered or not
- *
- * @type {string | boolean}
- */
-export const DDS_FOOTER_LOCALE_BUTTON =
-  process.env.DDS_FOOTER_LOCALE_BUTTON === 'true' || DDS_FLAGS_ALL || false;
-
-/**
  * This flag turns on/off the ButtonGroup component
  *
  * @type {string | boolean}

--- a/packages/utilities/src/utilities/featureflag/featureflag.js
+++ b/packages/utilities/src/utilities/featureflag/featureflag.js
@@ -6,7 +6,7 @@
  * @private
  * @returns {object} JSX object
  *
- * return featureFlag(DDS_FOOTER_LOCALE_BUTTON, <div>hello world</div>);
+ * return featureFlag(DDS_FEATURE_NAME, <div>hello world</div>);
  *
  */
 function featureFlag(flag, jsx) {


### PR DESCRIPTION
### Related Ticket(s)

#506, #507

### Description

This removes the feature flag from the footer to always show the locale selector CTA.

### Changelog

**Removed**

- Removed `DDS_FOOTER_LOCALE_BUTTON`
