### PR TITLE
fix(lint): imports sorted alphabetically

### DIFF
--- a/packages/utilities/src/utilities/markdownToHtml/__tests__/markdownToHtml.js
+++ b/packages/utilities/src/utilities/markdownToHtml/__tests__/markdownToHtml.js
@@ -1,5 +1,5 @@
-import { settings } from 'carbon-components';
 import { markdownToHtml } from '../';
+import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 


### PR DESCRIPTION
### Description

I was getting an error pointing that the imports for this test should be sorted alphabetically, as this was keeping me from commiting my changes once I based one of my branchs I've decided to fix this.

### Changelog

**Changed**

- Imports sorted

