### PR TITLE
Image component new

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,11 +7,12 @@ exemptLabels:
   - 'severity 1'
   - 'priority: high'
   - 'epic'
+  - 'icebox'
 # Label to use when marking an issue as stale
 staleLabel: inactive
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  We've marked this issue as stale because there hasn't been any activity for 30 days.
+  We've marked this issue as stale because there hasn't been any activity for 60 days.
   If there's no further activity on this issue in the next three days then we'll close it. You can
   keep the conversation going with just a short comment. Thanks for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable

--- a/packages/patterns-react/src/internal/FeatureFlags.js
+++ b/packages/patterns-react/src/internal/FeatureFlags.js
@@ -77,6 +77,13 @@ export const DDS_CARDS_WITHOUT_IMAGES =
  */
 export const DDS_USECASES =
   process.env.DDS_USECASES === 'true' || DDS_FLAGS_ALL || false;
+/**
+ * This determines if the featuredlink will be rendered or not
+ *
+ * @type {string | boolean}
+ */
+export const DDS_FEATURED_LINK =
+  process.env.DDS_FEATURED_LINK === 'true' || DDS_FLAGS_ALL || false;
 
 /**
  * This determines if the simple overview will be rendered or not

--- a/packages/patterns-react/src/patterns/FeaturedLink/FeaturedLink.js
+++ b/packages/patterns-react/src/patterns/FeaturedLink/FeaturedLink.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { DDS_FEATURED_LINK } from '../../internal/FeatureFlags';
+import FeaturedLinkItem from './FeaturedLinkItem';
+import { ImageComponent } from '@carbon/ibmdotcom-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
+
+const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
+/**
+ * Featured Link Component
+ *
+ * @param {object} images props object
+ * @returns {*} FeaturedLink JSX component
+ */
+const sortImages = images => {
+  return [
+    {
+      minWidth: 1056,
+      url: images.default,
+    },
+    {
+      minWidth: 672,
+      url: images.tablet,
+    },
+    {
+      minWidth: 320,
+      url: images.mobile,
+    },
+  ];
+};
+
+/**
+ * Featured Link Component
+ *
+ * @param {object} props props object
+ * @param {string} props.title FeaturedLink section title
+ * @param {Array} props.content FeaturedLink section content object array
+ * @returns {*} FeaturedLink JSX component
+ */
+const FeaturedLink = ({ title, content, image }) => {
+  return featureFlag(
+    DDS_FEATURED_LINK,
+    <section
+      className={`${prefix}--featuredlink`}
+      data-autoid={`${stablePrefix}--featuredlink`}>
+      <div className={`${prefix}--featuredlink__container`}>
+        <div className={`${prefix}--featuredlink__row`}>
+          <div className={`${prefix}--featuredlink__col`}>
+            <h3 className={`${prefix}--featuredlink__title`}>{title}</h3>
+            <a href={content.link.href} target={content.link.target}>
+              <div className={`${prefix}--featuredlink__content`}>
+                {image && (
+                  <div className={`${prefix}--featuredlink__image-container`}>
+                    <ImageComponent
+                      images={sortImages(image)}
+                      defaultImage={image.default}
+                      alt={image.alt}
+                    />
+                  </div>
+                )}
+                <FeaturedLinkItem
+                  title={content.title}
+                  copy={content.copy}
+                  link={content.link}
+                />
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+FeaturedLink.propTypes = {
+  title: PropTypes.string.isRequired,
+  content: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      copy: PropTypes.string,
+      link: PropTypes.shape({
+        icon: PropTypes.string,
+        target: PropTypes.string,
+        href: PropTypes.string,
+      }),
+    })
+  ),
+};
+
+export default FeaturedLink;

--- a/packages/patterns-react/src/patterns/FeaturedLink/FeaturedLinkItem.js
+++ b/packages/patterns-react/src/patterns/FeaturedLink/FeaturedLinkItem.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { ArrowRight20 } from '@carbon/icons-react';
+import { Button } from 'carbon-components-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
+
+const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
+
+/**
+ * Featured Link Item Object
+ *
+ * @param {object} props props object
+ * @param {string} props.title Card Title
+ * @param {object} props.link Card link object
+ * @returns {*} JSX Featured Link Item Object
+ */
+const FeaturedLinkItem = ({ title, link }) => {
+  return (
+    <div
+      data-autoid={`${stablePrefix}--featuredlink-item`}
+      className={`${prefix}--featuredlink-item`}>
+      <h4 className={`${prefix}--featuredlink-item__title`}>{title}</h4>
+      <div className={`${prefix}--featuredlink-item__link`}>
+        <Button
+          className={`${prefix}--featuredlink-item__link__button`}
+          href={link.href}
+          target={link.target}
+          kind="primary">
+          <ArrowRight20 fill="white" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+FeaturedLinkItem.propTypes = {
+  title: PropTypes.string,
+  link: PropTypes.shape({
+    href: PropTypes.string,
+    target: PropTypes.string,
+  }),
+};
+
+export default FeaturedLinkItem;

--- a/packages/patterns-react/src/patterns/FeaturedLink/README.md
+++ b/packages/patterns-react/src/patterns/FeaturedLink/README.md
@@ -1,0 +1,108 @@
+# Featued Link Cards
+
+> The Featured Link Cards pattern is to be utilized within IBM.com.
+
+## Getting started
+
+Here's a quick example to get you started.
+
+```scss
+// yourapplication.scss
+@import '@carbon/type/scss/font-face/mono';
+@import '@carbon/type/scss/font-face/sans';
+@include carbon--font-face-mono();
+@include carbon--font-face-sans();
+
+@import '@carbon/ibmdotcom-styles/scss/patterns/featuredlink/index.scss';
+```
+
+> 💡 Only import font's once per usage
+
+```javascript
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { CardArray } from '@carbon/ibmdotcom-patterns-react';
+import 'yourapplication.scss';
+
+const title = 'Lorem ipsum dolor sit amet.';
+
+const content = [
+  {
+    title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    copy:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    link: {
+      target: '_blank',
+      href: 'https://www.example.com',
+    },
+  },
+];
+
+function App() {
+  return <FeaturedLink title={title} content={content} />;
+}
+
+ReactDOM.render(<App />, document.querySelector('#app'));
+```
+
+> 💡 Don't forget to import the Featured Link styles from
+> [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+#### Feature Flags
+
+To utilize the following features, set the following variable's to `true` within
+your `.env` file or your application build settings.
+
+```
+DDS_FEATURED_LINK=true
+```
+
+> See
+> [feature-flags.md](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/patterns-react/docs/feature-flags.md)
+> and
+> [.env.example](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/patterns-react/.env.example)
+> for more information
+
+## Props
+
+| Name      | Required | Data Type | Default Value | Description                                          |
+| --------- | -------- | --------- | ------------- | ---------------------------------------------------- |
+| `title`   | YES      | String    | n/a           | Main title of the pattern.                           |
+| `content` | NO       | Array     | null          | Array of content group objects. See `content` below. |
+| `image`   | NO       | object    | n/a           | An object. See `image` below.                        |
+
+### content
+
+| Name    | Data Type | Description                                                  |
+| ------- | --------- | ------------------------------------------------------------ |
+| `title` | String    | Title of the Content Card item.                              |
+| `copy`  | String    | Copy of the Content Card item.                               |
+| `link`  | Object    | Object containing target and href of link. See `link` below. |
+
+### link
+
+| Name     | Data Type | Description                                                 |
+| -------- | --------- | ----------------------------------------------------------- |
+| `target` | String    | Open within current tab or new tab ('\_self' or '\_blank'). |
+| `href`   | String    | Url of the Content Card item link.                          |
+
+## Stable selectors
+
+| Name                      | Description |
+| ------------------------- | ----------- |
+| `dds--featuredlink`       | Component   |
+| `dds--featuredlink-group` | Component   |
+| `dds--featuredlink-item`  | Component   |
+
+## 🙌 Contributing
+
+We're always looking for contributors to help us fix bugs, build new features,
+or help us improve the project documentation. If you're interested, definitely
+check out our
+[Contributing Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md)!
+👀
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/LICENSE).

--- a/packages/patterns-react/src/patterns/FeaturedLink/__stories__/FeaturedLink.stories.js
+++ b/packages/patterns-react/src/patterns/FeaturedLink/__stories__/FeaturedLink.stories.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import './index.scss';
+import { object, text, withKnobs } from '@storybook/addon-knobs';
+import { DDS_FEATURED_LINK } from '../../../internal/FeatureFlags';
+import FeaturedLink from '../FeaturedLink';
+import React from 'react';
+import readme from '../README.md';
+import { storiesOf } from '@storybook/react';
+
+if (DDS_FEATURED_LINK) {
+  storiesOf('Featured Links', module)
+    .addDecorator(withKnobs)
+    .addParameters({
+      readme: {
+        sidebar: readme,
+      },
+    })
+    .add('Default', () => {
+      const title = text(
+        'Pattern title(required):',
+        'How is artificial intelligence used today in your industry?'
+      );
+
+      const content = {
+        title: text('Card1 Title:', 'Explore AI use cases in all industries'),
+        link: {
+          target: text('Card1 link target:', '_blank'),
+          href: text('Card1 link href:', 'https://www.ibm.com'),
+        },
+      };
+
+      const images = {
+        mobile: 'https://picsum.photos/id/2/320/160',
+        tablet: 'https://picsum.photos/id/2/400/400',
+        default: 'https://picsum.photos/id/2/672/672',
+        alt: 'lead space image',
+      };
+
+      return (
+        <FeaturedLink
+          title={title}
+          content={content}
+          image={object('image', images)}
+        />
+      );
+    });
+}

--- a/packages/patterns-react/src/patterns/FeaturedLink/__stories__/index.scss
+++ b/packages/patterns-react/src/patterns/FeaturedLink/__stories__/index.scss
@@ -1,0 +1,1 @@
+@import '../../../../../styles/scss/patterns/FeaturedLink/index.scss';

--- a/packages/patterns-react/src/patterns/FeaturedLink/index.js
+++ b/packages/patterns-react/src/patterns/FeaturedLink/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as FeaturedLink } from './FeaturedLink';

--- a/packages/patterns-react/src/patterns/index.js
+++ b/packages/patterns-react/src/patterns/index.js
@@ -7,6 +7,7 @@
 
 export * from './CardArray';
 export * from './CardsWithoutImages';
+export * from './FeaturedLink';
 export * from './LeadSpace';
 export * from './LeadSpaceCentered';
 export * from './ListSection';

--- a/packages/react/src/components/ImageComponent/ImageComponent.js
+++ b/packages/react/src/components/ImageComponent/ImageComponent.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { settings } from 'carbon-components';
+
+const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
+
+/**
+ *  sorts media query min-widths order to ensure the
+ * browser returns the proper sources and the specified widths
+ *
+ * @param {Array} sources image sources and min-widths
+ *
+ * @returns {Array} sorted array of sources
+ */
+const sortSources = sources => {
+  return sources.sort((a, b) => (a.minWidth > b.minWidth ? -1 : 1));
+};
+
+/**
+ * renders background image
+ *
+ * @param {object} props props object
+ * @param {object} props.images array of images used for diff breakpoints
+ * @param {string} props.defaultImage default image (usually image for largest breakpoint)
+ * @param {string} props.alt alt of the image
+ * @returns {*} picture element
+ */
+const Image = ({ images, defaultImage, alt }) => {
+  const sortedImages = sortSources(images);
+
+  return (
+    <picture data-autoid={`${stablePrefix}--imagecomponent`}>
+      {sortedImages.map((imgSrc, key) => {
+        return <source key={key} srcSet={imgSrc.url} />;
+      })}
+      <img
+        className={`${prefix}--imagecomponent__image`}
+        src={defaultImage}
+        alt={alt}
+      />
+    </picture>
+  );
+};
+
+Image.propTypes = {
+  images: PropTypes.arrayOf(
+    PropTypes.shape({
+      minWidth: PropTypes.number,
+      url: PropTypes.string,
+    })
+  ),
+  defaultImage: PropTypes.string,
+  alt: PropTypes.string,
+};
+
+export default Image;

--- a/packages/react/src/components/ImageComponent/__stories__/ImageComponent.stories.js
+++ b/packages/react/src/components/ImageComponent/__stories__/ImageComponent.stories.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import './index.scss';
+import { object, text, withKnobs } from '@storybook/addon-knobs';
+import ImageComponent from '../ImageComponent';
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+storiesOf('ImageComponent', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    const defaultImages = text(
+      'Default image:',
+      'https://picsum.photos/id/2/672/672'
+    );
+    const imageObject = object('Images Object:', [
+      'https://picsum.photos/id/2/320/160',
+      'https://picsum.photos/id/2/400/400',
+      'https://picsum.photos/id/2/672/672',
+    ]);
+    const alt = text('alt', 'lead space image');
+
+    return (
+      <ImageComponent
+        defaultImage={defaultImages}
+        images={imageObject}
+        alt={alt}></ImageComponent>
+    );
+  });

--- a/packages/react/src/components/ImageComponent/__stories__/index.scss
+++ b/packages/react/src/components/ImageComponent/__stories__/index.scss
@@ -1,0 +1,6 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/react/src/components/ImageComponent/index.js
+++ b/packages/react/src/components/ImageComponent/index.js
@@ -1,0 +1,7 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export { default as ImageComponent } from './ImageComponent';

--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -4,17 +4,17 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import React from 'react';
-import PropTypes from 'prop-types';
+import {
+  settings as ddsSettings,
+  featureFlag,
+} from '@carbon/ibmdotcom-utilities';
+import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../internal/FeatureFlags';
 import { ExpressiveModal } from '../ExpressiveModal';
 import { ModalBody } from 'carbon-components-react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
-import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../internal/FeatureFlags';
-import {
-  featureFlag,
-  settings as ddsSettings,
-} from '@carbon/ibmdotcom-utilities';
+
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 

--- a/packages/react/src/components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js
+++ b/packages/react/src/components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js
@@ -1,11 +1,10 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, text, object, boolean } from '@storybook/addon-knobs';
+import './index.scss';
+import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../../internal/FeatureFlags';
 import LightboxMediaViewer from '../LightboxMediaViewer';
+import React from 'react';
 import readme from '../README.md';
-
-import './index.scss';
+import { storiesOf } from '@storybook/react';
 
 if (DDS_LIGHTBOX_MEDIA_VIEWER) {
   storiesOf('LightboxMediaViewer', module)

--- a/packages/react/src/components/index.js
+++ b/packages/react/src/components/index.js
@@ -18,3 +18,4 @@ export * from './Layout';
 export * from './ExpressiveModal';
 export * from './carbon-components-react/UIShell';
 export * from './TableOfContents';
+export * from './ImageComponent';

--- a/packages/react/src/internal/FeatureFlags.js
+++ b/packages/react/src/internal/FeatureFlags.js
@@ -46,3 +46,11 @@ export const DDS_TOC = process.env.DDS_TOC === 'true' || DDS_FLAGS_ALL || false;
  */
 export const DDS_LIGHTBOX_MEDIA_VIEWER =
   process.env.DDS_LIGHTBOX_MEDIA_VIEWER === 'true' || DDS_FLAGS_ALL || false;
+
+/**
+ * This determines the image component will be rendered or not
+ *
+ * @type {string | boolean}
+ */
+export const DDS_IMAGE_COMPONENT =
+  process.env.DDS_IMAGE_COMPONENT === 'true' || DDS_FLAGS_ALL || false;

--- a/packages/styles/scss/components/imagecomponent/_imagecomponent.scss
+++ b/packages/styles/scss/components/imagecomponent/_imagecomponent.scss
@@ -1,0 +1,19 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../globals/imports';
+
+@mixin image-component {
+  .#{$prefix}--imagecomponent__image {
+    height: auto;
+    width: 100%;
+  }
+}
+
+@include exports('image-component') {
+  @include image-component;
+}

--- a/packages/styles/scss/ibm-dotcom-styles.scss
+++ b/packages/styles/scss/ibm-dotcom-styles.scss
@@ -24,6 +24,7 @@
 
 // Patterns
 @import 'patterns/cardarray/cardarray';
+@import 'patterns/featuredlink/featuredlink';
 @import 'patterns/leadspace/leadspace';
 @import 'patterns/leadspace-centered/leadspace-centered';
 @import 'patterns/listsection/listsection';

--- a/packages/styles/scss/patterns/FeaturedLink/README.md
+++ b/packages/styles/scss/patterns/FeaturedLink/README.md
@@ -1,0 +1,36 @@
+### SCSS
+
+#### Usage
+
+Import the package css into the top of your main CSS file.
+
+```css
+@import '@carbon/ibmdotcom-styles/scss/patterns/featuredlink/index';
+```
+
+#### Elements
+
+| Class                          | Description                          |
+| ------------------------------ | ------------------------------------ |
+| `.bx--featuredlink__container` | Element containing all featured link |
+
+                                            section content
+
+| `.bx--featuredlink__row` | Vertical divisions across the viewport | |
+`.bx--featuredlink__col` | Horizonal divisions across the viewport and change in
+width at different screen widths | | `.bx--featuredlink__title` | Title for
+featured link section pattern | | `.bx--featuredlink__divider_col` | Horizonal
+division for divider element | | `.bx--featuredlink__divider` | Divider element
+| | `.bx--featuredlink-item__title` | featured link item title element | |
+`.bx--featuredlink-item__content` | featured link item content element | |
+`.bx--featuredlink-item__link` | featured link item Link element | |
+`.bx--featuredlink-item__link__button` | featured link item Link button element
+|
+
+#### Blocks
+
+| Class                     | Description                                            |
+| ------------------------- | ------------------------------------------------------ |
+| `.bx--featuredlink`       | Highest level class name for the featured link pattern |
+| `.bx--featuredlink-group` | featured link section group component class            |
+| `.bx--featuredlink-item`  | featured link item component class                     |

--- a/packages/styles/scss/patterns/FeaturedLink/_featuredlink-item.scss
+++ b/packages/styles/scss/patterns/FeaturedLink/_featuredlink-item.scss
@@ -1,0 +1,76 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../components/link-with-icon/link-with-icon';
+
+@mixin aspect-ratio($width, $height) {
+  position: relative;
+  &::before {
+    display: block;
+    content: '';
+    width: 100%;
+    padding-top: ($height / $width) * 100%;
+  }
+  > * {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    right: 0;
+    bottom: 0;
+  }
+}
+
+@mixin featuredlink-item {
+  .#{$prefix}--featuredlink-item {
+    padding-top: $carbon--layout-01;
+    padding-left: $carbon--layout-01;
+    background: $ui-05;
+    display: flex;
+    flex-direction: column;
+
+    @include carbon--breakpoint('sm') {
+      @include aspect-ratio(2, 1);
+    }
+
+    @include carbon--breakpoint('md') {
+      @include aspect-ratio(1, 1);
+
+      width: 50%;
+    }
+
+    @include carbon--breakpoint-down('lg') {
+      flex: 0 50%;
+    }
+
+    &__title {
+      margin-bottom: $carbon--layout-03;
+      width: 90%;
+      max-width: 640px;
+      color: $text-04;
+      @include carbon--type-style('heading-02');
+    }
+    &__content {
+      margin-bottom: $carbon--layout-03;
+      width: 90%;
+      max-width: 640px;
+      @include carbon--type-style('heading-02');
+    }
+    &__link {
+      display: flex;
+      justify-content: flex-end;
+      flex-grow: 1;
+      &__button.bx--btn {
+        min-width: 0;
+        padding-right: $carbon--spacing-05;
+        align-self: flex-end;
+      }
+    }
+  }
+}
+@include exports('featuredlink-item') {
+  @include featuredlink-item;
+}

--- a/packages/styles/scss/patterns/FeaturedLink/_featuredlink.scss
+++ b/packages/styles/scss/patterns/FeaturedLink/_featuredlink.scss
@@ -1,0 +1,100 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@mixin aspect-ratio($width, $height) {
+  position: relative;
+  &::before {
+    display: block;
+    content: '';
+    width: 100%;
+    padding-top: ($height / $width) * 100%;
+  }
+  > * {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+}
+
+@mixin featuredlink {
+  .#{$prefix}--featuredlink {
+    color: $text-01;
+    background: $ui-background;
+    display: flex;
+
+    a {
+      text-decoration: none;
+    }
+
+    &__content {
+      display: flex;
+      flex-direction: column;
+    }
+
+    &__container {
+      @include carbon--make-container;
+    }
+
+    &__row {
+      @include carbon--make-row;
+    }
+
+    &__col {
+      @include carbon--make-col-ready;
+    }
+
+    &__title {
+      @include carbon--type-style('expressive-heading-04');
+
+      margin-top: $carbon--spacing-07;
+      margin-bottom: $carbon--spacing-07;
+    }
+    @include carbon--breakpoint('sm') {
+      &__image-container {
+        margin-bottom: -2px;
+        @include aspect-ratio(2, 1);
+      }
+      &-item {
+        @include aspect-ratio(2, 1);
+      }
+      &__title {
+        margin-top: $carbon--spacing-07;
+        margin-bottom: $carbon--spacing-10;
+      }
+    }
+    @include carbon--breakpoint('md') {
+      &__content {
+        justify-content: center;
+        flex-direction: row;
+      }
+
+      &__image-container {
+        width: 50%;
+      }
+
+      &__title {
+        margin: $carbon--layout-03 0 $carbon--layout-05 0;
+        @include carbon--make-col(6, 8);
+      }
+    }
+    @include carbon--breakpoint('lg') {
+      &__col {
+        @include carbon--make-col(16, 16);
+      }
+      &__title {
+        @include carbon--make-col(10, 16);
+
+        margin-bottom: $carbon--layout-04;
+      }
+    }
+  }
+}
+@include exports('featuredlink') {
+  @include featuredlink;
+}

--- a/packages/styles/scss/patterns/FeaturedLink/index.scss
+++ b/packages/styles/scss/patterns/FeaturedLink/index.scss
@@ -1,0 +1,11 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../globals/imports';
+@import './featuredlink';
+@import './featuredlink-item';
+@import '../../components/imagecomponent/_imagecomponent';


### PR DESCRIPTION
(Please Review the files from second commit).
THIS PR IS A COMPANION PR FOR THE FEATURED LINK [FEATURED LINK PATTERN](https://github.com/carbon-design-system/ibm-dotcom-library/pull/852). SHOULD BE REVIEWED ALONG WITH  [FEATURED LINK PATTERN](https://github.com/carbon-design-system/ibm-dotcom-library/pull/852)

### Related Tickets 

[FEATURED LINK PATTERN](https://github.com/carbon-design-system/ibm-dotcom-library/pull/852)

### Description

Creation of the reusable component for the image component.

<img width="1431" alt="Screen Shot 2020-01-06 at 11 24 06 AM" src="https://user-images.githubusercontent.com/12287070/71831534-16347700-3077-11ea-89c1-d51b2ba00d9b.png">


