### PR TITLE
fix(pattern): fixed the LinkList hover state width to edges

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -42,6 +42,8 @@
 
         color: $link-01;
       }
+
+      max-width: none;
     }
 
     @include carbon--breakpoint('md') {


### PR DESCRIPTION
### Related Ticket(s)
### Description

Fixed the width of LinkList when hover on the CTA item.

### Changelog
**Changed**

 - Added max width of CTA modifier for @lg breakpoint.
Before:
![image](https://user-images.githubusercontent.com/53789187/76026819-850a4100-5efd-11ea-9206-32f95dd59a79.png)
Now:
![image](https://user-images.githubusercontent.com/53789187/76026690-4aa0a400-5efd-11ea-8d25-981ac7f48aaa.png)
