### PR TITLE
fix(pattern): fix on top-menu for ios

### DIFF
--- a/packages/react/src/patterns/sub-patterns/TableOfContents/TOCMobile.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/TOCMobile.js
@@ -46,6 +46,9 @@ const TOCMobile = ({ menuItems, selectedId, menuLabel, updateState }) => {
     updateState(id, title);
     const selector = `a[name="${id}"]`;
     smoothScroll(null, selector);
+    document.querySelector(
+      `.${prefix}--tableofcontents__sidebar`
+    ).style.top = 0;
   };
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

#1503 

### Description

I've tried to fix a bug where the menu dropdown would get out of the screen when an option is selected on ios devices.