### PR TITLE
fix(feature-card): set card to hang into gutters

### DIFF
--- a/packages/react/src/patterns/blocks/FeatureCard/__stories__/FeatureCard.stories.js
+++ b/packages/react/src/patterns/blocks/FeatureCard/__stories__/FeatureCard.stories.js
@@ -6,7 +6,6 @@
  */
 import './index.scss';
 import { object, text, withKnobs } from '@storybook/addon-knobs';
-import { ArrowRight20 } from '@carbon/icons-react';
 import FeatureCard from '../FeatureCard';
 import React from 'react';
 import readme from '../README.md';
@@ -46,9 +45,6 @@ storiesOf('Patterns (Blocks)|FeatureCard', module)
                 image: image,
                 cta: {
                   href: cardhref,
-                  icon: {
-                    src: ArrowRight20,
-                  },
                 },
               }}
             />

--- a/packages/react/src/patterns/blocks/FeatureCard/__stories__/FeatureCard.stories.js
+++ b/packages/react/src/patterns/blocks/FeatureCard/__stories__/FeatureCard.stories.js
@@ -6,6 +6,7 @@
  */
 import './index.scss';
 import { object, text, withKnobs } from '@storybook/addon-knobs';
+import { ArrowRight20 } from '@carbon/icons-react';
 import FeatureCard from '../FeatureCard';
 import React from 'react';
 import readme from '../README.md';
@@ -45,6 +46,9 @@ storiesOf('Patterns (Blocks)|FeatureCard', module)
                 image: image,
                 cta: {
                   href: cardhref,
+                  icon: {
+                    src: ArrowRight20,
+                  },
                 },
               }}
             />

--- a/packages/styles/scss/globals/utils/_hang.scss
+++ b/packages/styles/scss/globals/utils/_hang.scss
@@ -1,0 +1,5 @@
+// mixin to hang into the gutters of the grid
+@mixin hang() {
+  margin-left: -($carbon--grid-gutter / 2);
+  margin-right: -($carbon--grid-gutter / 2);
+}

--- a/packages/styles/scss/patterns/blocks/feature-card/_feature-card.scss
+++ b/packages/styles/scss/patterns/blocks/feature-card/_feature-card.scss
@@ -37,6 +37,7 @@
       bottom: 0;
       @include carbon--breakpoint('md') {
         flex-direction: row;
+        @include hang;
       }
 
       &__wrapper,
@@ -53,10 +54,7 @@
     @include carbon--breakpoint('md') {
       .#{$prefix}--content-group__title {
         max-width: 100%;
-      }
-
-      .#{$prefix}--content-group__children {
-        @include hang;
+        padding: 0;
       }
     }
   }

--- a/packages/styles/scss/patterns/blocks/feature-card/_feature-card.scss
+++ b/packages/styles/scss/patterns/blocks/feature-card/_feature-card.scss
@@ -8,6 +8,7 @@
 @import '../../../components/image/image';
 @import '../../sub-patterns/card/index';
 @import '../../../globals/utils/aspect-ratio';
+@import '../../../globals/utils/hang';
 
 @mixin feature-card {
   .#{$prefix}--feature-card {
@@ -20,7 +21,7 @@
       color: $inverse-01;
     }
 
-    .bx--content-group__children {
+    .#{$prefix}--content-group__children {
       padding-top: aspect-ratio(1, 1);
       position: relative;
       @include carbon--breakpoint('md') {
@@ -46,6 +47,16 @@
           width: 50%;
           height: aspect-ratio(1, 1);
         }
+      }
+    }
+
+    @include carbon--breakpoint('md') {
+      .#{$prefix}--content-group__title {
+        max-width: 100%;
+      }
+
+      .#{$prefix}--content-group__children {
+        @include hang;
       }
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

Feature card: Card Needs to Hang #1067

### Description

Set card in the `FeatureCard` component to hang into the gutters as per [design specs](https://ibm.ent.box.com/file/608050432455)

<img width="684" alt="Screen Shot 2020-02-25 at 3 53 35 PM" src="https://user-images.githubusercontent.com/54281166/75287554-9316de00-57e8-11ea-9d03-b652cf3cc494.png">

### Changelog

**New**

- add `hang` mixin to global utils folder

**Changed**

- set the content group title in `FeatureCard` to full width
- in `md` breakpoint and higher, have the card hang

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
