### PR TITLE
fix(storybook): fix storybook var for TOC

### DIFF
--- a/packages/react/src/patterns/sub-patterns/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/__stories__/TableOfContents.stories.js
@@ -12,8 +12,6 @@ import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 import TableOfContents from '../TableOfContents';
 
-const _menuLabel = text('menu label', 'Jump to');
-
 const _themes = {
   g100: 'g100',
   white: '',
@@ -26,6 +24,8 @@ storiesOf('Patterns (Sub-Patterns)|Table of Contents', module)
     },
   })
   .add('Manually define Menu Items', () => {
+    const _menuLabel = text('menu label', 'Jump to');
+
     const menuItems = [
       {
         title: 'Cras molestie condimentum',
@@ -59,6 +59,8 @@ storiesOf('Patterns (Sub-Patterns)|Table of Contents', module)
     );
   })
   .add('Dynamic Items', () => {
+    const _menuLabel = text('menu label', 'Jump to');
+
     return (
       <TableOfContents
         theme={select('theme', _themes, _themes.white)}


### PR DESCRIPTION
### Description

`menuLabel` global variable in `TableOfContents` story is being picked up by all component stories.

![image](https://user-images.githubusercontent.com/909118/75901293-49dc1500-5e0c-11ea-914f-0f5a1b0036a3.png)

This localises the variable to `TOC` story only.


### Changelog

**Changed**

- localise `menuLabel` variable so it is not used by all component stories.


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
