### PR TITLE
fix(component): fixed focus outline style

### DIFF
--- a/packages/styles/scss/components/card-link/index.scss
+++ b/packages/styles/scss/components/card-link/index.scss
@@ -52,7 +52,7 @@
     }
 
     &:focus {
-      outline-color: $focus;
+      outline: 2px solid $focus;
     }
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Related to ticket #874 
### Description

I've updated the component styling to fix the outline size, setting it to 2px.
<img width="370" alt="Screen Shot 2019-12-20 at 14 28 30" src="https://user-images.githubusercontent.com/30945011/71277969-0c9bd700-2335-11ea-88bb-711dd9ee1cf3.png">
<img width="393" alt="Screen Shot 2019-12-20 at 14 28 39" src="https://user-images.githubusercontent.com/30945011/71277973-0efe3100-2335-11ea-87cd-3277323b70f3.png">


### Changelog

**Changed**

- CardLink scss file