### PR TITLE
fix(storybook): move localemodal knob within story

### DIFF
--- a/packages/react/src/components/LocaleModal/__stories__/LocaleModal.stories.js
+++ b/packages/react/src/components/LocaleModal/__stories__/LocaleModal.stories.js
@@ -5,10 +5,6 @@ import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
-const localeModalProps = {
-  headerTitle: text('title', 'Select region'),
-};
-
 storiesOf('Components|Locale Modal', module)
   .addDecorator(withKnobs)
   .addParameters({
@@ -17,5 +13,9 @@ storiesOf('Components|Locale Modal', module)
     },
   })
   .add('Default', () => {
+    const localeModalProps = {
+      headerTitle: text('title', 'Select region'),
+    };
+
     return <LocaleModal isOpen={true} {...localeModalProps} />;
   });


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

move locale modal knob within story otherwise it appears as a global knob

### Changelog

**Changed**

-move locale modal knob within story

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
