### PR TITLE
feat(expressive): search expressive theme

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_search.scss
+++ b/packages/styles/scss/themes/expressive/components/_search.scss
@@ -1,0 +1,30 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/layout/scss/convert';
+
+//-----------------------------
+// Search (expressive)
+//-----------------------------
+
+/// Search styles (expressive)
+/// @access private
+/// @group search-expressive
+@mixin search-expressive {
+  .#{$prefix}--search svg {
+    height: carbon--rem(20px);
+    width: carbon--rem(20px);
+  }
+
+  .#{$prefix}--search--lg .#{$prefix}--search-input {
+    height: $carbon--spacing-09;
+  }
+
+  .#{$prefix}--search--sm .#{$prefix}--search-input {
+    height: $carbon--spacing-08;
+  }
+}

--- a/packages/styles/scss/themes/expressive/index.scss
+++ b/packages/styles/scss/themes/expressive/index.scss
@@ -22,6 +22,7 @@
 @import 'components/text-input';
 @import 'components/tile';
 @import 'components/time-picker';
+@import 'components/search';
 @import 'components/select';
 
 //-------------------------
@@ -49,6 +50,7 @@
     @include text-input-expressive;
     @include tile-expressive;
     @include time-picker-expressive;
+    @include search-expressive;
     @include select-expressive;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Expressive theme – Search #956

### Description

increase search bar icons to fit expressive theme

### Changelog

**Changed**

- set icons to 20x20 and increase search input bar height

<img width="1640" alt="Screen Shot 2020-01-09 at 3 36 56 PM" src="https://user-images.githubusercontent.com/54281166/72102904-0d050d80-32f6-11ea-867f-00d20b80fc5c.png">

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
