### PR TITLE
fix(css): move storybook css out of story file into local index.scss

### DIFF
--- a/packages/react/src/components/ButtonGroup/__stories__/ButtonGroup.stories.js
+++ b/packages/react/src/components/ButtonGroup/__stories__/ButtonGroup.stories.js
@@ -3,9 +3,10 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { ArrowRight20, ArrowDown20, Pdf20 } from '@carbon/icons-react';
 import '@carbon/grid/scss/grid.scss';
-import '../../../../../styles/scss/components/buttongroup/_buttongroup.scss';
 import readme from '../README.md';
 import { DDS_BUTTON_GROUP } from '../../../internal/FeatureFlags';
+
+import './index.scss';
 
 import ButtonGroup from '../ButtonGroup';
 

--- a/packages/react/src/components/ButtonGroup/__stories__/ButtonGroup.stories.js
+++ b/packages/react/src/components/ButtonGroup/__stories__/ButtonGroup.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { ArrowRight20, ArrowDown20, Pdf20 } from '@carbon/icons-react';
-import '@carbon/grid/scss/grid.scss';
 import readme from '../README.md';
 import { DDS_BUTTON_GROUP } from '../../../internal/FeatureFlags';
 

--- a/packages/react/src/components/ButtonGroup/__stories__/index.scss
+++ b/packages/react/src/components/ButtonGroup/__stories__/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/buttongroup/_buttongroup.scss';

--- a/packages/react/src/components/ButtonGroup/__stories__/index.scss
+++ b/packages/react/src/components/ButtonGroup/__stories__/index.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@import '@carbon/grid/scss/grid.scss';
 @import '../../../../../styles/scss/components/buttongroup/_buttongroup.scss';

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -4,9 +4,10 @@ import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
 import DotcomShell from '../DotcomShell';
 import mastheadKnobs from '../../Masthead/__stories__/data/Masthead.stories.knobs.js';
 import readme from '../README.md';
-import '../../../../../styles/scss/components/dotcom-shell/_dotcom-shell.scss';
 import content from './data/content';
 import { DDS_MASTHEAD_L1 } from '../../../internal/FeatureFlags';
+
+import './index.scss';
 
 const footer = {
   default: 'default',

--- a/packages/react/src/components/DotcomShell/__stories__/index.scss
+++ b/packages/react/src/components/DotcomShell/__stories__/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/dotcom-shell/_dotcom-shell.scss';

--- a/packages/react/src/components/ExpressiveModal/__stories__/ExpressiveModal.stories.js
+++ b/packages/react/src/components/ExpressiveModal/__stories__/ExpressiveModal.stories.js
@@ -7,7 +7,7 @@ import { ExpressiveModal } from '../';
 import { ButtonGroup } from '../../ButtonGroup';
 import readme from '../README.md';
 
-import '../../../../../styles/scss/components/expressive-modal/_expressive-modal.scss';
+import './index.scss';
 
 /**
  * Dummy content for the modal story

--- a/packages/react/src/components/ExpressiveModal/__stories__/index.scss
+++ b/packages/react/src/components/ExpressiveModal/__stories__/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/expressive-modal/_expressive-modal.scss';

--- a/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
+++ b/packages/react/src/components/HorizontalRule/__stories__/HorizontalRule.stories.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
-import '../../../../../styles/scss/components/horizontalrule/_horizontalrule.scss';
-import 'carbon-components/scss/globals/grid/_grid.scss';
 import readme from '../README.md';
+import './index.scss';
 
 import HorizontalRule from '../HorizontalRule';
 

--- a/packages/react/src/components/HorizontalRule/__stories__/index.scss
+++ b/packages/react/src/components/HorizontalRule/__stories__/index.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/horizontalrule/_horizontalrule.scss';
+@import 'carbon-components/scss/globals/grid/_grid.scss';

--- a/packages/react/src/components/Layout/__stories__/Layout.stories.js
+++ b/packages/react/src/components/Layout/__stories__/Layout.stories.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select } from '@storybook/addon-knobs';
-import '@carbon/grid/scss/grid.scss';
-import '../../../../../styles/scss/components/layout/_layout.scss';
 import readme from '../README.md';
+import './index.scss';
 
 import Layout from '../Layout';
 

--- a/packages/react/src/components/Layout/__stories__/index.scss
+++ b/packages/react/src/components/Layout/__stories__/index.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/grid/scss/grid.scss';
+@import '../../../../../styles/scss/components/layout/_layout.scss';

--- a/packages/react/src/components/LinkWithIcon/__stories__/LinkWithIcon.stories.js
+++ b/packages/react/src/components/LinkWithIcon/__stories__/LinkWithIcon.stories.js
@@ -3,8 +3,8 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { ArrowRight20 } from '@carbon/icons-react';
 import LinkWithIcon from '../LinkWithIcon';
-import '../../../../../styles/scss/components/link-with-icon/_link-with-icon.scss';
 import readme from '../README.md';
+import './index.scss';
 
 storiesOf('Link with Icon', module)
   .addDecorator(withKnobs)

--- a/packages/react/src/components/LinkWithIcon/__stories__/index.scss
+++ b/packages/react/src/components/LinkWithIcon/__stories__/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/link-with-icon/_link-with-icon.scss';

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -4,8 +4,9 @@ import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
 import Masthead from '../Masthead';
 import mastheadKnobs from './data/Masthead.stories.knobs.js';
 import readme from '../README.md';
-import '../../../../../styles/scss/components/masthead/index.scss';
 import { DDS_MASTHEAD_L1 } from '../../../internal/FeatureFlags';
+
+import './index.scss';
 
 storiesOf('Masthead', module)
   .addDecorator(withKnobs)

--- a/packages/react/src/components/Masthead/__stories__/index.scss
+++ b/packages/react/src/components/Masthead/__stories__/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/masthead/index.scss';

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { DDS_TOC } from '../../../internal/FeatureFlags';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
-import '../../../../../styles/scss/components/tableofcontents/index.scss';
 import TableOfContents from '../TableOfContents';
 import readme from '../README.md';
+
+import './index.scss';
 
 if (DDS_TOC) {
   storiesOf('Table of contents', module)

--- a/packages/react/src/components/TableOfContents/__stories__/index.scss
+++ b/packages/react/src/components/TableOfContents/__stories__/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../../../styles/scss/components/tableofcontents/index.scss';


### PR DESCRIPTION
### Description

Removes individual imports of css in Storybook in favor of a single `index.scss`. This prevents styles from being overwritten. This does not address #409 

### Changelog

**Changed**

- Storybook story css imports consolidated into a single `index.scss`


