### PR TITLE
fix(vanilla): adding process null check for vanilla

### DIFF
--- a/packages/services/src/services/Analytics/Analytics.js
+++ b/packages/services/src/services/Analytics/Analytics.js
@@ -4,14 +4,15 @@ import root from 'window-or-global';
  * @constant {boolean} scrollTracker determines whether scroll tracking analytics is enabled
  * @private
  */
-const _scrollTracker = process.env.SCROLL_TRACKING === 'true' || false;
+const _scrollTracker =
+  (process && process.env.SCROLL_TRACKING === 'true') || false;
 
 /**
  * Current NODE_ENV
  * @type {string | string}
  * @private
  */
-const _env = process.env.NODE_ENV || 'development';
+const _env = (process && process.env.NODE_ENV) || 'development';
 
 /**
  * Analytics API class with methods for firing analytics events on

--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -6,13 +6,14 @@ import root from 'window-or-global';
  * @constant {string | string} Host for the Locale API call
  * @private
  */
-const _host = process.env.TRANSLATION_HOST || 'https://1.www.s81c.com';
+const _host =
+  (process && process.env.TRANSLATION_HOST) || 'https://1.www.s81c.com';
 
 /**
  * @constant {string | string} CORS proxy for lower environment calls
  * @private
  */
-const _proxy = process.env.CORS_PROXY || '';
+const _proxy = (process && process.env.CORS_PROXY) || '';
 
 /**
  * Sets the default location if nothing is returned

--- a/packages/services/src/services/MarketingSearch/MarketingSearch.js
+++ b/packages/services/src/services/MarketingSearch/MarketingSearch.js
@@ -4,13 +4,14 @@ import axios from 'axios';
  * @constant {string | string} Host for the API calls
  * @private
  */
-const _host = process.env.MARKETING_SEARCH_HOST || 'https://www.ibm.com';
+const _host =
+  (process && process.env.MARKETING_SEARCH_HOST) || 'https://www.ibm.com';
 
 /**
  * @constant {string | string} API version
  * @private
  */
-const _version = process.env.MARKETING_SEARCH_VERSION || 'v3';
+const _version = (process && process.env.MARKETING_SEARCH_VERSION) || 'v3';
 
 /**
  * MarketingSearch endpoint

--- a/packages/services/src/services/Profile/Profile.js
+++ b/packages/services/src/services/Profile/Profile.js
@@ -4,13 +4,14 @@ import jsonp from 'jsonp';
  * @constant {string | string} Host for the profile status API call
  * @private
  */
-const _host = process.env.PROFILE_HOST || 'https://idaas.iam.ibm.com';
+const _host =
+  (process && process.env.PROFILE_HOST) || 'https://idaas.iam.ibm.com';
 
 /**
  * @constant {string | string} API version
  * @private
  */
-const _version = process.env.PROFILE_VERSION || 'v1';
+const _version = (process && process.env.PROFILE_VERSION) || 'v1';
 
 /**
  * Profile status endpoint

--- a/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
+++ b/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
@@ -5,13 +5,14 @@ import axios from 'axios';
  * @constant {string | string} Host for the API calls
  * @private
  */
-const _host = process.env.SEARCH_TYPEAHEAD_HOST || 'https://www-api.ibm.com';
+const _host =
+  (process && process.env.SEARCH_TYPEAHEAD_HOST) || 'https://www-api.ibm.com';
 
 /**
  * @constant {string | string} API version
  * @private
  */
-const _version = process.env.SEARCH_TYPEAHEAD_VERSION || 'v1';
+const _version = (process && process.env.SEARCH_TYPEAHEAD_VERSION) || 'v1';
 
 /**
  * SearchTypeahead endpoint

--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -6,13 +6,14 @@ import root from 'window-or-global';
  * @constant {string | string} Host for the Translation API call
  * @private
  */
-const _host = process.env.TRANSLATION_HOST || 'https://www.ibm.com';
+const _host =
+  (process && process.env.TRANSLATION_HOST) || 'https://www.ibm.com';
 
 /**
  * @constant {string | string} CORS proxy for lower environment calls
  * @private
  */
-const _proxy = process.env.CORS_PROXY || '';
+const _proxy = (process && process.env.CORS_PROXY) || '';
 
 /**
  * Translation API endpoint

--- a/packages/utilities/src/utilities/geolocation/geolocation.js
+++ b/packages/utilities/src/utilities/geolocation/geolocation.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 const _endpoint =
-  process.env.GEO_API || 'https://api.www.s81c.com/webmaster/dbip/';
+  (process && process.env.GEO_API) ||
+  'https://api.www.s81c.com/webmaster/dbip/';
 /**
  * Utility to retrieve user's country code based on their IP address
  *


### PR DESCRIPTION
### Related Ticket(s)

Issue incoming

### Description

This adds a null check for `process` in case adopters are not compiling on their end for the environment variables.

### Changelog

**Changed**

- additional null checks for `process`
