### PR TITLE
Fix/content group cards accessibility

### DIFF
--- a/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
+++ b/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
@@ -89,6 +89,8 @@ const _renderCards = items =>
         icon={ArrowRight20}
         href={elem.cta.href}
         type="link"
+        role="region"
+        aria-labelledby={`region${index}`}
       />
     </div>
   ));

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
@@ -68,7 +68,22 @@ const TOCDesktop = ({ menuItems, selectedId, updateState }) => {
       behavior: 'smooth',
       block: 'start',
     });
+    triggerFocus(`a[name="${id}"]`);
   };
+
+  /**
+   * Trigger the focus on screen readers, so they can read the target paragraph
+   *
+   * @param {*} elem Selector to find the item
+   */
+  function triggerFocus(elem) {
+    const element = document.querySelector(elem);
+    element.setAttribute('tabindex', '0');
+    element.focus();
+    element.addEventListener('focusout', () =>
+      element.removeAttribute('tabindex')
+    );
+  }
 
   /**
    * Set class name for active menu item

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCDesktop.js
@@ -80,9 +80,7 @@ const TOCDesktop = ({ menuItems, selectedId, updateState }) => {
     const element = document.querySelector(elem);
     element.setAttribute('tabindex', '0');
     element.focus();
-    element.addEventListener('focusout', () =>
-      element.removeAttribute('tabindex')
-    );
+    element.removeAttribute('tabindex');
   }
 
   /**

--- a/packages/styles/scss/patterns/sub-patterns/card/index.scss
+++ b/packages/styles/scss/patterns/sub-patterns/card/index.scss
@@ -9,8 +9,8 @@
 @import '../../../temp-carbon-expressive/temp-carbon-expressive';
 @import '@carbon/motion/scss/motion.scss';
 
-@import 'carbon-components/scss/components/tile/tile';
 @import 'carbon-components/scss/components/link/link';
+@import 'carbon-components/scss/components/tile/tile';
 
 @mixin card {
   .#{$prefix}--card {


### PR DESCRIPTION
### Related Ticket(s)

#1383 
### Description

I've added `role` and `aria-labelledby` attributes to the cards, so they are better understood by screen readers.

### Changelog

**New**

- added `role` and `aria-labelledby`

**Changed**

- SCSS import order