### PR TITLE
fix(css): add white bg to masthead header

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -23,6 +23,7 @@ $search-transition-timing: 95ms;
     transition-delay: 200ms;
     transition-timing-function: $search-transition;
     transition-duration: 300ms;
+    background-color: $ui-background;
 
     &--sticky {
       &.#{$prefix}--masthead--sticky__l1 {


### PR DESCRIPTION
### Related Ticket(s)

#1604 

### Description

Adds background color to full width of `Masthead` to prevent issues like this

![Mar-05-2020 16-22-32](https://user-images.githubusercontent.com/909118/76026994-d87c8f00-5efd-11ea-9431-90b2d0ff6274.gif)


### Changelog

**Changed**

- add `background-color` to `Masthead` container


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
