### PR TITLE
fix(css): remove 1px space above TOC select

### DIFF
--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -49,9 +49,6 @@
       background-color: $field-01;
       padding-right: $carbon--spacing-05;
       padding-left: $carbon--spacing-05;
-      &-top {
-        height: 1px;
-      }
       &__select {
         border-radius: 0;
         border: none;


### PR DESCRIPTION
### Related Ticket(s)

#819 

<img width="742" alt="Screenshot 2019-12-11 at 12 57 19 PM" src="https://user-images.githubusercontent.com/909118/70647384-d2388880-1c16-11ea-9b46-0a04b2bf1ef2.png">

### Description

In mobile viewports there is a 1px gap above the section selector. Content is visible through this gap when scrolling.

### Changelog

**Removed**

- remove 1px height of empty element
