### PR TITLE
fix(locale-selector): various fixes to the locale modal

### DIFF
--- a/packages/react/src/components/LocaleModal/LocaleModalCountries.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalCountries.js
@@ -148,7 +148,7 @@ LocaleModalCountries.defaultProps = {
     'This page is available in the following locations and languages',
   unavailabilityText:
     'This page is unavailable in your preferred location or language',
-  placeHolderText: 'Search',
+  placeHolderText: 'Search by location or language',
   labelText: 'Search',
 };
 

--- a/packages/react/src/components/LocaleModal/LocaleModalRegions.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalRegions.js
@@ -79,7 +79,7 @@ const LocaleModalRegions = ({
             return (
               <div
                 key={`${region.name}`}
-                className={`${prefix}--col-sm-2 ${prefix}--col-md-8 ${prefix}--col-lg-8 ${prefix}--col-xlg-8 ${prefix}--no-gutter`}>
+                className={`${prefix}--col-sm-4 ${prefix}--col-md-8 ${prefix}--col-lg-8 ${prefix}--col-xlg-8 ${prefix}--no-gutter`}>
                 <CardLink
                   data-autoid={`${stablePrefix}--locale-modal__geo-btn-${region.key}`}
                   data-region={region.key}

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -19,7 +19,7 @@ $search-transition-timing: 95ms;
     top: 0;
     left: 0;
     width: 100%;
-    z-index: 99999;
+    z-index: 1;
     transition-delay: 200ms;
     transition-timing-function: $search-transition;
     transition-duration: 300ms;
@@ -41,7 +41,6 @@ $search-transition-timing: 95ms;
       height: 1px;
       bottom: -1px;
       left: 0;
-      z-index: 9999;
       background-color: $ui-03;
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

[LocaleSelector] Mobile issues for region selector view #835
[LocaleSelector] Cannot go back when in country/language selection mode #836
[LocaleSelector] Change placeholder text to "Search by location or language" #837

### Description
Change default placeholder text to "Search by location or language"
<img width="573" alt="Screen Shot 2019-12-12 at 11 28 13 AM" src="https://user-images.githubusercontent.com/54281166/70730761-93b4d380-1cd3-11ea-9b4d-864b8298dc59.png">

Have modal take entire height of screen on mobile and align the region divs to take entire width
<img width="317" alt="Screen Shot 2019-12-12 at 10 54 14 AM" src="https://user-images.githubusercontent.com/54281166/70730769-96afc400-1cd3-11ea-8954-0ad636b5a1bb.png">


### Changelog

**Changed**

- Change `z-index` of Masthead
- Change modal placeholder prop default search text