### PR TITLE
fix(image): properly linking the Image README to storybook

### DIFF
--- a/packages/patterns-react/src/patterns/FeaturedLink/__stories__/FeaturedLink.stories.js
+++ b/packages/patterns-react/src/patterns/FeaturedLink/__stories__/FeaturedLink.stories.js
@@ -13,7 +13,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_FEATURED_LINK) {
-  storiesOf('Featured Links', module)
+  storiesOf('Featured Link', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/react/src/components/Image/__stories__/Image.stories.js
+++ b/packages/react/src/components/Image/__stories__/Image.stories.js
@@ -8,10 +8,16 @@ import './index.scss';
 import { object, text, withKnobs } from '@storybook/addon-knobs';
 import Image from '../Image';
 import React from 'react';
+import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 storiesOf('Image', module)
   .addDecorator(withKnobs)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
   .add('Default', () => {
     const imageObject = object('Images Object:', [
       { src: 'https://picsum.photos/id/2/320/160', minWidth: 320 },


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

The `Image` component in storybook was missing the README, this fixes this.

### Changelog

**Changed**

- README added to `Image` storybook