### PR TITLE
fix(eslint): adjust config for sort-imports in eslint

### DIFF
--- a/packages/eslint-config-ibmdotcom/index.js
+++ b/packages/eslint-config-ibmdotcom/index.js
@@ -26,7 +26,13 @@ module.exports = {
         varsIgnorePattern: '^_',
       },
     ],
-    'sort-imports': 2,
+    'sort-imports': [
+      'error',
+      {
+        ignoreCase: true,
+        ignoreMemberSort: true,
+      },
+    ],
     'react/jsx-uses-vars': 1,
     'react/jsx-uses-react': 1,
 

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { Footer } from '../Footer';
 import { Masthead } from '../Masthead';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -1,10 +1,10 @@
 import './index.scss';
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
+import content from './data/content';
 import { DDS_MASTHEAD_L1 } from '../../../internal/FeatureFlags';
 import DotcomShell from '../DotcomShell';
-import React from 'react';
-import content from './data/content';
 import mastheadKnobs from '../../Masthead/__stories__/data/Masthead.stories.knobs.js';
+import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 

--- a/packages/react/src/components/ExpressiveModal/ExpressiveModal.js
+++ b/packages/react/src/components/ExpressiveModal/ExpressiveModal.js
@@ -6,11 +6,11 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { ComposedModal } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import ExpressiveModalCloseBtn from './ExpressiveModalCloseBtn';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/ExpressiveModal/ExpressiveModalCloseBtn.js
+++ b/packages/react/src/components/ExpressiveModal/ExpressiveModalCloseBtn.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import classNames from 'classnames';
 import { Close20 } from '@carbon/icons-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/ExpressiveModal/__tests__/ExpressiveModal.test.js
+++ b/packages/react/src/components/ExpressiveModal/__tests__/ExpressiveModal.test.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { act } from 'react-dom/test-utils';
 import ExpressiveModal from '../ExpressiveModal';
 import MockedComponent from './mocks/mock-component';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { act } from 'react-dom/test-utils';
 
 describe('<ExpressiveModal />', () => {
   let container;

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -5,21 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {
-  LocaleAPI,
-  TranslationAPI,
-  globalInit,
-} from '@carbon/ibmdotcom-services';
-import React, { useEffect, useState } from 'react';
-import {
   settings as ddsSettings,
   ipcinfoCookie,
 } from '@carbon/ibmdotcom-utilities';
+import {
+  globalInit,
+  LocaleAPI,
+  TranslationAPI,
+} from '@carbon/ibmdotcom-services';
+import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import FooterLogo from './FooterLogo';
 import FooterNav from './FooterNav';
 import LegalNav from './LegalNav';
 import LocaleButton from './LocaleButton';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Footer/FooterLogo.js
+++ b/packages/react/src/components/Footer/FooterLogo.js
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import FooterLogo from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h65-white.svg';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Footer/FooterNav.js
+++ b/packages/react/src/components/Footer/FooterNav.js
@@ -6,10 +6,10 @@
  */
 
 import { Accordion } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import FooterNavGroup from './FooterNavGroup';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Footer/FooterNavGroup.js
+++ b/packages/react/src/components/Footer/FooterNavGroup.js
@@ -6,9 +6,9 @@
  */
 
 import { AccordionItem, Link } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { Link } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Footer/LocaleButton.js
+++ b/packages/react/src/components/Footer/LocaleButton.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Button } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { Globe20 } from '@carbon/icons-react';
 import LocaleModal from '../LocaleModal/LocaleModal';
 import PropTypes from 'prop-types';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -1,9 +1,9 @@
 import './index.scss';
 import { boolean, object, select, withKnobs } from '@storybook/addon-knobs';
 import { Footer } from '../';
-import React from 'react';
 import footerMenu from '../__data__/footer-menu.json';
 import footerThin from '../__data__/footer-legal.json';
+import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 

--- a/packages/react/src/components/Footer/__tests__/Footer.test.js
+++ b/packages/react/src/components/Footer/__tests__/Footer.test.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { act } from 'react-dom/test-utils';
 import Footer from '../Footer';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { TranslationAPI } from '@carbon/ibmdotcom-services';
-import { act } from 'react-dom/test-utils';
 import { shallow } from 'enzyme';
+import { TranslationAPI } from '@carbon/ibmdotcom-services';
 
 const FOOTER_MENU_MOCK_DATA = require('../__data__/footer-menu.json').data;
 const LEGAL_NAV_MOCK_DATA = require('../__data__/footer-legal.json').data;

--- a/packages/react/src/components/Footer/__tests__/LocaleButton.test.js
+++ b/packages/react/src/components/Footer/__tests__/LocaleButton.test.js
@@ -7,8 +7,8 @@
 
 import { ComposedModal } from 'carbon-components-react';
 import LocaleButton from '../LocaleButton';
-import React from 'react';
 import mocklist from '../__data__/locale-list.json';
+import React from 'react';
 import { shallow } from 'enzyme';
 
 jest.mock('@carbon/ibmdotcom-services', () => ({

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes from 'prop-types';
-import React from 'react';
 import classnames from 'classnames';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Icon/IbmLogo.js
+++ b/packages/react/src/components/Icon/IbmLogo.js
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import MastheadLogo from '@carbon/ibmdotcom-styles/icons/svg/IBM-8bar-logo--h23.svg';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { baseFontSize, breakpoints } from '@carbon/layout';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
+++ b/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { Link } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/LocaleModal/LocaleModal.js
+++ b/packages/react/src/components/LocaleModal/LocaleModal.js
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { altlangs, settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { ArrowLeft20, Globe20 } from '@carbon/icons-react';
 import { ComposedModal, ModalBody, ModalHeader } from 'carbon-components-react';
 import React, { useEffect, useState } from 'react';
-import { altlangs, settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import cx from 'classnames';
 import { LocaleAPI } from '@carbon/ibmdotcom-services';
 import LocaleModalCountries from './LocaleModalCountries';
 import LocaleModalRegions from './LocaleModalRegions';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/LocaleModal/LocaleModalCountries.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalCountries.js
@@ -6,9 +6,9 @@
  */
 
 import React, { useEffect } from 'react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import { Search } from 'carbon-components-react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/LocaleModal/LocaleModalRegions.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalRegions.js
@@ -8,8 +8,8 @@
 import { ArrowRight20, Error20 } from '@carbon/icons-react';
 import React, { useEffect } from 'react';
 import { CardLink } from '../../patterns/sub-patterns/CardLink';
-import PropTypes from 'prop-types';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/LocaleModal/__tests__/LocaleModal.test.js
+++ b/packages/react/src/components/LocaleModal/__tests__/LocaleModal.test.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { act } from 'react-dom/test-utils';
+import { altlangs } from '@carbon/ibmdotcom-utilities';
 import { LocaleAPI } from '@carbon/ibmdotcom-services';
 import LocaleModal from '../LocaleModal';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { act } from 'react-dom/test-utils';
-import { altlangs } from '@carbon/ibmdotcom-utilities';
 
 const pageLangs = altlangs();
 

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -19,7 +19,9 @@ import {
 } from '@carbon/ibmdotcom-services';
 import React, { useEffect, useRef, useState } from 'react';
 import { User20, UserOnline20 } from '@carbon/icons-react';
+import cx from 'classnames';
 import { DDS_MASTHEAD_L1 } from '../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { IbmLogo } from '../Icon';
 import MastheadL1 from './MastheadL1';
 import MastheadLeftNav from './MastheadLeftNav';
@@ -27,8 +29,6 @@ import MastheadProfile from './MastheadProfile';
 import MastheadSearch from './MastheadSearch';
 import MastheadTopNav from './MastheadTopNav';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import root from 'window-or-global';
 import { settings } from 'carbon-components';
 

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -7,10 +7,10 @@
 
 import { HeaderMenuItem, HeaderNavigation } from 'carbon-components-react';
 import { ArrowLeft16 } from '@carbon/icons-react';
+import cx from 'classnames';
 import HeaderMenu from '../carbon-components-react/UIShell/HeaderMenu';
 import PropTypes from 'prop-types';
 import React from 'react';
-import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -13,11 +13,11 @@ import {
   SideNavMenuItem,
 } from 'carbon-components-react';
 import { ArrowLeft16 } from '@carbon/icons-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import SideNavMenu from '../carbon-components-react/UIShell/SideNavMenu';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
+import SideNavMenu from '../carbon-components-react/UIShell/SideNavMenu';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;

--- a/packages/react/src/components/Masthead/MastheadProfile.js
+++ b/packages/react/src/components/Masthead/MastheadProfile.js
@@ -10,9 +10,9 @@ import {
   OverflowMenu,
   OverflowMenuItem,
 } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 
 const { stablePrefix } = ddsSettings;
 

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -7,15 +7,15 @@
 
 import React, { useEffect, useReducer } from 'react';
 import Autosuggest from 'react-autosuggest';
+import cx from 'classnames';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { escapeRegExp } from '@carbon/ibmdotcom-utilities';
 import { LocaleAPI } from '@carbon/ibmdotcom-services';
 import MastheadSearchInput from './MastheadSearchInput';
 import MastheadSearchSuggestion from './MastheadSearchSuggestion';
 import PropTypes from 'prop-types';
-import { SearchTypeaheadAPI } from '@carbon/ibmdotcom-services';
-import cx from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { escapeRegExp } from '@carbon/ibmdotcom-utilities';
 import root from 'window-or-global';
+import { SearchTypeaheadAPI } from '@carbon/ibmdotcom-services';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { Close20 } from '@carbon/icons-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { HeaderGlobalAction } from 'carbon-components-react';
 import PropTypes from 'prop-types';
-import { Search20 } from '@carbon/icons-react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import root from 'window-or-global';
+import { Search20 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
+++ b/packages/react/src/components/Masthead/MastheadSearchSuggestion.js
@@ -1,9 +1,9 @@
-import PropTypes from 'prop-types';
-import React from 'react';
 import classNames from 'classnames';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -10,10 +10,10 @@ import {
   HeaderName,
   HeaderNavigation,
 } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import HeaderMenu from '../carbon-components-react/UIShell/HeaderMenu';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 
 const { stablePrefix } = ddsSettings;
 

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -2,8 +2,8 @@ import './index.scss';
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_MASTHEAD_L1 } from '../../../internal/FeatureFlags';
 import Masthead from '../Masthead';
-import React from 'react';
 import mastheadKnobs from './data/Masthead.stories.knobs.js';
+import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 

--- a/packages/react/src/components/Masthead/__tests__/MastheadSearch.test.js
+++ b/packages/react/src/components/Masthead/__tests__/MastheadSearch.test.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import MastheadSearch from '../MastheadSearch';
+import { mount } from 'enzyme';
 import React from 'react';
 import { SearchTypeaheadAPI } from '@carbon/ibmdotcom-services';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { mount } from 'enzyme';
 
 const { stablePrefix } = ddsSettings;
 

--- a/packages/react/src/components/overview.js
+++ b/packages/react/src/components/overview.js
@@ -1,5 +1,5 @@
-import README from '../../README.md';
 import React from 'react';
+import README from '../../README.md';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
 

--- a/packages/react/src/patterns/blocks/CardArray/CardArray.js
+++ b/packages/react/src/patterns/blocks/CardArray/CardArray.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useRef } from 'react';
 import {
   settings as ddsSettings,
   featureFlag,
 } from '@carbon/ibmdotcom-utilities';
 import { markdownToHtml, sameHeight } from '@carbon/ibmdotcom-utilities';
+import React, { useEffect, useRef } from 'react';
 
 import { ArrowRight20 } from '@carbon/icons-react';
 import { CardLink } from '../../sub-patterns/CardLink';

--- a/packages/react/src/patterns/blocks/FeaturedLink/FeaturedLink.js
+++ b/packages/react/src/patterns/blocks/FeaturedLink/FeaturedLink.js
@@ -9,10 +9,10 @@ import { ArrowRight20 } from '@carbon/icons-react';
 import { CardLink } from '../../sub-patterns/CardLink';
 import { ContentGroup } from '../../sub-patterns/ContentGroup';
 import { DDS_FEATURED_LINK } from '../../../internal/FeatureFlags';
-import PropTypes from 'prop-types';
-import React from 'react';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { featureFlag } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/ListSection/ListSection.js
+++ b/packages/react/src/patterns/blocks/ListSection/ListSection.js
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import classNames from 'classnames';
 import { ContentGroup } from '../../sub-patterns/ContentGroup';
 import { DDS_LISTSECTION } from '../../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import ListSectonItem from './ListSectionItem';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/ListSection/ListSectionItem.js
+++ b/packages/react/src/patterns/blocks/ListSection/ListSectionItem.js
@@ -6,10 +6,10 @@
  */
 
 import { ArrowRight20 } from '@carbon/icons-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { LinkWithIcon } from '../../../components/LinkWithIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/LogoGrid/LogoGrid.js
+++ b/packages/react/src/patterns/blocks/LogoGrid/LogoGrid.js
@@ -4,12 +4,12 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { DDS_LOGO_GRID } from '../../../internal/FeatureFlags';
-import PropTypes from 'prop-types';
-import React from 'react';
 import classNames from 'classnames';
+import { DDS_LOGO_GRID } from '../../../internal/FeatureFlags';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { featureFlag } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/LogoGrid/__stories__/LogoGrid.stories.js
+++ b/packages/react/src/patterns/blocks/LogoGrid/__stories__/LogoGrid.stories.js
@@ -2,8 +2,8 @@ import './index.scss';
 import { object, select, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_LOGO_GRID } from '../../../../internal/FeatureFlags';
 import LogoGrid from '../LogoGrid';
-import React from 'react';
 import logos from './data/logos.json';
+import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 

--- a/packages/react/src/patterns/blocks/PictogramArray/PictogramArray.js
+++ b/packages/react/src/patterns/blocks/PictogramArray/PictogramArray.js
@@ -6,11 +6,11 @@
  */
 
 import { DDS_PICTOGRAM_ARRAY } from '../../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import PictogramArrayItem from './PictogramArrayItem';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/SimpleLongForm/SimpleLongForm.js
+++ b/packages/react/src/patterns/blocks/SimpleLongForm/SimpleLongForm.js
@@ -7,13 +7,13 @@
 
 import { ArrowRight20 } from '@carbon/icons-react';
 import { CardLink } from '../../sub-patterns/CardLink';
+import classNames from 'classnames';
 import { DDS_SIMPLELONGFORM } from '../../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { LinkWithIcon } from '../../../components/LinkWithIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/SimpleLongForm/__stories__/SimpleLongForm.stories.js
+++ b/packages/react/src/patterns/blocks/SimpleLongForm/__stories__/SimpleLongForm.stories.js
@@ -8,8 +8,8 @@ import {
 } from '@storybook/addon-knobs';
 import { DDS_SIMPLELONGFORM } from '../../../../internal/FeatureFlags';
 import React from 'react';
-import SimpleLongForm from '../SimpleLongForm';
 import readme from '../README.md';
+import SimpleLongForm from '../SimpleLongForm';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_SIMPLELONGFORM) {

--- a/packages/react/src/patterns/blocks/UseCases/UseCases.js
+++ b/packages/react/src/patterns/blocks/UseCases/UseCases.js
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import classNames from 'classnames';
 import { DDS_USECASES } from '../../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import FeaturedLink from '../FeaturedLink/FeaturedLink';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import UseCasesGroup from './UseCasesGroup';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
+import UseCasesGroup from './UseCasesGroup';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;

--- a/packages/react/src/patterns/blocks/UseCases/UseCasesGroup.js
+++ b/packages/react/src/patterns/blocks/UseCases/UseCasesGroup.js
@@ -7,11 +7,11 @@
 
 import { ArrowRight20 } from '@carbon/icons-react';
 import { CardLink } from '../../sub-patterns/CardLink';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import UseCasesItem from './UseCasesItem';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
+import UseCasesItem from './UseCasesItem';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;

--- a/packages/react/src/patterns/blocks/UseCases/UseCasesItem.js
+++ b/packages/react/src/patterns/blocks/UseCases/UseCasesItem.js
@@ -6,10 +6,10 @@
  */
 
 import { ArrowRight20 } from '@carbon/icons-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { LinkWithIcon } from '../../../components/LinkWithIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/blocks/UseCases/__stories__/UseCases.stories.js
+++ b/packages/react/src/patterns/blocks/UseCases/__stories__/UseCases.stories.js
@@ -8,9 +8,9 @@ import {
 } from '@storybook/addon-knobs';
 import { DDS_USECASES } from '../../../../internal/FeatureFlags';
 import React from 'react';
-import UseCases from '../UseCases';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
+import UseCases from '../UseCases';
 
 if (DDS_USECASES) {
   storiesOf('Patterns (Blocks)|Use Cases', module)

--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useRef } from 'react';
 import { featureFlag, sameHeight } from '@carbon/ibmdotcom-utilities';
+import React, { useEffect, useRef } from 'react';
 import { ArrowRight20 } from '@carbon/icons-react';
 import { CardLink } from '../../sub-patterns/CardLink';
-import { DDS_CARD_SECTION } from '../../../internal/FeatureFlags';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { DDS_CARD_SECTION } from '../../../internal/FeatureFlags';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
 import root from 'window-or-global';
 import { settings } from 'carbon-components';
 

--- a/packages/react/src/patterns/sections/CardSection/__stories__/CardSection.stories.js
+++ b/packages/react/src/patterns/sections/CardSection/__stories__/CardSection.stories.js
@@ -1,12 +1,12 @@
 import './index.scss';
 import { object, select, withKnobs } from '@storybook/addon-knobs';
+import cards from './data/cards.json';
 import CardSection from '../CardSection';
 import { DDS_CARD_SECTION } from '../../../../internal/FeatureFlags';
 import ImageCards from '../ImageCards';
 import React from 'react';
-import SimpleCards from '../SimpleCards';
-import cards from './data/cards.json';
 import readme from '../README.md';
+import SimpleCards from '../SimpleCards';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_CARD_SECTION) {

--- a/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
+++ b/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
@@ -10,11 +10,11 @@ import {
   featureFlag,
 } from '@carbon/ibmdotcom-utilities';
 import { ButtonGroup } from '../../sub-patterns/ButtonGroup';
+import classnames from 'classnames';
 import { DDS_LEADSPACE } from '../../../internal/FeatureFlags';
 import LeadSpaceImage from './LeadSpaceImage';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sections/LeadSpace/LeadSpaceImage.js
+++ b/packages/react/src/patterns/sections/LeadSpace/LeadSpaceImage.js
@@ -4,9 +4,9 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sections/LeadSpace/__tests__/LeadSpace.test.js
+++ b/packages/react/src/patterns/sections/LeadSpace/__tests__/LeadSpace.test.js
@@ -1,6 +1,6 @@
 import LeadSpace from '../LeadSpace';
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 require('../../../internal/FeatureFlags');
 

--- a/packages/react/src/patterns/sections/LeadSpace/__tests__/LeadSpaceImage.test.js
+++ b/packages/react/src/patterns/sections/LeadSpace/__tests__/LeadSpaceImage.test.js
@@ -1,6 +1,6 @@
 import LeadSpaceImage from '../LeadSpaceImage';
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 describe('<LeadSpaceImage />', () => {
   it('renders expected number of source elements', () => {

--- a/packages/react/src/patterns/sections/LeadSpaceCentered/LeadSpaceCentered.js
+++ b/packages/react/src/patterns/sections/LeadSpaceCentered/LeadSpaceCentered.js
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
 import {
   settings as ddsSettings,
   featureFlag,
 } from '@carbon/ibmdotcom-utilities';
+import React, { useEffect, useState } from 'react';
 import { ButtonGroup } from '../../sub-patterns/ButtonGroup';
+import classnames from 'classnames';
 import { DDS_LEADSPACE_CENTERED } from '../../../internal/FeatureFlags';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sections/LeadSpaceCentered/__tests__/LeadSpaceCentered.test.js
+++ b/packages/react/src/patterns/sections/LeadSpaceCentered/__tests__/LeadSpaceCentered.test.js
@@ -1,6 +1,6 @@
 import LeadSpaceCentered from '../LeadSpaceCentered';
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 require('../../../../internal/FeatureFlags');
 

--- a/packages/react/src/patterns/sections/SimpleBenefits/SimpleBenefits.js
+++ b/packages/react/src/patterns/sections/SimpleBenefits/SimpleBenefits.js
@@ -6,14 +6,14 @@
  */
 
 import React, { useEffect } from 'react';
-import { DDS_SIMPLEBENEFITS } from '../../../internal/FeatureFlags';
-import PropTypes from 'prop-types';
-import SimpleBenefitsItem from './SimpleBenefitsItem';
 import classNames from 'classnames';
+import { DDS_SIMPLEBENEFITS } from '../../../internal/FeatureFlags';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { featureFlag } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
 import root from 'window-or-global';
 import { settings } from 'carbon-components';
+import SimpleBenefitsItem from './SimpleBenefitsItem';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;

--- a/packages/react/src/patterns/sections/SimpleBenefits/SimpleBenefitsItem.js
+++ b/packages/react/src/patterns/sections/SimpleBenefits/SimpleBenefitsItem.js
@@ -6,10 +6,10 @@
  */
 
 import { ArrowRight20 } from '@carbon/icons-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { LinkWithIcon } from '../../../components/LinkWithIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sections/SimpleBenefits/__stories__/SimpleBenefits.stories.js
+++ b/packages/react/src/patterns/sections/SimpleBenefits/__stories__/SimpleBenefits.stories.js
@@ -2,8 +2,8 @@ import './index.scss';
 import { object, select, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_SIMPLEBENEFITS } from '../../../../internal/FeatureFlags';
 import React from 'react';
-import SimpleBenefits from '../SimpleBenefits';
 import readme from '../README.md';
+import SimpleBenefits from '../SimpleBenefits';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_SIMPLEBENEFITS) {

--- a/packages/react/src/patterns/sections/SimpleOverview/SimpleOverview.js
+++ b/packages/react/src/patterns/sections/SimpleOverview/SimpleOverview.js
@@ -6,13 +6,13 @@
  */
 
 import { ArrowRight20 } from '@carbon/icons-react';
+import classNames from 'classnames';
 import { DDS_SIMPLE_OVERVIEW } from '../../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { LinkWithIcon } from '../../../components/LinkWithIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { featureFlag } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sections/SimpleOverview/__stories__/SimpleOverview.stories.js
+++ b/packages/react/src/patterns/sections/SimpleOverview/__stories__/SimpleOverview.stories.js
@@ -9,8 +9,8 @@ import './index.scss';
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_SIMPLE_OVERVIEW } from '../../../../internal/FeatureFlags';
 import React from 'react';
-import SimpleOverview from '../SimpleOverview';
 import readme from '../README.md';
+import SimpleOverview from '../SimpleOverview';
 import { storiesOf } from '@storybook/react';
 
 if (DDS_SIMPLE_OVERVIEW) {

--- a/packages/react/src/patterns/sub-patterns/ButtonGroup/__tests__/ButtonGroup.test.js
+++ b/packages/react/src/patterns/sub-patterns/ButtonGroup/__tests__/ButtonGroup.test.js
@@ -1,6 +1,6 @@
 import ButtonGroup from '../ButtonGroup';
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 jest.mock('../../../../internal/FeatureFlags', () => ({
   DDS_BUTTON_GROUP: true,

--- a/packages/react/src/patterns/sub-patterns/CardLink/CardLink.js
+++ b/packages/react/src/patterns/sub-patterns/CardLink/CardLink.js
@@ -4,12 +4,12 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import classNames from 'classnames';
 import { ClickableTile } from 'carbon-components-react';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { Image } from '../../../components/Image';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sub-patterns/ContentGroup/ContentGroup.js
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/ContentGroup.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { DDS_CONTENT_GROUP } from '../../../internal/FeatureFlags';
-import PropTypes from 'prop-types';
-import React from 'react';
 import classNames from 'classnames';
+import { DDS_CONTENT_GROUP } from '../../../internal/FeatureFlags';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { featureFlag } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sub-patterns/Layout/Layout.js
+++ b/packages/react/src/patterns/sub-patterns/Layout/Layout.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes from 'prop-types';
-import React from 'react';
 import classnames from 'classnames';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes from 'prop-types';
-import React from 'react';
 import classNames from 'classnames';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCMobile.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCMobile.js
@@ -6,11 +6,11 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
-import { TableOfContents20 } from '@carbon/icons-react';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
 import root from 'window-or-global';
 import { settings } from 'carbon-components';
+import { TableOfContents20 } from '@carbon/icons-react';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -74,7 +74,7 @@ const TOCMobile = ({ menuItems, selectedId, menuLabel, updateState }) => {
   /**
    * Handle OnBlur event
    *
-   * @returns null
+   * @returns {null} Returns null for blur events
    */
   const handleOnBlur = () => {
     return null;

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TableOfContents.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TableOfContents.js
@@ -5,19 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
 import {
   settings as ddsSettings,
   featureFlag,
 } from '@carbon/ibmdotcom-utilities';
+import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { DDS_TOC } from '../../../internal/FeatureFlags';
 import Layout from '../Layout/Layout';
 import PropTypes from 'prop-types';
-import TOCDesktop from './TOCDesktop';
-import TOCMobile from './TOCMobile';
-import classNames from 'classnames';
 import root from 'window-or-global';
 import { settings } from 'carbon-components';
+import TOCDesktop from './TOCDesktop';
+import TOCMobile from './TOCMobile';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -72,7 +72,7 @@ const TableOfContents = ({ menuItems, children, menuLabel, theme }) => {
     const id = elems[0] || menuItems[0].id;
     const filteredItems = menuItems.filter(menu => {
       if (id !== 'undefined') {
-        return menu.id == id;
+        return menu.id === id;
       }
     });
     const title = filteredItems[0].title;

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/__stories__/TableOfContents.stories.js
@@ -1,10 +1,11 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import './index.scss';
 import { select, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_TOC } from '../../../../internal/FeatureFlags';
 import React from 'react';
-import TableOfContents from '../TableOfContents';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
+import TableOfContents from '../TableOfContents';
 
 if (DDS_TOC) {
   storiesOf('Patterns (Sub-Patterns)|Table of Contents', module)

--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -8,6 +8,7 @@ const _scrollTracker = process.env.SCROLL_TRACKING === 'true' || false;
 
 /**
  * Current NODE_ENV
+ *
  * @type {string | string}
  * @private
  */

--- a/packages/services/src/services/DDO/DDO.js
+++ b/packages/services/src/services/DDO/DDO.js
@@ -17,6 +17,7 @@ function _checkFlag() {
 
 /**
  * Number of times to retry the datalayer ready loop before failing
+ *
  * @type {number}
  * @private
  */
@@ -24,6 +25,7 @@ const _timeoutRetries = 50;
 
 /**
  * Tracks the number of attempts for the datalayer ready loop
+ *
  * @type {number}
  * @private
  */

--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -43,6 +43,7 @@ const _endpoint = `${_proxy}${_host}/common/js/dynamicnav/www/countrylist/jsonon
 
 /**
  * Session Storage key for country list
+ *
  * @type {string}
  * @private
  */

--- a/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
+++ b/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
@@ -1,5 +1,5 @@
-import { LocaleAPI } from '../Locale';
 import axios from 'axios';
+import { LocaleAPI } from '../Locale';
 
 /**
  * @constant {string | string} Host for the API calls

--- a/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
+++ b/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
@@ -1,6 +1,6 @@
-import SearchTypeaheadAPI from '../SearchTypeahead';
 import mockAxios from 'axios';
 import responseSuccess from './data/response.json';
+import SearchTypeaheadAPI from '../SearchTypeahead';
 
 const _lc = 'en'; // TODO: bake in tests where lc changes
 const _cc = 'us'; // TODO: bake in tests where cc changes

--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -1,5 +1,5 @@
-import { LocaleAPI } from '../Locale';
 import axios from 'axios';
+import { LocaleAPI } from '../Locale';
 import root from 'window-or-global';
 
 /**

--- a/packages/services/src/services/Translation/__tests__/Translation.test.js
+++ b/packages/services/src/services/Translation/__tests__/Translation.test.js
@@ -1,6 +1,6 @@
-import TranslationAPI from '../Translation';
 import mockAxios from 'axios';
 import responseSuccess from './data/response.json';
+import TranslationAPI from '../Translation';
 
 jest.mock('../../Locale', () => ({
   LocaleAPI: {

--- a/packages/vanilla/src/bundle.js
+++ b/packages/vanilla/src/bundle.js
@@ -17,6 +17,7 @@ const _autoinit = process.env.VANILLA_AUTOINIT === 'true' || true;
 
 /**
  * The handles for event handlers to lazily instantiate components.
+ *
  * @type {Array}
  */
 const lazyInitHandles = [];


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1216

### Description

This adjusts the eslint configuration of `sort-imports` to turn on `ignoreCase` and `ignoreMemberSort`. This also ensures all linting passes.

### Changelog

**Changed**

- `sort-imports` configuration in eslint