### PR TITLE
fix(pattern): added padding bottom for lg sm brkpts

### DIFF
--- a/packages/styles/scss/patterns/blocks/contentgroupcards/_contentgroupcards.scss
+++ b/packages/styles/scss/patterns/blocks/contentgroupcards/_contentgroupcards.scss
@@ -39,12 +39,10 @@
       @include carbon--type-style('expressive-heading-03');
     }
 
+    padding-bottom: $carbon--layout-05;
+
     @include carbon--breakpoint(lg) {
       padding-bottom: $carbon--layout-07;
-    }
-
-    @include carbon--breakpoint(sm) {
-      padding-bottom: $carbon--layout-05;
     }
 
     .#{$prefix}--content-group {

--- a/packages/styles/scss/patterns/blocks/contentgroupcards/_contentgroupcards.scss
+++ b/packages/styles/scss/patterns/blocks/contentgroupcards/_contentgroupcards.scss
@@ -39,6 +39,14 @@
       @include carbon--type-style('expressive-heading-03');
     }
 
+    @include carbon--breakpoint(lg) {
+      padding-bottom: $carbon--layout-07;
+    }
+
+    @include carbon--breakpoint(sm) {
+      padding-bottom: $carbon--layout-05;
+    }
+
     .#{$prefix}--content-group {
       @include carbon--breakpoint(sm) {
         @include carbon--make-col(4, 4);
@@ -47,7 +55,6 @@
           padding-right: $carbon--layout-01;
         }
       }
-
       @include carbon--breakpoint(md) {
         .#{$prefix}--content-group-cards__row {
           padding-left: 0;
@@ -65,7 +72,6 @@
         padding-right: $carbon--layout-01;
       }
     }
-
     @include themed-items;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

Related issue: #1368 

### Description

Added bottom spacing for card section in mobile and large screens

### Changelog

**Changed**

- contentgroupcards.scss
![image](https://user-images.githubusercontent.com/53789187/74679134-f7072a00-518a-11ea-8604-07cea61819c0.png)
