### PR TITLE
fix(scss): adjusted bottom padding of content-group-pictograms

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/patterns/blocks/content-group-pictograms/_content-group-pictograms.scss
@@ -10,6 +10,14 @@
     &__item:not(:last-of-type) {
       padding-bottom: $carbon--layout-03;
     }
+
+    @include carbon--breakpoint(md) {
+      padding-bottom: $carbon--layout-03;
+    }
+
+    @include carbon--breakpoint(lg) {
+      padding-bottom: $carbon--layout-05;
+    }
   }
 }
 @include exports('content-group-pictograms') {


### PR DESCRIPTION
### Related Ticket(s)

#1476 

### Description

I've updated the bottom padding of the `ContentGroupPictograms` pattern in order to better match with the design specs.

### Changelog
**Changed**

- Added bottom padding on the pattern 