### PR TITLE
fix(card): have icon outside of cta object

### DIFF
--- a/packages/react/src/patterns/sub-patterns/Card/Card.js
+++ b/packages/react/src/patterns/sub-patterns/Card/Card.js
@@ -25,7 +25,17 @@ const { prefix } = settings;
  * @param {object} props react proptypes
  * @returns {object} JSX object
  */
-const Card = ({ title, copy, href, cta, image, className, type, ...props }) => {
+const Card = ({
+  title,
+  copy,
+  href,
+  cta,
+  image,
+  className,
+  type,
+  icon: Icon,
+  ...props
+}) => {
   const CardTile = type === 'link' ? ClickableTile : Tile;
   return (
     <CardTile
@@ -37,7 +47,7 @@ const Card = ({ title, copy, href, cta, image, className, type, ...props }) => {
       <div className={`${prefix}--card__wrapper`}>
         <h3 className={`${prefix}--card__title`}>{title}</h3>
         {optionalContent(copy)}
-        {renderFooter(cta, type, href)}
+        {renderFooter(cta, type, href, Icon)}
       </div>
     </CardTile>
   );
@@ -65,15 +75,16 @@ function optionalContent(copy) {
  * @param {object} cta cta object
  * @param {string} type type of card (clickable/static)
  * @param {string} href url for card
+ * @param {object} Icon cta icon for card
  * @returns {object} JSX object
  */
-function renderFooter(cta, type, href) {
+function renderFooter(cta, type, href, Icon) {
   return (
     <footer className={`${prefix}--card__footer`}>
       {type !== 'link' ? (
         <CTA style="text" type={cta.type} href={href} copy={cta.copy} />
       ) : (
-        cta.icon && <cta.icon />
+        Icon && <Icon />
       )}
     </footer>
   );
@@ -86,7 +97,6 @@ Card.propTypes = {
   href: PropTypes.string.isRequired,
   cta: PropTypes.shape({
     type: PropTypes.string,
-    icon: PropTypes.element,
     copy: PropTypes.string,
   }),
   image: PropTypes.object,

--- a/packages/react/src/patterns/sub-patterns/Card/__stories__/Card.stories.js
+++ b/packages/react/src/patterns/sub-patterns/Card/__stories__/Card.stories.js
@@ -29,7 +29,6 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
     const type = text('type', 'static');
     const copy = text('copy', '');
     const cta = {
-      icon: ArrowRight20,
       type: 'local',
       copy: text('cta.copy', ''),
     };
@@ -50,6 +49,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
         copy={copy}
         href={href}
         cta={cta}
+        icon={ArrowRight20}
         target={target}
         type={type}
       />
@@ -65,6 +65,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
           copy={copy}
           cta={cta}
           href={href}
+          icon={ArrowRight20}
           target={target}
           type={type}
           className="bx--aspect-ratio--object"
@@ -77,7 +78,6 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
     const type = text('type', 'link');
     const copy = text('copy', '');
     const cta = {
-      icon: ArrowRight20,
       type: 'local',
       copy: text('cta.copy', ''),
     };
@@ -98,6 +98,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
         copy={copy}
         href={href}
         cta={cta}
+        icon={ArrowRight20}
         target={target}
         type={type}
       />
@@ -112,6 +113,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
           title={title}
           copy={copy}
           cta={cta}
+          icon={ArrowRight20}
           href={href}
           target={target}
           type={type}


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Other patterns using the Card component are breaking as they are passing `icon` as its own prop instead of within `cta` object. Quick fix for now until I look at all the func specs

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: patterns" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
