### PR TITLE
fix(scss): added padding for link-list

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -7,6 +7,8 @@
 
 @mixin link-list {
   .#{$prefix}--link-list {
+    padding-bottom: $carbon--layout-05;
+    padding-top: $carbon--layout-05;
     &__heading {
       margin-bottom: $carbon--spacing-05;
 


### PR DESCRIPTION
### Related Ticket(s)

#1667 

### Description

I've added padding for both top and bottom to the `Link-list` pattern.

### Changelog

**New**

- Padding added on scss