### PR TITLE
fix(pattern): fixed same height usage for the top-level card-link

### DIFF
--- a/packages/react/src/patterns/sections/CardSection/CardSection.js
+++ b/packages/react/src/patterns/sections/CardSection/CardSection.js
@@ -55,6 +55,10 @@ const CardSection = ({ heading, theme, cards, cta, ...otherProps }) => {
       containerRef.current.getElementsByClassName(`${prefix}--card__eyebrow`),
       'md'
     );
+    sameHeight(
+      containerRef.current.getElementsByClassName(`${prefix}--card--link`),
+      'md'
+    );
   };
 
   /**


### PR DESCRIPTION
### Related Ticket(s)

#1880 

### Description

A bug was fixed, which was happening when the `Top Level Card` was the only card on the second row

