### PR TITLE
fix(content-group): set expressive heading to scale

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/content-group/_content-group.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-group/_content-group.scss
@@ -37,7 +37,7 @@
       padding-right: $carbon--layout-01;
       max-width: 90%;
 
-      @include carbon--type-style('expressive-heading-04');
+      @include carbon--type-style('expressive-heading-04', true);
     }
 
     &__children {


### PR DESCRIPTION
### Related Ticket(s)

Content group – text is not fluid between breakpoints #1334

### Description

Set the content group heading to scale

### Changelog

**Changed**

- pass in `true` to `carbon--type-style` mixin to allow the heading to scale


between sm, med and lg breakpoints
<img width="552" alt="Screen Shot 2020-02-06 at 3 51 04 PM" src="https://user-images.githubusercontent.com/54281166/73977756-e805b980-48f8-11ea-8ac0-2b63173e53be.png">

between xl and max breakpoints
<img width="554" alt="Screen Shot 2020-02-06 at 3 51 21 PM" src="https://user-images.githubusercontent.com/54281166/73977760-ea681380-48f8-11ea-887e-539148697f00.png">


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
