### PR TITLE
feat(locale): method for getting the language/locale display name

### DIFF
--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -197,9 +197,6 @@ class LocaleAPI {
             'Content-Type': 'application/json; charset=utf-8',
           },
         })
-        .then(response => {
-          return response;
-        })
         .then(response => response.data);
 
       sessionStorage.setItem(

--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -26,6 +26,14 @@ const _localeDefault = {
 };
 
 /**
+ * Default display name for lang combination
+ *
+ * @type {string}
+ * @private
+ */
+const _localeNameDefault = 'United States - English';
+
+/**
  * Locale API endpoint
  *
  * @type {string}
@@ -123,6 +131,30 @@ class LocaleAPI {
   }
 
   /**
+   * This fetches the language display name based on language/locale combo
+   *
+   * @returns {Promise<string>} Display name of locale/language
+   */
+  static async getLangDisplay() {
+    const lang = this.getLang();
+    const list = await this.getList(lang);
+    // combines the countryList arrays
+    let countries = [];
+    list.regionList.forEach(region => {
+      countries = countries.concat(region.countryList);
+    });
+    const location = countries.filter(country => {
+      return country.locale[0][0] === `${lang.lc}-${lang.cc}`;
+    });
+
+    if (location.length > 0) {
+      return `${location[0].name} - ${location[0].locale[0][1]}`;
+    } else {
+      return _localeNameDefault;
+    }
+  }
+
+  /**
    * Get the country list of all supported countries and their languages
    * if not set in session storage
    *
@@ -164,6 +196,9 @@ class LocaleAPI {
           headers: {
             'Content-Type': 'application/json; charset=utf-8',
           },
+        })
+        .then(response => {
+          return response;
         })
         .then(response => response.data);
 

--- a/packages/services/src/services/Locale/__tests__/Locale.test.js
+++ b/packages/services/src/services/Locale/__tests__/Locale.test.js
@@ -13,13 +13,13 @@ jest.mock('@carbon/ibmdotcom-utilities', () => ({
 
 describe('LocaleAPI', () => {
   const _cc = 'us';
-  const _lc = 'es';
+  const _lc = 'en';
 
   const endpoint = `${process.env.TRANSLATION_HOST}/common/js/dynamicnav/www/countrylist/jsononly`;
   const fetchUrl = `${endpoint}/${_cc}${_lc}-utf8.json`;
 
   beforeEach(function() {
-    mockAxios.get.mockImplementationOnce(() =>
+    mockAxios.get.mockImplementation(() =>
       Promise.resolve({
         data: response,
       })
@@ -65,6 +65,11 @@ describe('LocaleAPI', () => {
       cc: 'us',
       lc: 'en',
     });
+  });
+
+  it('should fetch the display name based on language/locale combination', async () => {
+    const data = await LocaleAPI.getLangDisplay();
+    expect(data).toEqual('United States - English');
   });
 
   it('should fetch locale from cookie if availiable', async () => {

--- a/packages/services/src/services/Locale/__tests__/Locale.test.js
+++ b/packages/services/src/services/Locale/__tests__/Locale.test.js
@@ -28,6 +28,7 @@ describe('LocaleAPI', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
   });
 
   it('should fetch the lang from the html attribute', () => {


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This is an additional method to get the display name of the locale/language combination based on getLang

### Changelog

**New**

- getLangDisplay method in LocaleAPI
