### PR TITLE
fix(toc): fixes toc overlapping the masthead dropdown

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -19,7 +19,7 @@ $search-transition-timing: 95ms;
     top: 0;
     left: 0;
     width: 100%;
-    z-index: 1;
+    z-index: 2;
     transition-delay: 200ms;
     transition-timing-function: $search-transition;
     transition-duration: 300ms;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1628

### Description

The table of contents was overlapping the masthead dropdown

Updated image: 

![Screen Shot 2020-03-09 at 5 30 45 PM](https://user-images.githubusercontent.com/56688604/76259346-d1ba8880-622b-11ea-9936-9b7d7d031adb.png)

### Changelog

**Changed**

Z index of the masthead


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
