### PR TITLE
fix(issue-1622): remove TOC header text color

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
@@ -12,13 +12,6 @@
 @mixin themed-items {
   color: $text-01;
   background: $ui-background;
-  .#{$prefix}--tableofcontents__content {
-    h2,
-    h3,
-    h4 {
-      color: $text-01;
-    }
-  }
   .#{$prefix}--tableofcontents__mobile {
     border-top: 1px solid $ui-04;
     border-bottom: 1px solid $ui-04;


### PR DESCRIPTION
### Related Ticket(s)

https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/1622

### Description

feature card within TOC is unreadable since its theme css is being overridden. remove hardcoded TOC css header styles so feature card styling can be done on pattern level.

![learn-page-bug](https://user-images.githubusercontent.com/38012976/77542144-1b39e300-6e7c-11ea-8c70-6905b0ccc727.png)

### Changelog

```
  .#{$prefix}--tableofcontents__content {
    h2,
    h3,
    h4 {
      color: $text-01;
    }
  }
```

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: styles" -->
