### PR TITLE
fix(profile): stops profile menu scroll

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -93,6 +93,17 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
     });
   }, []);
 
+  /**
+   * Forces profile menu position to fixed to prevent scrolling
+   *
+   */
+  const _setProfileListPosition = () => {
+    const profileMenuList = document.querySelector(
+      `.${prefix}--masthead__profile-item`
+    );
+    profileMenuList.closest('ul').style.position = 'fixed';
+  };
+
   const [isMastheadSticky, setIsMastheadSticky] = useState(false);
   const stickyRef = useRef(null);
   const mastheadL1Ref = useRef(null);
@@ -187,8 +198,12 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
                       'data-autoid': `${stablePrefix}--masthead__profile`,
                       flipped: true,
                       style: { width: '3rem' },
+                      onOpen: () => _setProfileListPosition(),
                       renderIcon: () =>
                         isAuthenticated ? <UserOnline20 /> : <User20 />,
+                    }}
+                    overflowMenuItemProps={{
+                      wrapperClassName: `${prefix}--masthead__profile-item`,
                     }}
                     profileMenu={
                       isAuthenticated


### PR DESCRIPTION
### Related Ticket(s)
#1332 

### Description
This forces the profile menu position to `fixed` to prevent it from scrolling.

![Apr-01-2020 16-38-32](https://user-images.githubusercontent.com/909118/78185109-8feebd80-7438-11ea-9416-9f3b7756ee2b.gif)



### Changelog

**New**

- use native component method `onOpen` to set profile menu position to `fixed` to prevent scrolling


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
