### PR TITLE
fix(expressive): rename combobox file to match config syntax

### DIFF
--- a/packages/styles/src/carbon-stories/ComboBox/ComboBox-story.js
+++ b/packages/styles/src/carbon-stories/ComboBox/ComboBox-story.js
@@ -86,12 +86,12 @@ const ControlledComboBoxApp = props => {
     </>
   );
 };
-ControlledComboBoxApp.__docgenInfo = {
-  ...ComboBox.__docgenInfo,
-  props: {
-    ...ComboBox.__docgenInfo.props,
-  },
-};
+// ControlledComboBoxApp.__docgenInfo = {
+//   ...ComboBox.__docgenInfo,
+//   props: {
+//     ...ComboBox.__docgenInfo.props,
+//   },
+// };
 
 storiesOf('ComboBox', module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
### Related Ticket(s)


### Description

ComboBox story isn't currently showing as the config file is loading stories with files ending in 
`-story.js` 

Commenting out `docgen` for now as it is causing issues with rendering the story.

### Changelog

**Changed**

- Renamed ComboBox story file to match what the config is expecting
- commented out `docgen` code


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
