### PR TITLE
fix(css): add missing css imports

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-block-media/index.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-media/index.scss
@@ -1,5 +1,6 @@
 @import '../../../globals/imports';
 @import '../../sub-patterns/card/index';
 @import '../../sub-patterns/content-block/content-block';
+@import '../../sub-patterns/content-group/content-group';
 @import '../../blocks/content-group-simple/content-group-simple';
 @import 'content-block-media';

--- a/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
@@ -8,6 +8,7 @@
 @import '../../../globals/imports';
 @import '../../../globals/utils/content-width';
 @import '../../../globals/utils/hang';
+@import '../../blocks/feature-card/feature-card';
 
 @mixin content-block {
   .#{$prefix}--content-block {


### PR DESCRIPTION
### Related Ticket(s)

#1592 

### Description

Adds missing CSS imports to `ContentBlock` and `ContentBlockMedia`

### Changelog

**Changed**

- add `ContentGroup` css to `ContentBlockMedia`
- add `FeatureCard` css to `ContentBlock`


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
