### PR TITLE
Consistent Passing of Carbon Icons

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2754,6 +2754,91 @@ Array [
 ]
 `;
 
+exports[`Storyshots Patterns (Sub-Patterns)|ContentItem Default 1`] = `
+Array [
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <div
+      className="storybook-readme-story"
+    >
+      <div
+        style={Object {}}
+      >
+        <div>
+          <div
+            class="bx--grid"
+          >
+            <div
+              class="bx--row"
+            >
+              <div
+                class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
+              >
+                <div
+                  className="bx--content-item"
+                  data-autoid="dds--content-item"
+                >
+                  <h4
+                    className="bx--content-item__heading"
+                    data-autoid="dds--content-item__heading"
+                  >
+                    Lorem ipsum dolor sit amet.
+                  </h4>
+                  <picture
+                    alt="content item image"
+                    className="bx--image"
+                    data-autoid="dds--image"
+                  >
+                    <source
+                      media="(min-width: 1056px )"
+                      srcSet="https://picsum.photos/id/2/352/176"
+                    />
+                    <source
+                      media="(min-width: 672px )"
+                      srcSet="https://picsum.photos/id/2/448/224"
+                    />
+                    <source
+                      media="(min-width: 320px )"
+                      srcSet="https://picsum.photos/id/2/288/144"
+                    />
+                    <img
+                      alt="content item image"
+                      className="bx--image__img bx--content-item__image"
+                      src="https://picsum.photos/id/2/352/176"
+                    />
+                  </picture>
+                  <div
+                    className="bx--content-item__copy"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                      }
+                    }
+                    data-autoid="dds--content-item__copy"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />,
+]
+`;
+
 exports[`Storyshots Patterns (Sub-Patterns)|Layout Default 1`] = `
 Array [
   <div

--- a/packages/react/src/components/LocaleModal/LocaleModalRegions.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalRegions.js
@@ -90,7 +90,7 @@ const LocaleModalRegions = ({
                   key={region.key}
                   title={region.name}
                   href={hasCountries ? 'javascript:void(0);' : null}
-                  icon={hasCountries ? <ArrowRight20 /> : <Error20 />}
+                  icon={hasCountries ? ArrowRight20 : Error20}
                 />
               </div>
             );

--- a/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
+++ b/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
@@ -90,7 +90,7 @@ const _renderCards = items =>
         className={`${prefix}--content-group-cards-item`}
         title={elem.heading}
         content={elem.copy}
-        icon={<ArrowRight20 />}
+        icon={ArrowRight20}
         href={elem.cta.href}
       />
     </div>

--- a/packages/react/src/patterns/blocks/FeaturedLink/FeaturedLink.js
+++ b/packages/react/src/patterns/blocks/FeaturedLink/FeaturedLink.js
@@ -36,7 +36,7 @@ const FeaturedLink = ({ heading, card }) => {
         <CardLink
           className={`${prefix}--featuredlink__card`}
           {...card}
-          icon={<ArrowRight20 />}
+          icon={ArrowRight20}
         />
       </ContentGroup>
     </section>

--- a/packages/react/src/patterns/blocks/SimpleLongForm/SimpleLongForm.js
+++ b/packages/react/src/patterns/blocks/SimpleLongForm/SimpleLongForm.js
@@ -76,7 +76,7 @@ const renderLink = (type, data) => {
       title={data.text}
       href={data.href}
       target={data.target}
-      icon={<ArrowRight20 />}
+      icon={ArrowRight20}
     />
   ) : type === 'iconLink' ? (
     <LinkWithIcon href={data.href} target={data.target}>

--- a/packages/react/src/patterns/blocks/UseCases/UseCasesGroup.js
+++ b/packages/react/src/patterns/blocks/UseCases/UseCasesGroup.js
@@ -49,7 +49,7 @@ const UseCasesGroup = ({ usecaseGroup: { title, image, lists, link } }) => {
             title={link.title}
             href={link.href}
             target={link.target}
-            icon={<ArrowRight20 />}
+            icon={ArrowRight20}
           />
         </div>
       )}

--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -81,7 +81,7 @@ const CardSection = ({ title, cards, theme }) => {
                       content={card.copy}
                       href={card.link.href}
                       target={card.link.target}
-                      icon={<ArrowRight20 />}
+                      icon={ArrowRight20}
                     />
                   </div>
                 );

--- a/packages/react/src/patterns/sub-patterns/CardLink/CardLink.js
+++ b/packages/react/src/patterns/sub-patterns/CardLink/CardLink.js
@@ -28,7 +28,7 @@ const CardLink = ({
   title,
   href,
   content,
-  icon,
+  icon: Icon,
   image,
   className,
   ...props
@@ -47,7 +47,7 @@ const CardLink = ({
       <div className={`${prefix}--card-link__wrapper`}>
         <h3 className={`${prefix}--card-link__title`}>{title}</h3>
         {optionalContent(content)}
-        {renderFooter(icon)}
+        {renderFooter(Icon)}
       </div>
     </ClickableTile>
   );
@@ -72,19 +72,21 @@ function optionalContent(content) {
 /**
  * Render footer with icon
  *
- * @param {object} icon passes in react icon
+ * @param {object} Icon passes in react icon
  * @returns {object} JSX object
  */
-function renderFooter(icon) {
-  return !icon ? null : (
-    <footer className={`${prefix}--card-link__footer`}>{icon}</footer>
+function renderFooter(Icon) {
+  return !Icon ? null : (
+    <footer className={`${prefix}--card-link__footer`}>
+      <Icon />
+    </footer>
   );
 }
 
 CardLink.propTypes = {
   title: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
-  icon: PropTypes.element,
+  icon: PropTypes.object,
   content: PropTypes.string,
   image: PropTypes.object,
   className: PropTypes.string,

--- a/packages/react/src/patterns/sub-patterns/CardLink/README.md
+++ b/packages/react/src/patterns/sub-patterns/CardLink/README.md
@@ -44,7 +44,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 | `content`   | NO       | String    | null          | Paragraph of text that further describing the resource with added detail.                                                        |
 | `className` | NO       | String    | null          | Classname to be assigned to the CardLink component                                                                               |
 | `href`      | YES      | String    | n/a           | Valid URL for a the location of an internal or external resource.                                                                |
-| `icon`      | NO       | Element   | null          | Provide an optional icon to the footer from [Carbon's icon library](https://www.carbondesignsystem.com/guidelines/icons/library) |
+| `icon`      | NO       | Object    | null          | Provide an optional icon to the footer from [Carbon's icon library](https://www.carbondesignsystem.com/guidelines/icons/library) |
 | `title`     | YES      | String    | n/a           | Concise yet descriptive string of text describing the linked resource.                                                           |
 | `imgSrc`    | NO       | String    | null          | Image source to be passed as a property to the to the CardLink component                                                         |
 | `altText`   | NO       | String    | null          | Image alternate text to be passed as a property to the to the CardLink component                                                 |

--- a/packages/react/src/patterns/sub-patterns/CardLink/__stories__/Card.stories.js
+++ b/packages/react/src/patterns/sub-patterns/CardLink/__stories__/Card.stories.js
@@ -43,7 +43,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
         title={title}
         href={href}
         content={content}
-        icon={<ArrowRight20 />}
+        icon={ArrowRight20}
         target={target}
       />
     ) : (
@@ -57,7 +57,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
           title={title}
           href={href}
           content={content}
-          icon={<ArrowRight20 />}
+          icon={ArrowRight20}
           target={target}
           className="bx--aspect-ratio--object"
         />

--- a/packages/react/src/patterns/sub-patterns/CardLink/__tests__/CardLink.test.js
+++ b/packages/react/src/patterns/sub-patterns/CardLink/__tests__/CardLink.test.js
@@ -36,7 +36,7 @@ describe('<CardLink />', () => {
   });
 
   it("renders cardlink's footer if icon is provided", () => {
-    const cardLink = shallow(<CardLink {...content} icon={<ArrowRight20 />} />);
+    const cardLink = shallow(<CardLink {...content} icon={ArrowRight20} />);
     expect(cardLink.find('.bx--card-link__footer')).toHaveLength(1);
     expect(cardLink.find(ArrowRight20)).toHaveLength(1);
   });


### PR DESCRIPTION
### Related Ticket(s)

#1268

### Description

Based on the work happening in #1268 we realized we had a couple different techniques when allowing the user to pass in an icon into a component. ButtonGroup stood out initially requiring the variable to be passed in instead of a JSX component, but looking at that code Carbon was dictating this and we were just passing it through. Lookiing to simplify some of the CTA logic we thought we should unify the technique across the board. It appears `CardLink` was the only component that was out of sync, but do let me know if I missed one.

### Changelog

**Changed**

- Pass in icon to `CardLink` via `ArrowRight20` vs. `<ArrowRight20 />`
- Updated documentation
- Updated other components dependent on `CardLink
