### PR TITLE
fix(footer): theme bugs

### DIFF
--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../temp-carbon-expressive/accordion/accordion-expressive';
+@import 'carbon-components/scss/components/accordion/accordion';
 
 /// Footer nav styles
 /// @access private
@@ -54,6 +55,7 @@
 
 @include exports('footer-nav') {
   @include carbon--theme($carbon--theme--g90) {
+    @include accordion;
     @include footer-nav;
   }
 }

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../temp-carbon-expressive/button/button-expressive';
+@import 'carbon-components/scss/components/button/button';
 
 /// Footer locale button
 /// @access private
@@ -75,6 +76,7 @@
 
 @include exports('local-button') {
   @include carbon--theme($carbon--theme--g90) {
+    @include button;
     @include local-button;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Footer Accordion Theme Slightly Off #876
Footer – secondary button theme is incorrect #877

### Description

import the carbon styles for accordion and button and stick them within the theme mixins

### Changelog

**Changed**

- add carbon accordion and button under the theme mixin


<img width="462" alt="Screen Shot 2019-12-17 at 12 05 30 PM" src="https://user-images.githubusercontent.com/54281166/71025667-80d83f80-20d5-11ea-9a60-3f16091f399b.png">

