### PR TITLE
fix(link-with-icon): fixed type size

### DIFF
--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -17,6 +17,8 @@
     display: flex;
 
     span {
+      @include carbon--type-style(body-short-02, true);
+
       vertical-align: middle;
       align-self: center;
     }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1455

### Description

The link with icon component was using the wrong type size. Affecting all components using this component. Adjusted to use the correct type size


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
