### PR TITLE
fix(scss): force gpu acceleration rendering for table of contents on ios

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/layout/_layout.scss
+++ b/packages/styles/scss/patterns/sub-patterns/layout/_layout.scss
@@ -14,6 +14,7 @@
         position: sticky;
         top: 0;
         z-index: 1;
+        transform: translate3d(0, 0, 0);
       }
     }
 


### PR DESCRIPTION
### Related Ticket(s)

#1725 

### Description

In order to fix an issue where the top menu of the `TableOfContents` pattern disappeared after scrolling using the menu

### Changelog

**New**

- transform3d added to the menu