### PR TITLE
feat(cloud): adding cloud foundry manifest files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you are building pages for IBM.com,
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibmdotcom.netlify.com)
+- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
   for full how-to docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.

--- a/packages/patterns-react/README.md
+++ b/packages/patterns-react/README.md
@@ -63,7 +63,7 @@ information in several ways:
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibmdotcom.netlify.com)
+- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
   for full how-to docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.

--- a/packages/patterns-react/manifest-experimental.yml
+++ b/packages/patterns-react/manifest-experimental.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-patterns-react-experimental
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-patterns-react-experimental.mybluemix.net
+      - route: ibmdotcom-patterns-react-experimental-temp.mybluemix.net
+

--- a/packages/patterns-react/manifest.yml
+++ b/packages/patterns-react/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ibmdotcom-patterns-react
-    path: ./public
+    path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:

--- a/packages/patterns-react/manifest.yml
+++ b/packages/patterns-react/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-patterns-react
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-patterns-react.mybluemix.net
+      - route: ibmdotcom-patterns-react-temp.mybluemix.net
+

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,7 +62,7 @@ can see usage information in several ways:
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibmdotcom.netlify.com)
+- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
   for full how-to docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.

--- a/packages/react/manifest-experimental.yml
+++ b/packages/react/manifest-experimental.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-react-experimental
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-react-experimental.mybluemix.net
+      - route: ibmdotcom-react-experimental-temp.mybluemix.net
+

--- a/packages/react/manifest-experimental.yml
+++ b/packages/react/manifest-experimental.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ibmdotcom-react-experimental
-    path: ./public
+    path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:

--- a/packages/react/manifest.yml
+++ b/packages/react/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-react
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-react.mybluemix.net
+      - route: ibmdotcom-react-temp.mybluemix.net
+

--- a/packages/react/manifest.yml
+++ b/packages/react/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ibmdotcom-react
-    path: ./public
+    path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -28,7 +28,7 @@ View available services [here](https://ibmdotcom-services.netlify.com/).
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibmdotcom.netlify.com)
+- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
   for full how-to docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.

--- a/packages/services/manifest.yml
+++ b/packages/services/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ibmdotcom-services
-    path: ./public
+    path: ./docs
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:

--- a/packages/services/manifest.yml
+++ b/packages/services/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-services
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-services.mybluemix.net
+      - route: ibmdotcom-services-temp.mybluemix.net
+

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -50,7 +50,7 @@ This can also be viewed in our
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibmdotcom.netlify.com)
+- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
   for full how-to docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.

--- a/packages/styles/manifest.yml
+++ b/packages/styles/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: carbon-expressive
-    path: ./public
+    path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:

--- a/packages/styles/manifest.yml
+++ b/packages/styles/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: carbon-expressive
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: carbon-expressive.mybluemix.net
+      - route: carbon-expressive-temp.mybluemix.net
+

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -28,7 +28,7 @@ View available utilities [here](https://ibmdotcom-utilities.netlify.com/).
 
 ## Documentation
 
-- See our documentation site [here](https://carbon-for-ibmdotcom.netlify.com)
+- See our documentation site [here](https://ibm-dotcom-library.mybluemix.net)
   for full how-to docs and guidelines
 - [Contributing](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md):
   Guidelines for making contributions to this repo.

--- a/packages/utilities/manifest.yml
+++ b/packages/utilities/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ibmdotcom-utilities
-    path: ./public
+    path: ./docs
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:

--- a/packages/utilities/manifest.yml
+++ b/packages/utilities/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-utilities
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-utilities.mybluemix.net
+      - route: ibmdotcom-utilities-temp.mybluemix.net
+

--- a/packages/vanilla/manifest.yml
+++ b/packages/vanilla/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: ibmdotcom-vanilla
+    path: ./public
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    routes:
+      - route: ibmdotcom-vanilla.mybluemix.net
+      - route: ibmdotcom-vanilla-temp.mybluemix.net
+

--- a/packages/vanilla/manifest.yml
+++ b/packages/vanilla/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ibmdotcom-vanilla
-    path: ./public
+    path: ./storybook-static
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     routes:


### PR DESCRIPTION
### Related Ticket(s)

#966 Moving master builds to IBM Cloud

### Description

This adds a number of manifest files necessary for the deployments of master branch to IBM Cloud.

### Changelog

**New**

- IBM Cloud manifest files 

**Changed**

- Updates to URLs from Netlify for the Cupcake website