### PR TITLE
fix(scss): hover now fits the whole width

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -31,6 +31,7 @@
     }
 
     .#{$prefix}--card {
+      max-width: none;
       &__wrapper {
         min-height: 116px;
       }


### PR DESCRIPTION
### Related Ticket(s)

#1601
### Description

I've fixed the `LinkList` hover state, so it fits the whole pattern.
