### PR TITLE
feat(storybook): breaking out sections in storybook

### DIFF
--- a/packages/patterns-react/src/patterns/CardArray/__stories__/CardArray.stories.js
+++ b/packages/patterns-react/src/patterns/CardArray/__stories__/CardArray.stories.js
@@ -7,7 +7,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_CARD_ARRAY) {
-  storiesOf('CardArray', module)
+  storiesOf('Blocks|CardArray', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/CardSection/__stories__/CardSection.stories.js
+++ b/packages/patterns-react/src/patterns/CardSection/__stories__/CardSection.stories.js
@@ -5,133 +5,12 @@ import { DDS_CARD_SECTION } from '../../../internal/FeatureFlags';
 import ImageCards from '../ImageCards';
 import React from 'react';
 import SimpleCards from '../SimpleCards';
+import cards from './data/cards.json';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
-const cardsGroup = {
-  simpleCards: [
-    {
-      title: 'Nunc convallis lobortis',
-      copy:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      title: 'Fusce gravida eu arcu',
-      copy:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      title: 'Interdum et malesuada',
-      copy:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      title: 'Nunc convallis loborti',
-      copy:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      title: 'Nunc convallis lbortis',
-      copy:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-  ],
-  imageCards: [
-    {
-      image: {
-        defaultImage: 'https://picsum.photos/id/1003/1056/480',
-        alt: 'cards with image',
-      },
-      title: 'Topic',
-      copy: 'Natural language processing.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      image: {
-        defaultImage: 'https://picsum.photos/id/1018/1056/480',
-        alt: 'cards with image',
-      },
-      title: 'Blog',
-      copy: 'Natural language processing.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      image: {
-        defaultImage: 'https://picsum.photos/id/1076/1056/480',
-        alt: 'cards with image',
-      },
-      title: 'Topic',
-      copy: 'Natural language processing.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      image: {
-        defaultImage: 'https://picsum.photos/id/102/1056/480',
-        alt: 'cards with image',
-      },
-      title: 'Blog',
-      copy: 'Serving society ethically in the age of Artificial Intelligence.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-    {
-      image: {
-        defaultImage: 'https://picsum.photos/id/1032/1056/480',
-        alt: 'cards with image',
-      },
-      title: 'Topic',
-      copy: 'Serving society ethically in the age of Artificial Intelligence.',
-      link: {
-        href: 'https://www.example.com',
-        text: 'Learn more',
-        target: '_self',
-      },
-    },
-  ],
-};
-
 if (DDS_CARD_SECTION) {
-  storiesOf('CardSection', module)
+  storiesOf('Sub-Patterns|CardSection', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {
@@ -140,7 +19,7 @@ if (DDS_CARD_SECTION) {
     })
 
     .add('default', () => {
-      const cardTypes = Object.keys(cardsGroup);
+      const cardTypes = Object.keys(cards);
       const themes = {
         white: '',
         g10: 'g10',
@@ -153,21 +32,28 @@ if (DDS_CARD_SECTION) {
           ? 'Aliquam condimentum interdum'
           : 'Read more about it';
 
-      const data = object(`Data (${type})`, cardsGroup[type]);
+      const data = object(`Data (${type})`, cards[type]);
 
-      cardsGroup[type] = data;
+      cards[type] = data;
 
       return (
         <CardSection
           title={cardsTitle}
-          cards={cardsGroup[type]}
+          cards={cards[type]}
           data={data}
           theme={theme}
         />
       );
-    })
+    });
 
-    .add('SimpleCards', () => {
+  storiesOf('Sections|CardSectionSimple', module)
+    .addDecorator(withKnobs)
+    .addParameters({
+      readme: {
+        sidebar: readme,
+      },
+    })
+    .add('defauilt', () => {
       const themes = {
         g10: 'g10',
         white: '',
@@ -176,13 +62,20 @@ if (DDS_CARD_SECTION) {
       return (
         <SimpleCards
           title="Aliquam condimentum interdum"
-          cards={object('Data', cardsGroup.simpleCards)}
+          cards={object('Data', cards.simpleCards)}
           theme={select('theme', themes, themes.g10)}
         />
       );
-    })
+    });
 
-    .add('ImageCards', () => {
+  storiesOf('Sections|CardSectionImages', module)
+    .addDecorator(withKnobs)
+    .addParameters({
+      readme: {
+        sidebar: readme,
+      },
+    })
+    .add('default', () => {
       const themes = {
         g10: 'g10',
         white: '',
@@ -191,7 +84,7 @@ if (DDS_CARD_SECTION) {
       return (
         <ImageCards
           title="Read more about it"
-          cards={object('Data', cardsGroup.imageCards)}
+          cards={object('Data', cards.imageCards)}
           theme={select('theme', themes, themes.g10)}
         />
       );

--- a/packages/patterns-react/src/patterns/CardSection/__stories__/data/cards.json
+++ b/packages/patterns-react/src/patterns/CardSection/__stories__/data/cards.json
@@ -1,0 +1,116 @@
+{
+  "simpleCards": [
+    {
+      "title": "Nunc convallis lobortis",
+      "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "title": "Fusce gravida eu arcu",
+      "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "title": "Interdum et malesuada",
+      "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "title": "Nunc convallis loborti",
+      "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "title": "Nunc convallis lbortis",
+      "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    }
+  ],
+  "imageCards": [
+    {
+      "image": {
+        "defaultImage": "https://picsum.photos/id/1003/1056/480",
+        "alt": "cards with image"
+      },
+      "title": "Topic",
+      "copy": "Natural language processing.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "image": {
+        "defaultImage": "https://picsum.photos/id/1018/1056/480",
+        "alt": "cards with image"
+      },
+      "title": "Blog",
+      "copy": "Natural language processing.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "image": {
+        "defaultImage": "https://picsum.photos/id/1076/1056/480",
+        "alt": "cards with image"
+      },
+      "title": "Topic",
+      "copy": "Natural language processing.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "image": {
+        "defaultImage": "https://picsum.photos/id/102/1056/480",
+        "alt": "cards with image"
+      },
+      "title": "Blog",
+      "copy": "Serving society ethically in the age of Artificial Intelligence.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    },
+    {
+      "image": {
+        "defaultImage": "https://picsum.photos/id/1032/1056/480",
+        "alt": "cards with image"
+      },
+      "title": "Topic",
+      "copy": "Serving society ethically in the age of Artificial Intelligence.",
+      "link": {
+        "href": "https://www.example.com",
+        "text": "Learn more",
+        "target": "_self"
+      }
+    }
+  ]
+}

--- a/packages/patterns-react/src/patterns/FeaturedLink/__stories__/FeaturedLink.stories.js
+++ b/packages/patterns-react/src/patterns/FeaturedLink/__stories__/FeaturedLink.stories.js
@@ -13,7 +13,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_FEATURED_LINK) {
-  storiesOf('Featured Link', module)
+  storiesOf('Blocks|Feature Card', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/patterns-react/src/patterns/LeadSpace/__stories__/LeadSpace.stories.js
@@ -14,7 +14,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_LEADSPACE) {
-  storiesOf('LeadSpace', module)
+  storiesOf('Sections|LeadSpace', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/LeadSpaceCentered/__stories__/LeadSpaceCentered.stories.js
+++ b/packages/patterns-react/src/patterns/LeadSpaceCentered/__stories__/LeadSpaceCentered.stories.js
@@ -14,7 +14,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_LEADSPACE_CENTERED) {
-  storiesOf('LeadSpace - Centered', module)
+  storiesOf('Sections|LeadSpace - Centered', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/ListSection/__stories__/ListSection.stories.js
+++ b/packages/patterns-react/src/patterns/ListSection/__stories__/ListSection.stories.js
@@ -13,7 +13,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_LISTSECTION) {
-  storiesOf('List Section', module)
+  storiesOf('Sections|List Section', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/LogoGrid/__stories__/LogoGrid.stories.js
+++ b/packages/patterns-react/src/patterns/LogoGrid/__stories__/LogoGrid.stories.js
@@ -3,59 +3,12 @@ import { object, select, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_LOGO_GRID } from '../../../internal/FeatureFlags';
 import LogoGrid from '../LogoGrid';
 import React from 'react';
+import logos from './data/logos.json';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
-const logosGroup = [
-  {
-    label: 'Company A',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company B',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company C',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company D',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company E',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company F',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company G',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company H',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-  {
-    label: 'Company I',
-    imgSrc: 'https://via.placeholder.com/140',
-    altText: 'placeholder',
-  },
-];
-
 if (DDS_LOGO_GRID) {
-  storiesOf('LogoGrid', module)
+  storiesOf('Blocks|LogoGrid', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {
@@ -74,7 +27,7 @@ if (DDS_LOGO_GRID) {
       return (
         <LogoGrid
           title={title}
-          logosGroup={object('Data', logosGroup)}
+          logosGroup={object('Data', logos)}
           theme={select('theme', themes, themes.g10)}
         />
       );

--- a/packages/patterns-react/src/patterns/LogoGrid/__stories__/data/logos.json
+++ b/packages/patterns-react/src/patterns/LogoGrid/__stories__/data/logos.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "Company A",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company B",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company C",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company D",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company E",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company F",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company G",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company H",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  },
+  {
+    "label": "Company I",
+    "imgSrc": "https://via.placeholder.com/140",
+    "altText": "placeholder"
+  }
+]

--- a/packages/patterns-react/src/patterns/PictogramArray/__stories__/PictogramArray.stories.js
+++ b/packages/patterns-react/src/patterns/PictogramArray/__stories__/PictogramArray.stories.js
@@ -8,7 +8,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_PICTOGRAM_ARRAY) {
-  storiesOf('PictogramArray', module)
+  storiesOf('Blocks|PictogramArray', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/SimpleBenefits/__stories__/SimpleBenefits.stories.js
+++ b/packages/patterns-react/src/patterns/SimpleBenefits/__stories__/SimpleBenefits.stories.js
@@ -7,7 +7,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_SIMPLEBENEFITS) {
-  storiesOf('Simple Benefits', module)
+  storiesOf('Sections|Simple Benefits', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/SimpleLongForm/__stories__/SimpleLongForm.stories.js
+++ b/packages/patterns-react/src/patterns/SimpleLongForm/__stories__/SimpleLongForm.stories.js
@@ -13,7 +13,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_SIMPLELONGFORM) {
-  storiesOf('Simple Long Form', module)
+  storiesOf('Blocks|Simple Long Form', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/SimpleOverview/__stories__/SimpleOverview.stories.js
+++ b/packages/patterns-react/src/patterns/SimpleOverview/__stories__/SimpleOverview.stories.js
@@ -14,7 +14,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_SIMPLE_OVERVIEW) {
-  storiesOf('Simple Overview', module)
+  storiesOf('Sections|Simple Overview', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/UseCases/__stories__/UseCases.stories.js
+++ b/packages/patterns-react/src/patterns/UseCases/__stories__/UseCases.stories.js
@@ -13,7 +13,7 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_USECASES) {
-  storiesOf('Use Cases', module)
+  storiesOf('Blocks|Use Cases', module)
     .addDecorator(withKnobs)
     .addParameters({
       readme: {

--- a/packages/patterns-react/src/patterns/overview.js
+++ b/packages/patterns-react/src/patterns/overview.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
 
-storiesOf('Overview', module)
+storiesOf('Overview|Get Started', module)
   .addDecorator(storyFn => (
     <div className="storybook-center-container">{storyFn()}</div>
   ))
-  .add('Get Started', withDocs(README, () => <div />));
+  .add('Read Me', withDocs(README, () => <div />));


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This is a slight modification to Storybook where we can break out our stories into sections. I think it will be easier to navigate through the patterns now that we're thinking about the hierarchy of these patterns and separating them out as such in Storybook (sections vs blocks vs sub-patterns).

### Changelog

**Changed**

- Adding separators/sections in Patterns storybook
