### PR TITLE
fix(sub-pattern): screen reader content targeting

### DIFF
--- a/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
+++ b/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
@@ -89,6 +89,8 @@ const _renderCards = items =>
         icon={ArrowRight20}
         href={elem.cta.href}
         type="link"
+        role="region"
+        aria-labelledby={`region${index}`}
       />
     </div>
   ));

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
@@ -64,11 +64,11 @@ const TOCDesktop = ({ menuItems, selectedId, updateState }) => {
     });
     const title = filteredItems[0].title;
     updateState(id, title);
+    triggerFocus(`a[name="${id}"]`);
     document.querySelector(`a[name="${id}"]`).scrollIntoView({
       behavior: 'smooth',
       block: 'start',
     });
-    triggerFocus(`a[name="${id}"]`);
   };
 
   /**
@@ -79,7 +79,7 @@ const TOCDesktop = ({ menuItems, selectedId, updateState }) => {
   function triggerFocus(elem) {
     const element = document.querySelector(elem);
     element.setAttribute('tabindex', '0');
-    element.focus();
+    element.focus({ preventScroll: true });
     element.removeAttribute('tabindex');
   }
 

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
@@ -68,7 +68,22 @@ const TOCDesktop = ({ menuItems, selectedId, updateState }) => {
       behavior: 'smooth',
       block: 'start',
     });
+    triggerFocus(`a[name="${id}"]`);
   };
+
+  /**
+   * Trigger the focus on screen readers, so they can read the target paragraph
+   *
+   * @param {*} elem Selector to find the item
+   */
+  function triggerFocus(elem) {
+    const element = document.querySelector(elem);
+    element.setAttribute('tabindex', '0');
+    element.focus();
+    element.addEventListener('focusout', () =>
+      element.removeAttribute('tabindex')
+    );
+  }
 
   /**
    * Set class name for active menu item

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
@@ -80,9 +80,7 @@ const TOCDesktop = ({ menuItems, selectedId, updateState }) => {
     const element = document.querySelector(elem);
     element.setAttribute('tabindex', '0');
     element.focus();
-    element.addEventListener('focusout', () =>
-      element.removeAttribute('tabindex')
-    );
+    element.removeAttribute('tabindex');
   }
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

#1395 
### Description

I've implemented a function that helps the screen readers by focusing the content when the scroll is triggered by the nav buttons.

This was tested and it's working with ChromeVox

### Changelog

**New**

- Focus on the target section
