### PR TITLE
fix(css): add missing pattern css imports

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-block-mixed/index.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-mixed/index.scss
@@ -1,5 +1,6 @@
 @import '../../../globals/imports';
 @import '../../sub-patterns/content-block/content-block';
+@import '../../sub-patterns/content-group/content-group';
 @import '../../blocks/content-group-cards/index';
 @import '../content-group-pictograms/index';
 @import '../content-group-simple/index';

--- a/packages/styles/scss/patterns/blocks/content-block-segmented/index.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-segmented/index.scss
@@ -6,6 +6,7 @@
 //
 @import '../../../globals/imports';
 @import '../../sub-patterns/content-block/content-block';
+@import '../../sub-patterns/content-group/content-group';
 @import '../../sub-patterns/content-item/content-item';
-@import '../../../components/image/image';
+@import '../../../components/image-with-caption/image-with-caption';
 @import 'content-block-segmented';


### PR DESCRIPTION
### Related Ticket(s)

#1608 

### Description

Adds missing CSS imports for `ContentBlockMixed` and `ContentBlockSegmented`

### Changelog

**Changed**

- adds missing css imports

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
