### PR TITLE
feat(video-player): embed video player within lightbox component 

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
+++ b/packages/react/src/components/LightboxMediaViewer/LightboxMediaViewer.js
@@ -16,6 +16,7 @@ import { ModalBody } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
+import { VideoPlayer } from '../VideoPlayer';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -24,13 +25,11 @@ const { prefix } = settings;
  * LightboxMediaViewer Component
  *
  * @param {object} modalProps props object
- * @param {string} modalProps.title LightboxMediaViewer media title
- * @param {string} modalProps.copy LightboxMediaViewer media short description
- * @param {string} modalProps.image LightboxMediaViewer responsive image object
+ * @param {object} modalProps.media LightboxMediaViewer media object
  * @param {boolean} modalProps.open sets whether the modal is open/close
  * @returns {*} JSX Object
  */
-const LightboxMediaViewer = ({ title, image, copy, ...modalProps }) => {
+const LightboxMediaViewer = ({ media, ...modalProps }) => {
   return featureFlag(
     DDS_LIGHTBOX_MEDIA_VIEWER,
     <section
@@ -40,20 +39,24 @@ const LightboxMediaViewer = ({ title, image, copy, ...modalProps }) => {
         <ModalBody>
           <div className={`${prefix}--lightbox-media-viewer__container`}>
             <div className={`${prefix}--lightbox-media-viewer__row`}>
-              <Image {...image} />
+              {media.type === 'video' ? (
+                <VideoPlayer videoId={media.src} />
+              ) : (
+                <Image defaultSrc={media.src} alt={media.alt} />
+              )}
               <div className={`${prefix}--lightbox-media-viewer__content`}>
-                {title && (
+                {media.title && (
                   <div
                     data-autoid={`${stablePrefix}--lightbox-media-viewer__content__title`}
                     className={`${prefix}--lightbox-media-viewer__content__title`}>
-                    {title}
+                    {media.title}
                   </div>
                 )}
-                {copy && (
+                {media.description && (
                   <div
                     data-autoid={`${stablePrefix}--lightbox-media-viewer__content__desc`}
                     className={`${prefix}--lightbox-media-viewer__content__desc`}>
-                    {copy}
+                    {media.description}
                   </div>
                 )}
               </div>
@@ -66,8 +69,6 @@ const LightboxMediaViewer = ({ title, image, copy, ...modalProps }) => {
 };
 
 LightboxMediaViewer.propTypes = {
-  title: PropTypes.string,
-  copy: PropTypes.string,
-  image: PropTypes.object.isRequired,
+  media: PropTypes.object.isRequired,
 };
 export default LightboxMediaViewer;

--- a/packages/react/src/components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js
+++ b/packages/react/src/components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js
@@ -1,5 +1,5 @@
 import './index.scss';
-import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { DDS_LIGHTBOX_MEDIA_VIEWER } from '../../../internal/FeatureFlags';
 import LightboxMediaViewer from '../LightboxMediaViewer';
 import React from 'react';
@@ -15,26 +15,41 @@ if (DDS_LIGHTBOX_MEDIA_VIEWER) {
       },
     })
     .add('Default', () => {
-      const title = text(
-        'Title (required)',
-        'Curabitur malesuada varius mi eu posuere'
-      );
-      const copy = text(
-        'Copy (required)',
-        `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Here are some common categories:`
-      );
-      const image = {
-        defaultSrc: 'https://dummyimage.com/1024x512/ee5396/161616&text=2:1',
+      const media = {
+        src: 'https://dummyimage.com/1024x512/ee5396/161616&text=2:1',
         alt: 'Image alt text',
+        title: text(
+          'title (required)',
+          'Curabitur malesuada varius mi eu posuere'
+        ),
+        description: text(
+          'description (required)',
+          `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Here are some common categories:`
+        ),
+        type: 'image',
+        active: false,
+        srcThumb: 'https://dummyimage.com/1024x512/ee5396/161616&text=2:1',
       };
 
-      return (
-        <LightboxMediaViewer
-          title={title}
-          copy={copy}
-          image={object('image', image)}
-          open={boolean('open', true)}
-        />
-      );
+      return <LightboxMediaViewer media={media} open={boolean('open', true)} />;
+    })
+    .add('Embedded Video Player', () => {
+      const media = {
+        src: '0_uka1msg4',
+        alt: 'Image alt text',
+        title: text(
+          'title (required)',
+          'Curabitur malesuada varius mi eu posuere'
+        ),
+        description: text(
+          'description (required)',
+          `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Here are some common categories:`
+        ),
+        type: 'video',
+        active: false,
+        srcThumb: '',
+      };
+
+      return <LightboxMediaViewer media={media} open={boolean('open', true)} />;
     });
 }

--- a/packages/react/src/components/VideoPlayer/VideoPlayer.js
+++ b/packages/react/src/components/VideoPlayer/VideoPlayer.js
@@ -33,7 +33,7 @@ const VideoPlayer = ({ videoId, showDescription }) => {
   }, [videoId, videoPlayerId]);
 
   return (
-    <div classNamee={`${prefix}--video-player`}>
+    <div className={`${prefix}--video-player`}>
       <div
         className={`${prefix}--video-player__video-container`}
         data-autoid={`${stablePrefix}--${videoPlayerId}`}>

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -19,6 +19,11 @@
     &__row {
       @include carbon--make-row;
     }
+
+    .#{$prefix}--video-player {
+      width: 100%;
+    }
+
     &__content {
       @include carbon--type-style('body-long-02');
 
@@ -43,6 +48,7 @@
         top: $carbon--spacing-05;
         right: $carbon--spacing-05;
       }
+
       &__container {
         padding-top: $carbon--spacing-05;
       }
@@ -52,6 +58,12 @@
         padding-top: $carbon--layout-04;
         padding-bottom: $carbon--spacing-05;
       }
+
+      .#{$prefix}--video-player {
+        @include carbon--make-col-ready;
+        @include carbon--make-col(12, 16);
+      }
+
       &__image {
         @include carbon--make-col-ready;
         @include carbon--make-col(12, 16);


### PR DESCRIPTION
### Related Ticket(s)

Enable the Lightbox media viewer to render the Kaltura embedded video player #1109

### Description

Render the Kaltura video player within the LightBox Media Viewer component.

<img width="1469" alt="Screen Shot 2020-03-19 at 11 43 54 PM" src="https://user-images.githubusercontent.com/54281166/77134485-95620600-6a3d-11ea-8fa6-89fa954f964c.png">


### Changelog

**Changed**

- changed props to somewhat match what was listed in the lightbox viewer func specs (`media` prop is an `object` instead of `array` as we're not supporting carousel right now)
- render the `VideoPlayer` component when media type is video.

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
