### PR TITLE
fix(lightbox-media-viewer): fixed linting error

### DIFF
--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -23,6 +23,7 @@
 
     &__row {
       @include carbon--make-row(0);
+
       flex-direction: column;
       flex-wrap: nowrap;
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1985

### Description

 Fixes linting error within the lightbox-media-viewer.scss file

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
