### PR TITLE
chore(story): removed aspect-ratio on card pattern storybook

### DIFF
--- a/packages/react/src/patterns/sub-patterns/Card/__stories__/Card.stories.js
+++ b/packages/react/src/patterns/sub-patterns/Card/__stories__/Card.stories.js
@@ -38,14 +38,6 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
     },
   })
   .add('Static', () => {
-    const ratio = {
-      none: null,
-      '2:1': '2x1',
-      '16:9': '16x9',
-      '3:2 (not available in Carbon)': '3x2',
-      '4:3': '4x3',
-      '1:1': '1x1',
-    };
     const themes = {
       white: '',
       g10: 'g10',
@@ -62,23 +54,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
         <div className="bx--grid">
           <div className="bx--row">
             <div className="bx--col-sm-2 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
-              {!select('Ratio', ratio, ratio['none']) ? (
-                <Card {...props.cardProps()} image={image} type="static" />
-              ) : (
-                <div
-                  className={`bx--aspect-ratio bx--aspect-ratio--${select(
-                    'Ratio',
-                    ratio,
-                    ratio['none']
-                  )}`}>
-                  <Card
-                    {...props.cardProps()}
-                    image={image}
-                    type="static"
-                    customClassName="bx--aspect-ratio--object"
-                  />
-                </div>
-              )}
+              <Card {...props.cardProps()} image={image} type="static" />
             </div>
           </div>
         </div>
@@ -86,14 +62,6 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
     );
   })
   .add('Link/Clickable', () => {
-    const ratio = {
-      none: null,
-      '2:1': '2x1',
-      '16:9': '16x9',
-      '3:2 (not available in Carbon)': '3x2',
-      '4:3': '4x3',
-      '1:1': '1x1',
-    };
     const themes = {
       white: '',
       g10: 'g10',
@@ -110,23 +78,7 @@ storiesOf('Patterns (Sub-Patterns)|Card', module)
         <div className="bx--grid">
           <div className="bx--row">
             <div className="bx--col-sm-2 bx--col-md-3 bx--col-lg-6 bx--col-xlg-4 bx--no-gutter">
-              {!select('Ratio', ratio, ratio['none']) ? (
-                <Card {...props.cardProps()} image={image} type="link" />
-              ) : (
-                <div
-                  className={`bx--aspect-ratio bx--aspect-ratio--${select(
-                    'Ratio',
-                    ratio,
-                    ratio['none']
-                  )}`}>
-                  <Card
-                    {...props.cardProps()}
-                    type="link"
-                    image={image}
-                    customClassName="bx--aspect-ratio--object"
-                  />
-                </div>
-              )}
+              <Card {...props.cardProps()} image={image} type="link" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Related Ticket(s)

#1562 
### Description

The aspect ratio knobs have been removed, so we fix a bug on storybook where content would go out of the cards in certain aspects.