### PR TITLE
fix(grid): adding grid classes by default in global import

### DIFF
--- a/packages/react/src/components/LightboxMediaViewer/__stories__/index.scss
+++ b/packages/react/src/components/LightboxMediaViewer/__stories__/index.scss
@@ -4,5 +4,5 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import '@carbon/grid/scss/grid.scss';
-@import '../../../../../styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss';
+
+@import '../../../../../styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer';

--- a/packages/react/src/patterns/sub-patterns/ButtonGroup/__stories__/index.scss
+++ b/packages/react/src/patterns/sub-patterns/ButtonGroup/__stories__/index.scss
@@ -5,5 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '@carbon/grid/scss/grid.scss';
 @import '../../../../../../styles/scss/patterns/sub-patterns/buttongroup/buttongroup';

--- a/packages/react/src/patterns/sub-patterns/Card/__stories__/index.scss
+++ b/packages/react/src/patterns/sub-patterns/Card/__stories__/index.scss
@@ -6,7 +6,6 @@
 //
 
 @import '../../../../../../styles/scss/patterns/sub-patterns/card';
-@import '@carbon/grid/scss/index.scss';
 
 .#{$prefix}--card--g10 {
   @include carbon--theme($carbon--theme--g10) {

--- a/packages/react/src/patterns/sub-patterns/Layout/__stories__/index.scss
+++ b/packages/react/src/patterns/sub-patterns/Layout/__stories__/index.scss
@@ -5,5 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '@carbon/grid/scss/grid.scss';
 @import '../../../../../../styles/scss/patterns/sub-patterns/layout/layout';

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -7,7 +7,6 @@
 
 @import '../../globals/imports';
 @import '../../temp-carbon-expressive/temp-carbon-expressive';
-
 @import 'carbon-components/scss/components/search/search';
 
 /// Locale modal

--- a/packages/styles/scss/globals/_imports.scss
+++ b/packages/styles/scss/globals/_imports.scss
@@ -19,7 +19,7 @@
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';
 @import '@carbon/import-once/scss/import-once';
-@import '@carbon/grid/scss/mixins';
+@import '@carbon/grid/scss/index';
 @import 'carbon-components/scss/globals/scss/css--reset';
 
 @import '../themes/expressive/index';

--- a/packages/styles/scss/patterns/blocks/content-group-cards/index.scss
+++ b/packages/styles/scss/patterns/blocks/content-group-cards/index.scss
@@ -9,4 +9,3 @@
 @import 'content-group-cards';
 @import '../../sub-patterns/content-group/content-group';
 @import '../../sub-patterns/card/index';
-@import '@carbon/grid/scss/grid';

--- a/packages/styles/scss/patterns/blocks/content-group-simple/index.scss
+++ b/packages/styles/scss/patterns/blocks/content-group-simple/index.scss
@@ -6,6 +6,5 @@
 //
 
 @import '../../sub-patterns/content-group/content-group';
-@import '@carbon/grid/scss/grid';
 @import '../../../globals/imports';
 @import 'content-group-simple';

--- a/packages/styles/scss/patterns/sub-patterns/link-list/index.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/index.scss
@@ -9,4 +9,3 @@
 @import '../../../globals/utils/hang';
 @import '../card/index';
 @import 'link-list';
-@import '@carbon/grid/scss/grid';

--- a/packages/styles/scss/patterns/sub-patterns/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/patterns/sub-patterns/pictogram-item/_pictogram-item.scss
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '@carbon/grid/scss/grid.scss';
 @import '../../../globals/imports';
 
 @mixin pictogram-item {

--- a/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '@carbon/grid/scss/grid.scss';
+@import '../../../globals/imports';
 @import '../layout/layout';
 
 // items that change according to the theme applied


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This was originally an issue where the grid classes were not getting loaded for the locale modal when pulled in discretely. When discussing, it made more sense to load in the grid classes by default for the global import instead.

### Changelog

**Changed**

- Changed global import to include the grid classes
- removed multiple pattern/component/story level grid imports