### PR TITLE
fix(locale): fixes fallback when translation response fails; fixes #1300

### DIFF
--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -43,6 +43,7 @@ const _endpoint = `${_proxy}${_host}/common/js/dynamicnav/www/countrylist/jsonon
 
 /**
  * Session Storage key for country list
+ *
  * @type {string}
  * @private
  */
@@ -181,25 +182,28 @@ class LocaleAPI {
     if (sessionList) {
       return sessionList;
     } else {
-      let url;
-      try {
-        await axios.get(`${_endpoint}/${cc}${lc}-utf8.json`);
-        url = `${_endpoint}/${cc}${lc}-utf8.json`;
-      } catch (error) {
-        // use _localeDefault if 404
-        url = `${_endpoint}/${_localeDefault.cc}${_localeDefault.lc}-utf8.json`;
-      }
+      const axiosConfig = {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      };
+
+      const defaultUrl = `${_endpoint}/${_localeDefault.cc}${_localeDefault.lc}-utf8.json`;
+      const url = `${_endpoint}/${cc}${lc}-utf8.json`;
+
       /**
        * if the json file for the cc-lc combo does not exist,
-       * browser will automatically redirect to the us-en country list
+       * browser will automatically use the us-en country list
        */
-      const list = await axios
-        .get(url, {
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-          },
-        })
-        .then(response => response.data);
+      const [defaultList, translatedList] = await Promise.all([
+        axios.get(defaultUrl, axiosConfig).catch(() => null),
+        axios.get(url, axiosConfig).catch(() => null),
+      ]);
+
+      const list =
+        translatedList !== null && translatedList.data
+          ? translatedList.data
+          : defaultList.data;
 
       sessionStorage.setItem(
         `${_sessionListKey}-${cc}-${lc}`,


### PR DESCRIPTION
### Related Ticket(s)

#1300 

### Description

Fixes fallback when translation response fails. 

### Changelog


**Changed**

- `us-en` is now always called in addition to user `cc-lc`, as opposed to only calling if user `cc-lc` fails.
