### PR TITLE
fix(scss): reinforced link-list pattern styling selectors

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -33,21 +33,17 @@
     }
 
     .#{$prefix}--card {
+      max-width: none;
       &__wrapper {
         min-height: 116px;
+        .#{$prefix}--card__copy p {
+          color: $link-01;
+          @include carbon--type-style('body-short-02');
+        }
       }
       &:not(:hover) {
         background: $ui-background;
       }
-      &__copy p {
-        @include carbon--type-style('body-short-02');
-
-        color: $link-01;
-      }
-    }
-
-    @include carbon--breakpoint('md') {
-      max-width: carbon--mini-units(80);
     }
   }
 }

--- a/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
@@ -15,8 +15,7 @@
   .#{$prefix}--tableofcontents__content {
     h2,
     h3,
-    h4,
-    p {
+    h4 {
       color: $text-01;
     }
   }


### PR DESCRIPTION
### Related Ticket(s)

#1733 

### Description

I've updated the selectors for `LinkList` and `TableOfComponents` so they are more specific to the patterns.

### Changelog

**Changed**

- SCSS Selectors
