### PR TITLE
fix(util): remove decodeString util

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.1-rc.2](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.5.1-rc.1...@carbon/ibmdotcom-react@1.5.1-rc.2) (2020-03-26)
+
+### Bug Fixes
+
+- **card-section-images:** account for eyebrow in sameheight utility
+  ([74184d2](https://github.com/carbon-design-system/ibm-dotcom-library/commit/74184d2))
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
 ## [1.5.1-rc.1](https://github.com/carbon-design-system/ibm-dotcom-library/compare/@carbon/ibmdotcom-react@1.5.1-rc.0...@carbon/ibmdotcom-react@1.5.1-rc.1) (2020-03-26)
 
 ### Bug Fixes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibmdotcom-react",
   "description": "IBM.com Library React Components and Patterns",
-  "version": "1.5.1-rc.1",
+  "version": "1.5.1-rc.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -10,6 +10,7 @@ import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
+import { uniqueid } from '@carbon/ibmdotcom-utilities';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -45,35 +46,44 @@ const sortSources = sources => {
  * @param {object} props.images array of images used for diff breakpoints
  * @param {string} props.defaultSrc default image (usually image for largest breakpoint)
  * @param {string} props.alt alt of the image
+ * @param {string} props.longDescription optional long description for infographics.
  * @returns {*} picture element
  */
-const Image = ({ classname, sources, defaultSrc, alt }) => {
+const Image = ({ classname, sources, defaultSrc, alt, longDescription }) => {
   if (!defaultSrc || !alt) {
     return null;
   }
 
   const sortedImages = sources ? sortSources(sources) : [];
-
+  const id = uniqueid(`${prefix}--image-`);
   return (
-    <picture
-      alt={alt}
-      className={`${prefix}--image`}
-      data-autoid={`${stablePrefix}--image`}>
-      {sortedImages.map((imgSrc, key) => {
-        return (
-          <source
-            media={`(min-width: ${imgSrc.breakpoint}px )`}
-            key={key}
-            srcSet={imgSrc.src}
-          />
-        );
-      })}
-      <img
-        className={classnames(`${prefix}--image__img`, classname)}
-        src={defaultSrc}
+    <>
+      <picture
         alt={alt}
-      />
-    </picture>
+        className={`${prefix}--image`}
+        data-autoid={`${stablePrefix}--image__longdescription-`}>
+        {sortedImages.map((imgSrc, key) => {
+          return (
+            <source
+              media={`(min-width: ${imgSrc.breakpoint}px )`}
+              key={key}
+              srcSet={imgSrc.src}
+            />
+          );
+        })}
+        <img
+          className={classnames(`${prefix}--image__img`, classname)}
+          src={defaultSrc}
+          alt={alt}
+          longdesc={longDescription ? `#${id}` : ''}
+        />
+      </picture>
+      {longDescription ? (
+        <div id={id} className={`${prefix}--image__longdescription`}>
+          {longDescription}
+        </div>
+      ) : null}
+    </>
   );
 };
 
@@ -87,6 +97,7 @@ Image.propTypes = {
   ),
   defaultSrc: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
+  longDescription: PropTypes.string,
 };
 
 export default Image;

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -57,22 +57,8 @@ const Image = ({ classname, sources, defaultSrc, alt, longDescription }) => {
   const sortedImages = sources ? sortSources(sources) : [];
   const id = uniqueid(`${prefix}--image-`);
   return (
-    <picture
-      alt={alt}
-      className={`${prefix}--image`}
-      data-autoid={`${stablePrefix}--image`}>
-      {sortedImages.map((imgSrc, key) => {
-        return (
-          <source
-            media={`(min-width: ${imgSrc.breakpoint}px )`}
-            key={key}
-            srcSet={imgSrc.src}
-          />
-        );
-      })}
-      <img
-        className={classnames(`${prefix}--image__img`, classname)}
-        src={defaultSrc}
+    <>
+      <picture
         alt={alt}
         className={`${prefix}--image`}
         data-autoid={`${stablePrefix}--image__longdescription-`}>

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -75,7 +75,7 @@ const Image = ({ classname, sources, defaultSrc, alt, longDescription }) => {
           className={classnames(`${prefix}--image__img`, classname)}
           src={defaultSrc}
           alt={alt}
-          longdesc={longDescription ? `#${id}` : ''}
+          aria-describedby={longDescription ? `${id}` : ''}
         />
       </picture>
       {longDescription ? (

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -57,8 +57,22 @@ const Image = ({ classname, sources, defaultSrc, alt, longDescription }) => {
   const sortedImages = sources ? sortSources(sources) : [];
   const id = uniqueid(`${prefix}--image-`);
   return (
-    <>
-      <picture
+    <picture
+      alt={alt}
+      className={`${prefix}--image`}
+      data-autoid={`${stablePrefix}--image`}>
+      {sortedImages.map((imgSrc, key) => {
+        return (
+          <source
+            media={`(min-width: ${imgSrc.breakpoint}px )`}
+            key={key}
+            srcSet={imgSrc.src}
+          />
+        );
+      })}
+      <img
+        className={classnames(`${prefix}--image__img`, classname)}
+        src={defaultSrc}
         alt={alt}
         className={`${prefix}--image`}
         data-autoid={`${stablePrefix}--image__longdescription-`}>

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -5,11 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { baseFontSize, breakpoints } from '@carbon/layout';
-import {
-  decodeString,
-  settings as ddsSettings,
-} from '@carbon/ibmdotcom-utilities';
 import classnames from 'classnames';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
@@ -67,13 +64,13 @@ const Image = ({ classname, sources, defaultSrc, alt }) => {
           <source
             media={`(min-width: ${imgSrc.breakpoint}px )`}
             key={key}
-            srcSet={decodeString(imgSrc.src)}
+            srcSet={imgSrc.src}
           />
         );
       })}
       <img
         className={classnames(`${prefix}--image__img`, classname)}
-        src={decodeString(defaultSrc)}
+        src={defaultSrc}
         alt={alt}
       />
     </picture>

--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -51,6 +51,10 @@ const CardSection = ({ heading, theme, cards, cta, ...otherProps }) => {
       containerRef.current.getElementsByClassName(`${prefix}--card__copy`),
       'md'
     );
+    sameHeight(
+      containerRef.current.getElementsByClassName(`${prefix}--card__eyebrow`),
+      'md'
+    );
   };
 
   /**

--- a/packages/react/src/patterns/sub-patterns/Card/Card.js
+++ b/packages/react/src/patterns/sub-patterns/Card/Card.js
@@ -87,7 +87,7 @@ function optionalContent(copy) {
 function renderFooter(cta, type) {
   return (
     cta && (
-      <footer className={`${prefix}--card__footer`}>
+      <div className={`${prefix}--card__footer`}>
         {type !== 'link' ? (
           <CTA style="text" {...cta} customClassName={`${prefix}--card__cta`} />
         ) : (
@@ -95,7 +95,7 @@ function renderFooter(cta, type) {
             <cta.icon.src className={`${prefix}--card__cta`} {...cta.icon} />
           )
         )}
-      </footer>
+      </div>
     )
   );
 }

--- a/packages/styles/scss/components/image/_image.scss
+++ b/packages/styles/scss/components/image/_image.scss
@@ -14,6 +14,15 @@
     object-fit: cover;
     display: block;
   }
+
+  .#{$prefix}--image__longdescription {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    left: -10000px;
+    top: auto;
+    overflow: hidden;
+  }
 }
 
 @include exports('image') {

--- a/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
@@ -135,7 +135,7 @@ $btn-min-width: 26;
 
     .#{$prefix}--leadspace__desc {
       @include carbon--type-style(expressive-heading-03, true);
-      @include carbon--make-col(3, 4);
+      @include carbon--make-col(4, 4);
     }
 
     @include themed-items;
@@ -162,7 +162,7 @@ $btn-min-width: 26;
       }
 
       .#{$prefix}--leadspace__desc {
-        @include carbon--make-col(5, 8);
+        @include carbon--make-col(4, 8);
       }
     }
   }
@@ -177,7 +177,7 @@ $btn-min-width: 26;
 
       .#{$prefix}--leadspace__desc {
         @include carbon--make-col-ready;
-        @include carbon--make-col(6, 16);
+        @include carbon--make-col(4, 16);
       }
     }
 

--- a/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
@@ -70,6 +70,9 @@ $btn-min-width: 26;
     padding-top: $carbon--layout-01;
   }
   .#{$prefix}--leadspace {
+    margin-right: auto;
+    margin-left: auto;
+    max-width: 99rem;
     position: relative;
     padding-top: aspect-ratio(320px, 370px);
     height: 0;
@@ -198,6 +201,9 @@ $btn-min-width: 26;
 
 @mixin leadspace-centered {
   .#{$prefix}--leadspace--centered {
+    margin-right: auto;
+    margin-left: auto;
+    max-width: 99rem;
     .#{$prefix}--buttongroup {
       padding-bottom: $carbon--layout-01;
       padding-top: 0;


### PR DESCRIPTION
### Related Ticket(s)

#1868 

### Description

This change removes the `decodeString` utility from the `Image` component. The original intent of this was to prevent React's default escaping of strings, which in this case was the `src` attribute for images.

As this utility utilized the `DOMParser` API, it introduced a breaking change to server-side rendering where this API does not exist (such as our own `nextjs-test`).

Additionally since this change would only affect image source attributes with query parameters, which is rare, I don't see an immediate need for this utility. For now I will remove its usage from `Image` and possibly removing the entire utility in the future. When needed perhaps component-level `encode/decode -URIComponent` will be sufficient.

If a server-side DOM API is necessary in the future, we can look into using something like [jsdom](https://github.com/jsdom/jsdom).

### Changelog

**Removed**

- removes `decodeString` utility from `Image`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
