### PR TITLE
fix(tabs): fixed padding for selected tabs

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_tabs.scss
+++ b/packages/styles/scss/themes/expressive/components/_tabs.scss
@@ -19,4 +19,8 @@
     height: 3rem;
     padding: carbon--rem(11.5px) $carbon--spacing-05;
   }
+  .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+    .#{$prefix}--tabs__nav-link {
+    padding: 0.7188rem 1rem;
+  }
 }

--- a/packages/styles/scss/themes/expressive/components/_tabs.scss
+++ b/packages/styles/scss/themes/expressive/components/_tabs.scss
@@ -23,4 +23,7 @@
     .#{$prefix}--tabs__nav-link {
     padding: 0.7188rem 1rem;
   }
+  a.bx--tabs__nav-link:active {
+    padding: 0.7188rem 1rem;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1356

### Description

Fixed issue where text is moving location when you select a tab. Below is how it used to look

![tabbing](https://user-images.githubusercontent.com/56688604/78710271-0f6e0800-78e3-11ea-9944-18b9ed2f56da.gif)


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
