### PR TITLE
Fix/locale host

### DIFF
--- a/packages/react/src/patterns/sub-patterns/TableOfContents/__stories__/data/dataContent.js
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/__stories__/data/dataContent.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 const dataContent = (
   <div>

--- a/packages/services/src/services/Locale/Locale.js
+++ b/packages/services/src/services/Locale/Locale.js
@@ -7,7 +7,7 @@ import root from 'window-or-global';
  * @private
  */
 const _host =
-  (process && process.env.TRANSLATION_HOST) || 'https://1.www.s81c.com';
+  (process && process.env.TRANSLATION_HOST) || 'https://www.ibm.com';
 
 /**
  * @constant {string | string} CORS proxy for lower environment calls

--- a/packages/utilities/src/utilities/ipcinfoCookie/ipcinfoCookie.js
+++ b/packages/utilities/src/utilities/ipcinfoCookie/ipcinfoCookie.js
@@ -1,13 +1,14 @@
 import Cookies from 'js-cookie';
 
 /**
- *  Name of cookie needed to grab cc and lc
+ * Name of cookie needed to grab cc and lc
+ * @type {string}
+ * @private
  */
 const _cookieName = 'ipcInfo';
 
 /**
  * Utility to set and get the ipcInfo cookie needed to determine country and language code
- *
  */
 class ipcinfoCookie {
   /**

--- a/packages/utilities/src/utilities/smoothScroll/smoothScroll.js
+++ b/packages/utilities/src/utilities/smoothScroll/smoothScroll.js
@@ -19,6 +19,7 @@
  *
  * @param {*} e event object
  * @param {*} selector menu item selector id
+ * @returns {null} Returns null if no scroll is needed
  */
 const smoothScroll = (e, selector) => {
   let getSelector;

--- a/packages/vanilla/src/components/masthead/masthead-submenu.js
+++ b/packages/vanilla/src/components/masthead/masthead-submenu.js
@@ -13,9 +13,11 @@ import { HeaderSubmenu } from 'carbon-components';
  */
 class MastheadSubmenu extends HeaderSubmenu {
   /**
+   * Header submenu action method
    *
    * @param {Event} event The event triggering this method
-   * @returns {actions | null}
+   * @returns {null|*} Various actions
+   * @private
    */
   _getAction = event => {
     const isFlyoutMenu = eventMatches(event, this.options.selectorFlyoutMenu);


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This came up when deploying `www.ibm.com/solutions`. Discovered that there are still CORS errors when calling from `www.ibm.com` to `https://1.www.s81c.com` (which is a bit baffling to me). When setting to `www.ibm.com`, this makes it same origin on production so this problem then goes away.

There are also other minor changes, mainly JSDoc fixes to get rid of various warnings.

### Changelog

**Changed**

- JSDocs (various)
- Locale `TRANSLATION_HOST` default configuration
