### PR TITLE
fix(accessibility): added region to wrapping div of card

### DIFF
--- a/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
+++ b/packages/react/src/patterns/blocks/ContentGroupCards/ContentGroupCards.js
@@ -79,7 +79,8 @@ const _renderCards = items =>
     <div
       data-autoid={`${stablePrefix}--content-group-cards-item`}
       className={`${prefix}--content-group-cards-item__col`}
-      key={index}>
+      key={index}
+      role="region">
       <Card
         customClassName={`${prefix}--content-group-cards-item`}
         heading={elem.heading}
@@ -91,7 +92,6 @@ const _renderCards = items =>
           },
         }}
         type="link"
-        role="region"
         aria-label={elem.heading}
       />
     </div>


### PR DESCRIPTION
### Related Ticket(s)

#1382 

### Description

As the last proposed fix didn't helped the screen-readers to identify the card links, after researching I've come up with this possible solution for the issue.

### Changelog

**Changed**

- Moved role region from `Card` to the wrapping `div`