### PR TITLE
fix(css): locale region buttons now scroll when cut off

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -27,7 +27,7 @@
 
     &__regions {
       width: 100%;
-      align-self: flex-end;
+      margin-top: auto;
       > .#{$prefix}--row {
         margin-left: 0;
         margin-right: 0;


### PR DESCRIPTION
### Related Ticket(s)

#845 

### Description

Locale modal region buttons now scrollable when viewport is too short

### Changelog

**Changed**

- locale modal regions now scrollable
