### PR TITLE
fix(docs): remove netlify references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,3 @@ and our
 
 Licensed under the
 [Apache 2.0 License](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/LICENSE).
-
-<a href="https://www.netlify.com">
-  <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"/>
-</a>

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -45,8 +45,7 @@ with the expressive theme applied, run the following command:
 $ yarn storybook
 ```
 
-This can also be viewed in our
-[Netlify output](https://carbon-expressive.mybluemix.net).
+This can also be viewed [here](https://carbon-expressive.mybluemix.net).
 
 ## Documentation
 


### PR DESCRIPTION
### Description

Remove Netlify from documentation as it is no longer being used.

### Changelog
**Changed**

- Netlify references

**Removed**

- Netlify references in documentation

