### PR TITLE
Feat/decode string util

### DIFF
--- a/packages/utilities/src/utilities/decodeString/__tests__/decodeString.test.js
+++ b/packages/utilities/src/utilities/decodeString/__tests__/decodeString.test.js
@@ -1,0 +1,10 @@
+import { decodeString } from '../';
+
+describe('Decode string utility', () => {
+  const str = 'https://www.ibm.com/search?lang=en&amp;cc=us&amp;q=cloud';
+
+  it('should return a string with decoded text content', () => {
+    const output = decodeString(str);
+    expect(output).toBe('https://www.ibm.com/search?lang=en&cc=us&q=cloud');
+  });
+});

--- a/packages/utilities/src/utilities/decodeString/decodeString.js
+++ b/packages/utilities/src/utilities/decodeString/decodeString.js
@@ -1,0 +1,21 @@
+/**
+ * Utility function to parse and decode text content.
+ * Strings can become encoded when passed as props for various reasons.
+ * This utility decodes those strings.
+ *
+ * @param {string} str String to decode
+ * @returns {string} Final string with decoded characters
+ * @example
+ * import { decodeString } from '@carbon/ibmdotcom-utilities'
+ *
+ * const str = decodeString('https://www.ibm.com/search?lang=en&amp;cc=us&amp;q=cloud');
+ * console.log(str); // https://www.ibm.com/search?lang=en&cc=us&q=cloud
+ *
+ */
+function decodeString(str) {
+  const parser = new DOMParser();
+  return parser.parseFromString(`<!doctype html><body>${str}`, 'text/html').body
+    .textContent;
+}
+
+export default decodeString;

--- a/packages/utilities/src/utilities/decodeString/index.js
+++ b/packages/utilities/src/utilities/decodeString/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as decodeString } from './decodeString';

--- a/packages/utilities/src/utilities/index.js
+++ b/packages/utilities/src/utilities/index.js
@@ -6,6 +6,7 @@
  */
 
 export * from './altlangs';
+export * from './decodeString';
 export * from './escaperegexp';
 export * from './featureflag';
 export * from './geolocation';


### PR DESCRIPTION
### Description

Occasionally when strings are passed as props, characters can become encoded resulting in unexpected behaviour. This utility decodes the string. Useful for strings containing URI's with query parameters or other special characters.

Currently this is occurring in the `Image` component.

Expected URI:
`https://someimage.com?text=text&size=size`

Actual URI
`https://someimage.com?text=text&amp;size=size`

### Changelog

**New**

- `decodeString` utility

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
