### PR TITLE
fix(expressive): uncomment default DataTable story

### DIFF
--- a/packages/styles/src/carbon-stories/DataTable/DataTable-story.js
+++ b/packages/styles/src/carbon-stories/DataTable/DataTable-story.js
@@ -24,9 +24,10 @@ const props = () => ({
 
 storiesOf('DataTable', module)
   .addDecorator(withKnobs)
-  /*.add('default', {
+  .add('default', 
+  withReadme(readme, () => require('./stories/default').default(props())),
+  {
     info: {
-      /!* eslint-disable no-useless-escape *!/
       text: `
           Data Tables are used to represent a collection of resources, displaying a
           subset of their fields in columns, or headers. The \`DataTable\` component
@@ -35,9 +36,8 @@ storiesOf('DataTable', module)
           You can find more detailed information surrounding usage of this component
           at the following url: ${readmeURL}
         `,
-      /!* eslint-enable no-useless-escape *!/
     },
-  })*/
+  })
   .add(
     'with toolbar',
     withReadme(readme, () =>


### PR DESCRIPTION
### Related Ticket(s)

Review Data table #940

### Description

`default` story for DataTable carbon component was commented out. Uncommenting and adding related README.

### Changelog


**Changed**

- uncommented `default` story and added associate readme 


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
