### PR TITLE
fix(locale-selector): reset country search results when clicking close icon or back to region button

### DIFF
--- a/packages/react/src/components/LocaleModal/LocaleModal.js
+++ b/packages/react/src/components/LocaleModal/LocaleModal.js
@@ -33,6 +33,7 @@ const LocaleModal = ({ isOpen, setIsOpen, ...localeModalProps }) => {
   const [list, setList] = useState({});
   const [langDisplay, setLangDisplay] = useState();
   const [isFiltering, setIsFiltering] = useState(false);
+  const [clearResults, setClearResults] = useState(false);
   const [currentRegion, setCurrentRegion] = useState();
 
   const filterClass = cx({
@@ -47,7 +48,20 @@ const LocaleModal = ({ isOpen, setIsOpen, ...localeModalProps }) => {
       setLangDisplay(getLangDisplay);
       setList(list);
     })();
-  }, []);
+
+    // reset the country search results when clicking close icon or back to region button
+    if (clearResults) {
+      const localeItems = document.querySelectorAll(
+        `.${prefix}--locale-modal__locales`
+      );
+
+      const localeHidden = `${prefix}--locale-modal__locales-hidden`;
+
+      [...localeItems].map(item => {
+        item.classList.remove(localeHidden);
+      });
+    }
+  }, [clearResults]);
 
   /**
    *  New region/country list based lang attributes available on page
@@ -119,11 +133,13 @@ const LocaleModal = ({ isOpen, setIsOpen, ...localeModalProps }) => {
           regionList={sortList(list)}
           setCurrentRegion={setCurrentRegion}
           setIsFiltering={setIsFiltering}
+          setClearResults={setClearResults}
           {...localeModalProps}
         />
         <LocaleModalCountries
           regionList={sortList(list)}
           setIsFiltering={setIsFiltering}
+          setClearResults={setClearResults}
           {...localeModalProps}
         />
       </ModalBody>

--- a/packages/react/src/components/LocaleModal/LocaleModalCountries.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalCountries.js
@@ -24,9 +24,14 @@ const { prefix } = settings;
  * @param {string} props.labelText label text for the Search icon
  * @param {object} props.regionList object of country and language codes
  *.@param {boolean} props.setIsFiltering true when search filter is visible
+ * @param {Function} props.setClearResults set flag to determine whether to reset the filtered results
  * @returns {*} LocaleModal component
  */
-const LocaleModalCountries = ({ regionList, ...localeModalProps }) => {
+const LocaleModalCountries = ({
+  regionList,
+  setClearResults,
+  ...localeModalProps
+}) => {
   useEffect(() => {
     const localeFilter = document.getElementById(
       `${prefix}--locale-modal__filter`
@@ -49,6 +54,7 @@ const LocaleModalCountries = ({ regionList, ...localeModalProps }) => {
      *
      */
     function filterLocale() {
+      setClearResults(false);
       const filterVal = localeFilter.value.toUpperCase();
 
       [...localeItems].map(item => {
@@ -83,9 +89,7 @@ const LocaleModalCountries = ({ regionList, ...localeModalProps }) => {
      *
      */
     closeBtn.addEventListener('click', () => {
-      [...localeItems].map(item => {
-        item.classList.remove(localeHidden);
-      });
+      setClearResults(true);
     });
   });
 
@@ -137,6 +141,7 @@ LocaleModalCountries.propTypes = {
   unavailabilityText: PropTypes.string,
   placeHolderText: PropTypes.string,
   labelText: PropTypes.string,
+  setClearResults: PropTypes.func,
 };
 
 /**

--- a/packages/react/src/components/LocaleModal/LocaleModalRegions.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalRegions.js
@@ -20,13 +20,15 @@ import { ArrowRight20, Error20 } from '@carbon/icons-react';
  * @param {object} props props object
  * @param {object} props.regionList object of regions
  * @param {string} props.setCurrentRegion state for region name
- *.@param {boolean} props.setIsFiltering true when search filter is visible
+ * @param {boolean} props.setIsFiltering true when search filter is visible
+ * @param {Function} props.setClearResults set flag to determine whether to reset the filtered results
  * @returns {*} LocaleModalRegions component
  */
 const LocaleModalRegions = ({
   regionList,
   setCurrentRegion,
   setIsFiltering,
+  setClearResults,
 }) => {
   useEffect(() => {
     const regionLink = document.querySelectorAll(`.${prefix}--card-link`);
@@ -60,6 +62,7 @@ const LocaleModalRegions = ({
         [...localeBackBtn].forEach(btn => {
           btn.addEventListener('click', () => {
             setIsFiltering(false);
+            setClearResults(true);
             document.getElementById(`${prefix}--locale-modal__filter`).value =
               '';
           });
@@ -104,7 +107,8 @@ const LocaleModalRegions = ({
 LocaleModalRegions.propTypes = {
   regionList: PropTypes.array,
   setCurrentRegion: PropTypes.string,
-  setIsFiltering: PropTypes.bool,
+  setIsFiltering: PropTypes.func,
+  setClearResults: PropTypes.func,
 };
 
 export default LocaleModalRegions;


### PR DESCRIPTION
### Related Ticket(s)

[LocaleSelector] State of search view doesn't clear after closing the modal or going back #839

### Description

Reset the search results when user closes the modal or clicks the back to region button

### Changelog

**Changed**

- add `clearResults` flag to determine whether to remove `${prefix}--locale-modal__locales-hidden` class and styling.

