### PR TITLE
fix(card-section): add card class to themed items in cardsection scss

### DIFF
--- a/packages/styles/scss/patterns/sections/card-section/_card-section.scss
+++ b/packages/styles/scss/patterns/sections/card-section/_card-section.scss
@@ -14,7 +14,8 @@
     &__heading {
       color: $text-01;
     }
-    &__content {
+    &__copy,
+    &__eyebrow {
       color: $text-02;
     }
     &__footer {


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Card Section Simple - Card font text is not readable, while theme (g90 and g100) is changed. #1479

### Description

`Card` className for copy changed to `--card__copy` instead of `--card__content`. Updating and adding `eyebrow` class as well to ensure the text is visible in darker themes

<img width="1371" alt="Screen Shot 2020-02-26 at 11 15 30 AM" src="https://user-images.githubusercontent.com/54281166/75364839-56032800-588a-11ea-894a-4dec1c2dabc8.png">

### Changelog

**Changed**

- update card classes in `card-section`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
