### PR TITLE
fix(alignment): added sameheight for eyebrow to fix alignment

### DIFF
--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -46,6 +46,10 @@ const CardSection = ({ heading, cards, theme }) => {
       'md'
     );
     sameHeight(
+      containerRef.current.getElementsByClassName(`${prefix}--card__eyebrow`),
+      'md'
+    );
+    sameHeight(
       containerRef.current.getElementsByClassName(`${prefix}--card__copy`),
       'md'
     );


### PR DESCRIPTION
### Related Ticket(s)

Related issue: #1504 

### Description

Fixed alignment of the cards when heading is big, 
### Changelog

**Changed**

-  Invoking sameHeight util for eyebrow.
![image](https://user-images.githubusercontent.com/53789187/75494776-fa6c9380-598a-11ea-8793-aa9464d5ccd3.png)
