### PR TITLE
fix(select): fixed inline select when invalid

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_select.scss
+++ b/packages/styles/scss/themes/expressive/components/_select.scss
@@ -26,4 +26,12 @@
     height: rem(20px);
     width: rem(20px);
   }
+  .#{$prefix}--select--inline.#{$prefix}--select--invalid .#{$prefix}--label,
+  .#{$prefix}--select--inline.#{$prefix}--select--invalid
+    .#{$prefix}--form__helper-text {
+    margin-top: 1rem;
+  }
+  .#{$prefix}--form__helper-text {
+    line-height: 1rem;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1355

The inline select labels and helper text were moving position when the invalid state is activated.


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
