### PR TITLE
fix(scss): Fixed card outline issues

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/card/index.scss
+++ b/packages/styles/scss/patterns/sub-patterns/card/index.scss
@@ -9,8 +9,8 @@
 @import '../../../temp-carbon-expressive/temp-carbon-expressive';
 @import '@carbon/motion/scss/motion.scss';
 
-@import 'carbon-components/scss/components/tile/tile';
 @import 'carbon-components/scss/components/link/link';
+@import 'carbon-components/scss/components/tile/tile';
 
 @mixin card {
   .#{$prefix}--card {


### PR DESCRIPTION
### Related Ticket(s)

#1336 
#1383 

### Description

I've changed the import order in the `Card` scss, in order to correct a bug where the outline was display thinner than intended.



<img width="770" alt="Screen Shot 2020-02-14 at 17 04 49" src="https://user-images.githubusercontent.com/30945011/74563895-8f639b80-4f4c-11ea-981a-ad15cb3d85a5.png">
<img width="755" alt="Screen Shot 2020-02-14 at 17 06 14" src="https://user-images.githubusercontent.com/30945011/74563902-91c5f580-4f4c-11ea-8f6f-2f38b47f0570.png">


### Changelog

**Changed**

- SCSS imports