### PR TITLE
fix(button): scope button min width style to leadspace

### DIFF
--- a/packages/styles/scss/patterns/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/leadspace/_leadspace.scss
@@ -87,16 +87,16 @@ $btn-min-width: 26;
       @include carbon--make-row;
     }
 
+    .#{$prefix}--btn {
+      min-width: carbon--mini-units($btn-min-width);
+    }
+
     .#{$prefix}--leadspace__desc {
       @include carbon--type-style(expressive-heading-03, true);
       @include carbon--make-col(3, 4);
     }
 
     @include themed-items;
-  }
-
-  .#{$prefix}--btn {
-    min-width: carbon--mini-units($btn-min-width);
   }
 
   .#{$prefix}--leadspace--g100 {


### PR DESCRIPTION
### Related Ticket(s)

Button width for <CardArray /> pattern too wide #921

### Description

Need to scope min-width button style to within Leadspace only as it will affect other patterns.

<img width="652" alt="Screen Shot 2020-01-02 at 4 11 23 PM" src="https://user-images.githubusercontent.com/54281166/71693766-492af200-2d7b-11ea-8abb-02ab47d58faa.png">


### Changelog

**Changed**

- scope min-width style

