### PR TITLE
Fix/masthead layout fixes

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -199,6 +199,7 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
 
               {navigation && (
                 <MastheadLeftNav
+                  {...mastheadProps}
                   navigation={mastheadData}
                   isSideNavExpanded={isSideNavExpanded}
                 />

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -29,7 +29,11 @@ const { prefix } = settings;
  * @param {boolean} isSideNavExpanded Is side nav expanded
  * @returns {*} Masthead left nav component
  */
-const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
+const MastheadLeftNav = ({
+  navigation,
+  isSideNavExpanded,
+  ...leftNavProps
+}) => {
   /**
    * Left side navigation
    *
@@ -72,6 +76,15 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded }) => {
       expanded={isSideNavExpanded}
       isPersistent={false}>
       <nav data-autoid={`${stablePrefix}--masthead__l0-sidenav`}>
+        {leftNavProps.platform && (
+          <a
+            data-autoid={`${stablePrefix}--side-nav__submenu-platform`}
+            href={leftNavProps.platform.url}
+            aria-haspopup="true"
+            className={`${prefix}--side-nav__submenu ${prefix}--side-nav__submenu-platform`}>
+            {leftNavProps.platform.name}
+          </a>
+        )}
         <SideNavItems>
           <HeaderSideNavItems>{sideNav}</HeaderSideNavItems>
         </SideNavItems>

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -27,7 +27,7 @@
 
     &__regions {
       width: 100%;
-      align-self: flex-end;
+      margin-top: auto;
       > .#{$prefix}--row {
         margin-left: 0;
         margin-right: 0;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -123,6 +123,13 @@
 
     &[aria-haspopup='true'] {
       height: carbon--mini-units(6);
+      &.bx--side-nav__submenu-platform {
+        border-bottom: 1px solid $ui-03;
+        text-decoration: none;
+        color: $text-01;
+
+        @include carbon--type-style(expressive-heading-02, true);
+      }
     }
 
     &-chevron {

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -17,6 +17,13 @@
 
   .#{$prefix}--header__menu-trigger {
     margin-right: 0;
+
+    &.#{$prefix}--header__action--active {
+      + .#{$prefix}--header__logo {
+        z-index: 6001;
+        margin-left: $spacing-09;
+      }
+    }
   }
 
   .#{$prefix}--side-nav {
@@ -32,6 +39,32 @@
       .#{$prefix}--side-nav__item {
         border-bottom: 1px solid $ui-03;
       }
+    }
+
+    &__overlay {
+      top: 0;
+      @include carbon--breakpoint-down(md) {
+        background-color: $ui-background;
+      }
+    }
+
+    &:not(.#{$prefix}--side-nav--fixed):hover {
+      @include carbon--breakpoint-down(md) {
+        max-width: 100vw;
+        width: 100vw;
+      }
+    }
+
+    &--expanded {
+      @include carbon--breakpoint-down(md) {
+        max-width: 100vw;
+        width: 100vw;
+      }
+    }
+
+    .#{$prefix}--header__logo {
+      height: 3rem;
+      padding-left: $spacing-09;
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -78,6 +78,10 @@
         width: 0.0625rem;
         background-color: #dcdcdc;
       }
+
+      @include carbon--breakpoint-down(lg) {
+        display: none;
+      }
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -55,6 +55,7 @@ $search-transition-timing: 95ms;
     margin-right: auto;
     margin-bottom: 1px;
     position: relative;
+    z-index: 5999;
 
     &__logo {
       height: 100%;
@@ -203,7 +204,9 @@ $search-transition-timing: 95ms;
       border: 2px solid transparent;
       > {
         svg {
-          fill: $text-01;
+          position: relative;
+          fill: currentColor;
+          top: 2px;
         }
       }
 
@@ -246,6 +249,12 @@ $search-transition-timing: 95ms;
       &--active {
         border: 2px solid $interactive-01;
         background-color: $ui-01;
+
+        @include carbon--breakpoint-up(sm) {
+          position: absolute;
+          top: 0;
+          z-index: 6001;
+        }
       }
     }
 


### PR DESCRIPTION
### Related Ticket(s)

#781 #782 

### Description
Masthead platform name, if it exists, is now hidden in mobile views and will appear in the sidenav instead. 

### Changelog

**Changed**

- Masthead platform name hidden in mobile view and appears in sidenav instead
- In mobile breakpoints (`md`) the sidenav is now 100% wide and covers search/profile buttons
- LocaleModal region buttons now scroll if viewport is too short

