### PR TITLE
fix(footer): theme bugs

### DIFF
--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../temp-carbon-expressive/accordion/accordion-expressive';
+@import 'carbon-components/scss/components/accordion/accordion';
 
 /// Footer nav styles
 /// @access private
@@ -54,6 +55,7 @@
 
 @include exports('footer-nav') {
   @include carbon--theme($carbon--theme--g90) {
+    @include accordion;
     @include footer-nav;
   }
 }

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -13,6 +13,8 @@
 /// @group footer
 
 @mixin footer-nav {
+  @include accordion;
+
   .#{$prefix}--footer-nav {
     @include carbon--make-col-ready;
 
@@ -55,7 +57,6 @@
 
 @include exports('footer-nav') {
   @include carbon--theme($carbon--theme--g90) {
-    @include accordion;
     @include footer-nav;
   }
 }

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -15,6 +15,7 @@
 @mixin footer-nav {
   .#{$prefix}--footer-nav {
     @include accordion;
+    @include temp-accordion-expressive;
     @include carbon--make-col-ready;
 
     padding: 0;

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -13,9 +13,8 @@
 /// @group footer
 
 @mixin footer-nav {
-  @include accordion;
-
   .#{$prefix}--footer-nav {
+    @include accordion;
     @include carbon--make-col-ready;
 
     padding: 0;

--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -13,6 +13,8 @@
 
 @mixin footer {
   .#{$prefix}--footer {
+    @include temp-link-expressive;
+
     color: $text-01;
     background-color: $ui-background;
     padding-top: carbon--mini-units(6);

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../temp-carbon-expressive/button/button-expressive';
+@import 'carbon-components/scss/components/button/button';
 
 /// Footer locale button
 /// @access private
@@ -16,60 +17,60 @@
     height: 500px;
   }
 
-  .#{$prefix}--locale-btn {
+  .#{$prefix}--locale-btn__container {
+    @include button;
     @include temp-button-expressive;
+    @include carbon--make-col-ready;
+    @include carbon--make-col(4, 4);
 
-    max-width: 100%;
-    width: 100%;
+    margin-top: carbon--mini-units(2);
+    padding-left: 0;
+    padding-right: 0;
+    order: 0;
 
-    @include carbon--breakpoint('md') {
-      min-width: carbon--mini-units(27);
-      max-width: carbon--mini-units(40);
+    .#{$prefix}--locale-btn {
+      max-width: 100%;
+      width: 100%;
 
-      .#{$prefix}--footer--short & {
-        float: right;
+      @include carbon--breakpoint('md') {
+        min-width: carbon--mini-units(27);
+        max-width: carbon--mini-units(40);
+
+        .#{$prefix}--footer--short & {
+          float: right;
+        }
       }
     }
 
-    &__container {
-      @include carbon--make-col-ready;
-      @include carbon--make-col(4, 4);
+    .#{$prefix}--footer--short & {
+      margin-top: 0;
+    }
 
-      margin-top: carbon--mini-units(2);
-      padding-left: 0;
-      padding-right: 0;
-      order: 0;
+    @include carbon--breakpoint('md') {
+      @include carbon--make-col(4, 8);
+
+      margin-bottom: carbon--mini-units(2);
 
       .#{$prefix}--footer--short & {
-        margin-top: 0;
+        @include carbon--make-col-offset(2, 8);
       }
+    }
 
-      @include carbon--breakpoint('md') {
-        @include carbon--make-col(4, 8);
+    @include carbon--breakpoint('lg') {
+      @include carbon--make-col(4, 16);
 
-        margin-bottom: carbon--mini-units(2);
+      order: 1;
 
-        .#{$prefix}--footer--short & {
-          @include carbon--make-col-offset(2, 8);
-        }
+      .#{$prefix}--footer--short & {
+        @include carbon--make-col-offset(10, 16);
       }
+    }
 
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col(4, 16);
+    @include carbon--breakpoint('max') {
+      @include carbon--make-col(3, 16);
 
-        order: 1;
-
-        .#{$prefix}--footer--short & {
-          @include carbon--make-col-offset(10, 16);
-        }
-      }
-
-      @include carbon--breakpoint('max') {
-        @include carbon--make-col(3, 16);
-
-        .#{$prefix}--footer--short & {
-          @include carbon--make-col-offset(11, 16);
-        }
+      .#{$prefix}--footer--short & {
+        @include carbon--make-col-offset(11, 16);
       }
     }
   }

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -13,8 +13,6 @@
 /// @group footer
 
 @mixin local-button {
-  @include button;
-
   .#{$prefix}--modal-content {
     height: 500px;
   }
@@ -33,6 +31,7 @@
     }
 
     &__container {
+      @include button;
       @include carbon--make-col-ready;
       @include carbon--make-col(4, 4);
 

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -6,7 +6,6 @@
 //
 
 @import '../../temp-carbon-expressive/button/button-expressive';
-@import 'carbon-components/scss/components/button/button';
 
 /// Footer locale button
 /// @access private
@@ -18,6 +17,8 @@
   }
 
   .#{$prefix}--locale-btn {
+    @include temp-button-expressive;
+
     max-width: 100%;
     width: 100%;
 
@@ -31,7 +32,6 @@
     }
 
     &__container {
-      @include button;
       @include carbon--make-col-ready;
       @include carbon--make-col(4, 4);
 

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -13,6 +13,8 @@
 /// @group footer
 
 @mixin local-button {
+  @include button;
+
   .#{$prefix}--modal-content {
     height: 500px;
   }
@@ -76,7 +78,6 @@
 
 @include exports('local-button') {
   @include carbon--theme($carbon--theme--g90) {
-    @include button;
     @include local-button;
   }
 }

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../temp-carbon-expressive/button/button-expressive';
+@import 'carbon-components/scss/components/button/button';
 
 /// Footer locale button
 /// @access private
@@ -75,6 +76,7 @@
 
 @include exports('local-button') {
   @include carbon--theme($carbon--theme--g90) {
+    @include button;
     @include local-button;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Footer Accordion Theme Slightly Off #876
Footer – secondary button theme is incorrect #877

### Description

import the carbon styles for accordion and button and stick them within the theme mixins

### Changelog

**Changed**

- add carbon accordion and button under the theme mixin


<img width="462" alt="Screen Shot 2019-12-17 at 12 05 30 PM" src="https://user-images.githubusercontent.com/54281166/71025667-80d83f80-20d5-11ea-9a60-3f16091f399b.png">
