### PR TITLE
fix(import): import content section styles in card section

### DIFF
--- a/packages/styles/scss/patterns/sections/card-section/_card-section.scss
+++ b/packages/styles/scss/patterns/sections/card-section/_card-section.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../../components/link-with-icon/link-with-icon';
+@import '../../sub-patterns/content-section/content-section';
 @import '../../../globals/imports';
 @import '../../../globals/utils/ratio-base';
 


### PR DESCRIPTION
### Related Ticket(s)

Card Section Simple Pattern seems to be missing CSS #1624

### Description

import the content-section styles within `card-section.scss` as the card section pattern is missing grid styles defined in `content-section.scss`

### Changelog

**Changed**

- import `content-section` styles

