### PR TITLE
fix(card-section-images): account for eyebrow in sameheight utility

### DIFF
--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -51,6 +51,10 @@ const CardSection = ({ heading, theme, cards, cta, ...otherProps }) => {
       containerRef.current.getElementsByClassName(`${prefix}--card__copy`),
       'md'
     );
+    sameHeight(
+      containerRef.current.getElementsByClassName(`${prefix}--card__eyebrow`),
+      'md'
+    );
   };
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

Pattern: CardSection Images - Cards are misaligned, when the heading is large. #1867

### Description

Take `eyebrow` element into account when adjusting height for card section

<img width="1680" alt="Screen Shot 2020-03-26 at 12 22 27 PM" src="https://user-images.githubusercontent.com/54281166/77670692-eb164100-6f5c-11ea-8a7f-157ab83db9f2.png">

### Changelog

**Changed**

- add `eyebrow` to `sameHeight` utility

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
