### PR TITLE
Fix/decode image strings

### DIFF
--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -5,8 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { baseFontSize, breakpoints } from '@carbon/layout';
+import {
+  decodeString,
+  settings as ddsSettings,
+} from '@carbon/ibmdotcom-utilities';
 import classnames from 'classnames';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
@@ -64,13 +67,13 @@ const Image = ({ classname, sources, defaultSrc, alt }) => {
           <source
             media={`(min-width: ${imgSrc.breakpoint}px )`}
             key={key}
-            srcSet={imgSrc.src}
+            srcSet={decodeString(imgSrc.src)}
           />
         );
       })}
       <img
         className={classnames(`${prefix}--image__img`, classname)}
-        src={defaultSrc}
+        src={decodeString(defaultSrc)}
         alt={alt}
       />
     </picture>

--- a/packages/react/src/components/Image/__stories__/Image.stories.js
+++ b/packages/react/src/components/Image/__stories__/Image.stories.js
@@ -9,7 +9,10 @@ import { object, text, withKnobs } from '@storybook/addon-knobs';
 import Image from '../Image';
 import React from 'react';
 import readme from '../README.md';
+import { settings } from 'carbon-components';
 import { storiesOf } from '@storybook/react';
+
+const { prefix } = settings;
 
 storiesOf('Components|Image', module)
   .addDecorator(withKnobs)
@@ -39,5 +42,13 @@ storiesOf('Components|Image', module)
       'https://dummyimage.com/672x672/ee5396/161616&text=1x1'
     );
 
-    return <Image sources={image} defaultSrc={defaultSrc} alt={alt}></Image>;
+    return (
+      <div className={`${prefix}--grid`}>
+        <div class="bx--row">
+          <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+            <Image sources={image} defaultSrc={defaultSrc} alt={alt}></Image>
+          </div>
+        </div>
+      </div>
+    );
   });


### PR DESCRIPTION
### Description

This adds the `decodeString` utility to the `Image` component to prevent encoding in strings, e.g.

`https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1`

becomes

`https://dummyimage.com/400x200/ee5396/161616&text=2x1` (no encoded **\&amp;**)

### Changelog

**New**

- `decodeString` util in `Image` component

**Changed**

- add grid layout to `Image` Storybook story


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
