### PR TITLE
fix(cardsection): fixed the aspect ratio on images

### DIFF
--- a/packages/react/src/patterns/sections/CardSection/__stories__/data/cards.json
+++ b/packages/react/src/patterns/sections/CardSection/__stories__/data/cards.json
@@ -39,7 +39,7 @@
   "CardSectionImages": [
     {
       "image": {
-        "defaultSrc": "https://dummyimage.com/1056x480/ee5396/161616",
+        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
         "alt": "Image alt text"
       },
       "eyebrow": "Topic",
@@ -50,7 +50,7 @@
     },
     {
       "image": {
-        "defaultSrc": "https://dummyimage.com/1056x480/ee5396/161616",
+        "defaultSrc": "https://dummyimage.com/792x1056/ee5396/161616%26text=3:4",
         "alt": "Image alt text"
       },
       "eyebrow": "Blog",
@@ -61,7 +61,7 @@
     },
     {
       "image": {
-        "defaultSrc": "https://dummyimage.com/1056x480/ee5396/161616",
+        "defaultSrc": "https://dummyimage.com/1056x1056/ee5396/161616%26text=1:1",
         "alt": "Image alt text"
       },
       "eyebrow": "Topic",
@@ -72,7 +72,7 @@
     },
     {
       "image": {
-        "defaultSrc": "https://dummyimage.com/1056x480/ee5396/161616",
+        "defaultSrc": "https://dummyimage.com/1056x528/ee5396/161616%26text=2:1",
         "alt": "Image alt text"
       },
       "eyebrow": "Blog",
@@ -83,7 +83,7 @@
     },
     {
       "image": {
-        "defaultSrc": "https://dummyimage.com/1056x480/ee5396/161616",
+        "defaultSrc": "https://dummyimage.com/1056x594/ee5396/161616%26text=16:9",
         "alt": "Image alt text"
       },
       "eyebrow": "Topic",

--- a/packages/styles/scss/globals/utils/_ratio-base.scss
+++ b/packages/styles/scss/globals/utils/_ratio-base.scss
@@ -1,20 +1,29 @@
 // mixin to give the ratio for lays doen for an aspect ratio
 @import '../../globals/utils/aspect-ratio';
 
-@mixin ratio-base($height, $width) {
-  display: flex;
-
-  &::before {
-    content: '';
-    width: 1px;
-    margin-left: -1px;
-    float: left;
-    height: 0;
+@mixin ratio-base($height, $width, $fixed) {
+  @if ($fixed) {
+    // fixed ratio overflow hidden
+    position: relative;
     padding-top: aspect-ratio($height, $width);
-  }
-  &::after {
-    content: '';
-    display: table;
-    clear: both;
+    height: 0;
+    overflow: hidden;
+  } @else {
+    // graceful ratio overflow similar to a min-height
+    display: flex;
+
+    &::before {
+      content: '';
+      width: 1px;
+      margin-left: -1px;
+      float: left;
+      height: 0;
+      padding-top: aspect-ratio($height, $width);
+    }
+    &::after {
+      content: '';
+      display: table;
+      clear: both;
+    }
   }
 }

--- a/packages/styles/scss/patterns/sections/card-section/_card-section.scss
+++ b/packages/styles/scss/patterns/sections/card-section/_card-section.scss
@@ -50,14 +50,17 @@
     &__card {
       .#{$prefix}--image {
         &__img {
-          @include carbon--breakpoint('lg') {
-            @include ratio-base(4, 3);
-
-            height: auto;
-          }
-
           height: carbon--mini-units(30);
-          flex: 1;
+        }
+
+        @include carbon--breakpoint('lg') {
+          @include ratio-base(4, 3, true);
+
+          &__img {
+            position: absolute;
+            height: 100%;
+            top: 0;
+          }
         }
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

closes #1721 
https://cognitive-app.slack.com/archives/CNEG9HNBW/p1584549707073900

### Description

Having issues where the card section image ratios aren't working properly. This pull request fixes that.

### Changelog

**Changed**

- shifted where the ratio was applied
- updated ratio base with a overflow hidden / fixed option.
- updated storybook with a variety of aspect ratios.
