### PR TITLE
fix(markdown-utility): make converter be opt-out

### DIFF
--- a/packages/utilities/src/utilities/markdownToHtml/__tests__/markdownToHtml.js
+++ b/packages/utilities/src/utilities/markdownToHtml/__tests__/markdownToHtml.js
@@ -14,13 +14,13 @@ describe('Markdown converter utility', () => {
   });
 
   it('return the converted string with italic', () => {
-    const output = markdownToHtml(str, { italic: true });
+    const output = markdownToHtml(str, { bold: false });
     const expected = `This is <em class="${prefix}--type-light">italic</em> and **bold**.`;
     expect(output).toBe(expected);
   });
 
   it('return the converted string with bold', () => {
-    const output = markdownToHtml(str, { bold: true });
+    const output = markdownToHtml(str, { italic: false });
     const expected = `This is _italic_ and <strong class="${prefix}--type-semibold">bold</strong>.`;
     expect(output).toBe(expected);
   });

--- a/packages/utilities/src/utilities/markdownToHtml/markdownToHtml.js
+++ b/packages/utilities/src/utilities/markdownToHtml/markdownToHtml.js
@@ -37,10 +37,10 @@ const _fixDoubleSpaces = str => str.replace(_doubleSpaceRegex, ' ');
  *
  * @param {string} str String to convert to html
  * @param {object} [options={}] Object with options for the conversion
- * @param {boolean} [options.italic=false] Defines if should convert italic
- * @param {boolean} [options.bold=false] Defines if should convert bold
- * @param {boolean} [options.allowHtml=false] Defines if should allow or remove html tags
+ * @param {boolean} [options.italic=true] Defines if should convert italic
+ * @param {boolean} [options.bold=true] Defines if should convert bold
  * @param {boolean} [options.useCarbonClasses=true] Defines if should use carbon typography classes
+ * @param {boolean} [options.allowHtml=false] Defines if should allow or remove html tags
  * @returns {string} String converted to html
  * @example
  * import { markdownToHtml } from '@carbon/ibmdotcom-utilities';
@@ -51,16 +51,15 @@ const _fixDoubleSpaces = str => str.replace(_doubleSpaceRegex, ' ');
 function markdownToHtml(
   str,
   {
-    italic = false,
-    bold = false,
-    allowHtml = false,
+    italic = true,
+    bold = true,
     useCarbonClasses = true,
+    allowHtml = false,
   } = {}
 ) {
-  const isAllStyles = !italic && !bold;
   let converted = allowHtml ? str : _removeHtmlTags(str);
 
-  if (italic || isAllStyles) {
+  if (italic) {
     converted = converted.replace(_italicRegex, (match, p1) => {
       if (!p1.length) {
         return match;
@@ -70,7 +69,8 @@ function markdownToHtml(
         : `<em>${p1}</em>`;
     });
   }
-  if (bold || isAllStyles) {
+
+  if (bold) {
     converted = converted.replace(_boldRegex, (match, p1) => {
       return useCarbonClasses
         ? `<strong class="${prefix}--type-semibold">${p1}</strong>`


### PR DESCRIPTION
### Description

Make markdown-to-html converter have markdown syntaxes parameters be opt-out instead of opt-in

### Changelog

**Changed**

- Make markdown-to-html utility function have default markdown syntaxes parameters as `true` and have it be manually turned of if needed by the user.

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
