### PR TITLE
chore(security): updating serialize-javascript in nextjs example

### DIFF
--- a/packages/react/examples/nextjs/package.json
+++ b/packages/react/examples/nextjs/package.json
@@ -17,5 +17,8 @@
     "node-sass": "^4.13.0",
     "react": "16.11.0",
     "react-dom": "16.11.0"
+  },
+  "resolutions": {
+    "serialize-javascript": ">= 2.1.2"
   }
 }

--- a/packages/react/examples/nextjs/yarn.lock
+++ b/packages/react/examples/nextjs/yarn.lock
@@ -5683,10 +5683,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+"serialize-javascript@>= 2.1.2", serialize-javascript@^1.7.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This updates the dependency `serialize-javascript` to address a security issue.

### Changelog

**Changed**

- serialize-javascript version to 2.1.2
