### PR TITLE
fix(circleci): added preid for nightly builds to avoid version conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           name: Publish nightly packages
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-            yarn lerna publish --canary minor --dist-tag nightly --no-push --no-git-tag-version --force-publish=* --yes
+            yarn lerna publish --canary minor --dist-tag nightly --preid nightly --no-push --no-git-tag-version --force-publish=* --yes
 
   artifacts:
     docker:


### PR DESCRIPTION
### Related Ticket(s)

#722 

### Description

Publishing as alpha for some reason throws an error `E403 You cannot publish over the previously published versions`. Switching the `preid` to `nightly` should avoid this, and also should make it easier to identify what versions were nightlies.

### Changelog

**Changed**

- changed preid to nightly builds