### PR TITLE
fix(autoid): make autoids more specific for card section

### DIFF
--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -28,7 +28,7 @@ const { prefix } = settings;
  * @param {Array} props.cards Array of card
  * @returns {object} JSX Object
  */
-const CardSection = ({ heading, theme, cards, cta }) => {
+const CardSection = ({ heading, theme, cards, cta, ...otherProps }) => {
   const containerRef = useRef();
   useEffect(() => {
     setCardHeight();
@@ -67,6 +67,7 @@ const CardSection = ({ heading, theme, cards, cta }) => {
   return (
     <ContentSection
       heading={heading}
+      autoid={otherProps.autoid}
       customClassName={classNames(`${prefix}--card-section`, _setTheme(theme))}>
       {_renderCards(cards, containerRef, cta)}
     </ContentSection>

--- a/packages/react/src/patterns/sections/CardSectionImages/CardSectionImages.js
+++ b/packages/react/src/patterns/sections/CardSectionImages/CardSectionImages.js
@@ -6,8 +6,11 @@
  */
 
 import { CardSection } from '../CardSection';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+const { stablePrefix } = ddsSettings;
 
 /**
  * CardSectionImages pattern it is Cards with images
@@ -22,7 +25,13 @@ const CardSectionImages = ({ cards, ...otherProps }) => {
       image && eyebrow && heading && !copy && href
   );
   delete otherProps.cta;
-  return <CardSection {...otherProps} cards={cardsWithImages} />;
+  return (
+    <CardSection
+      {...otherProps}
+      autoid={`${stablePrefix}--card-section-images-section`}
+      cards={cardsWithImages}
+    />
+  );
 };
 
 CardSectionImages.propTypes = {

--- a/packages/react/src/patterns/sections/CardSectionSimple/CardSectionSimple.js
+++ b/packages/react/src/patterns/sections/CardSectionSimple/CardSectionSimple.js
@@ -1,6 +1,9 @@
 import { CardSection } from '../CardSection';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+const { stablePrefix } = ddsSettings;
 /**
  * CardSectionSimple pattern it is Cards without images
  *
@@ -14,7 +17,14 @@ const CardSectionSimple = ({ cards, cta, ...otherProps }) => {
     ({ image, eyebrow, heading, copy, cta: { href } }) =>
       !image && !eyebrow && heading && copy && href
   );
-  return <CardSection {...otherProps} cards={cardsWithoutImages} cta={cta} />;
+  return (
+    <CardSection
+      {...otherProps}
+      autoid={`${stablePrefix}--card-section-simple-section`}
+      cards={cardsWithoutImages}
+      cta={cta}
+    />
+  );
 };
 
 CardSectionSimple.propTypes = {

--- a/packages/react/src/patterns/sub-patterns/ContentSection/ContentSection.js
+++ b/packages/react/src/patterns/sub-patterns/ContentSection/ContentSection.js
@@ -24,7 +24,13 @@ const { prefix } = settings;
  * @param {string} props.customClassName optional class to be applied to the containing node
  * @returns {*} JSX ContentSection component
  */
-const ContentSection = ({ heading, theme, children, customClassName }) => {
+const ContentSection = ({
+  heading,
+  theme,
+  children,
+  customClassName,
+  ...otherProps
+}) => {
   /**
    * sets the class name based on theme type
    *
@@ -43,7 +49,11 @@ const ContentSection = ({ heading, theme, children, customClassName }) => {
         customClassName,
         _setTheme(theme)
       )}
-      data-autoid={`${stablePrefix}--content-section`}>
+      data-autoid={
+        otherProps.autoid
+          ? otherProps.autoid
+          : `${stablePrefix}--content-section`
+      }>
       <div className={`${prefix}--content-section__grid`}>
         <div className={`${prefix}--content-section__row`}>
           <div className={`${prefix}--content-section__left`}>


### PR DESCRIPTION
### Related Ticket(s)

Card Section Simple has a generic data-autoid #1621

### Description

make autoid for card section patterns more specific.

<img width="1680" alt="Screen Shot 2020-03-09 at 12 34 16 PM" src="https://user-images.githubusercontent.com/54281166/76236258-cacb5000-6202-11ea-9c6c-bbaac965888d.png">

### Changelog

**Changed**

- pass `autoid` prop to `CardSection` and `ContentSection` components