### PR TITLE
Fix/cta text link

### DIFF
--- a/packages/react/src/components/CTA/CTA.js
+++ b/packages/react/src/components/CTA/CTA.js
@@ -69,9 +69,10 @@ const renderCTA = ({ style, type, ...otherProps }) => {
       );
     default: {
       const Icon = _iconSelector(type);
+      const href = otherProps.href ? otherProps.href : otherProps.cta.href;
       return (
         <LinkWithIcon
-          href={otherProps.cta.href}
+          href={href}
           target={_external(type)}
           onClick={e => _jump(e, type)}>
           {otherProps.copy}

--- a/packages/react/src/components/CTA/CTA.js
+++ b/packages/react/src/components/CTA/CTA.js
@@ -71,7 +71,7 @@ const renderCTA = ({ style, type, ...otherProps }) => {
       const Icon = _iconSelector(type);
       return (
         <LinkWithIcon
-          href={otherProps.href}
+          href={otherProps.cta.href}
           target={_external(type)}
           onClick={e => _jump(e, type)}>
           {otherProps.copy}

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
@@ -32,7 +32,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
       cta: {
         href: 'https://www.ibm.com',
       },
-      style: select('CTA style', ctaStyles, ctaStyles.card),
+      style: 'card',
       type: select('CTA type', ctaTypes, ctaTypes.local),
       heading: 'Lorem ipsum dolor sit amet',
       copy: 'Lorem ipsum dolor sit ametttt',

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
@@ -1,6 +1,6 @@
 import './index.scss';
 import { Desktop, Pattern, Touch } from '@carbon/pictograms-react';
-import { text, object, withKnobs } from '@storybook/addon-knobs';
+import { text, object, select, withKnobs } from '@storybook/addon-knobs';
 import ContentBlockMixed from '../ContentBlockMixed';
 import ContentGroupCardsKnobs from '../../ContentGroupCards/__stories__/data/ContentGroupCards.knobs';
 import ContentGroupSimpleKnobs from '../../ContentGroupSimple/__stories__/data/ContentGroupSimple.knobs';
@@ -17,13 +17,24 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
   })
   .add('Default', () => {
     const heading = 'Lorem ipsum dolor sit amet';
+    const ctaStyles = {
+      text: 'text',
+      card: 'card',
+    };
 
-    const cta = {
+    const ctaTypes = {
+      local: 'local',
+      jump: 'jump',
+      external: 'external',
+    };
+
+    const ctaProps = {
       cta: {
-        href: 'https://www.example.com',
+        href: 'https://www.ibm.com',
       },
-      style: 'card',
-      type: 'local',
+      style: select('CTA style', ctaStyles, ctaStyles.card),
+      type: select('CTA type', ctaTypes, ctaTypes.local),
+      heading: 'Lorem ipsum dolor sit amet',
       copy: 'Lorem ipsum dolor sit ametttt',
     };
 
@@ -40,9 +51,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
         copy:
           'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
         cta: {
-          cta: {
-            href: 'https://www.example.com',
-          },
+          href: 'https://www.ibm.com',
           type: 'local',
           copy: 'Lorem ipsum dolor',
         },
@@ -56,9 +65,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
         copy:
           'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
         cta: {
-          cta: {
-            href: 'https://www.example.com',
-          },
+          href: 'https://www.ibm.com',
           type: 'local',
           copy: 'Lorem ipsum dolor',
         },
@@ -72,9 +79,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
         copy:
           'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
         cta: {
-          cta: {
-            href: 'https://www.example.com',
-          },
+          href: 'https://www.ibm.com',
           type: 'local',
           copy: 'Lorem ipsum dolor',
         },
@@ -118,7 +123,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
             <ContentBlockMixed
               heading={heading}
               copy={copy}
-              cta={cta}
+              cta={ctaProps}
               items={items}
             />
           </div>

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
@@ -17,10 +17,6 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
   })
   .add('Default', () => {
     const heading = 'Lorem ipsum dolor sit amet';
-    const ctaStyles = {
-      text: 'text',
-      card: 'card',
-    };
 
     const ctaTypes = {
       local: 'local',

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
@@ -16,12 +16,23 @@ storiesOf('Patterns (Blocks)|ContentBlockSimple', module)
     },
   })
   .add('Default', () => {
+    const ctaStyles = {
+      text: 'text',
+      card: 'card',
+    };
+
+    const ctaTypes = {
+      local: 'local',
+      jump: 'jump',
+      external: 'external',
+    };
+
     const ctaProps = {
       cta: {
         href: 'https://www.ibm.com',
       },
-      style: 'card',
-      type: 'external',
+      style: select('CTA style', ctaStyles, ctaStyles.card),
+      type: select('CTA type', ctaTypes, ctaTypes.local),
       heading: 'Lorem ipsum dolor sit amet',
       copy: 'Lorem ipsum dolor sit ametttt',
     };


### PR DESCRIPTION
### Related Ticket(s)

#1682 

### Description

Fixes `href` prop for `CTA` component when using `text` style

### Changelog

**New**

- add `style` and `type` CTA knobs to `ContentBlockSimple` story

**Changed**

- fix `href` prop for `text` style CTA


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
