### PR TITLE
chore(docs): fixed wrong property name on documentation for pictograms

### DIFF
--- a/packages/react/src/patterns/blocks/ContentGroupPictograms/README.md
+++ b/packages/react/src/patterns/blocks/ContentGroupPictograms/README.md
@@ -38,7 +38,7 @@ const items = [
       copy: 'Lorem ipsum dolor',
     },
     pictogram: {
-      url: Desktop,
+      src: Desktop,
       'aria-label': 'Desktop Pictogram',
     },
   },
@@ -52,7 +52,7 @@ const items = [
       copy: 'Lorem ipsum dolor',
     },
     pictogram: {
-      url: Touch,
+      src: Touch,
       'aria-label': 'Touch Pictogram',
     },
   },
@@ -66,7 +66,7 @@ const items = [
       copy: 'Lorem ipsum dolor',
     },
     pictogram: {
-      url: Pattern,
+      src: Pattern,
       'aria-label': 'Pattern Pictogram',
     },
   },

--- a/packages/react/src/patterns/sub-patterns/PictogramItem/README.md
+++ b/packages/react/src/patterns/sub-patterns/PictogramItem/README.md
@@ -33,7 +33,7 @@ function App() {
   };
 
   const pictogram = {
-    url: Desktop,
+    src: Desktop,
     ariaLabel: 'Desktop pictogram',
   };
 


### PR DESCRIPTION
### Description

Fixed wrong property name on `PictogramItem` and `ContentGroupPictograms` docs