### PR TITLE
fix(util): remove decodeString util from Image

### DIFF
--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -5,11 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { baseFontSize, breakpoints } from '@carbon/layout';
-import {
-  decodeString,
-  settings as ddsSettings,
-} from '@carbon/ibmdotcom-utilities';
 import classnames from 'classnames';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';

--- a/packages/react/src/components/Image/__stories__/Image.stories.js
+++ b/packages/react/src/components/Image/__stories__/Image.stories.js
@@ -43,10 +43,12 @@ storiesOf('Components|Image', module)
     );
 
     return (
-      <Image
-        sources={image}
-        defaultSrc={defaultSrc}
-        alt={alt}
-        longDescription="Description used for infographics"></Image>
+      <div className={`${prefix}--grid`}>
+        <div class="bx--row">
+          <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+            <Image sources={image} defaultSrc={defaultSrc} alt={alt}></Image>
+          </div>
+        </div>
+      </div>
     );
   });


### PR DESCRIPTION
### Related Ticket(s)

#1868 

### Description

This change removes the `decodeString` utility from the `Image` component. The original intent of this was to override (when necessary) React's default escaping of strings, which in this case was the `src` attribute for images.

As this utility utilized the `DOMParser` API, it introduced a breaking change to server-side rendering where this API does not exist (such as our own `nextjs-test`).

Additionally since this change would only affect image source attributes with query parameters, which is rare, I don't see an immediate need for this utility. For now I will remove its usage from `Image` and possibly removing the entire utility in the future. When needed perhaps component-level `encode/decode -URIComponent` will be sufficient.

If a server-side DOM API is necessary in the future, we can look into using something like [jsdom](https://github.com/jsdom/jsdom).

### Changelog

**Removed**

- removes `decodeString` utility from `Image`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
