### PR TITLE
fix(lint): fixed alphabertic imports on lightbox

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import {
+  settings as ddsSettings,
+  featureFlag,
+} from '@carbon/ibmdotcom-utilities';
+import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../internal/FeatureFlags';
 import { ExpressiveModal } from '../ExpressiveModal';
 import { ModalBody } from 'carbon-components-react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
-import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../internal/FeatureFlags';
-import {
-  featureFlag,
-  settings as ddsSettings,
-} from '@carbon/ibmdotcom-utilities';
+
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 

--- a/packages/react/src/components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js
+++ b/packages/react/src/components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { withKnobs, text, object, boolean } from '@storybook/addon-knobs';
+import './index.scss';
+
+import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../../internal/FeatureFlags';
 import LightboxMediaViewer from '../LightboxMediaViewer';
+import React from 'react';
 import readme from '../README.md';
-
-import './index.scss';
+import { storiesOf } from '@storybook/react';
 
 if (DDS_LIGHTBOX_MEDIA_VIEWER) {
   storiesOf('LightboxMediaViewer', module)


### PR DESCRIPTION
### Description

As I was receiving linting issues after rebasing one of my branches to master, I've fixed the errors by sorting the imports for the Lightbox component.

### Changelog

**Changed**

- Sorted imports alphabetically

