### PR TITLE
fix(autoid): add autoid to ContentGroup CTA

### DIFF
--- a/packages/react/src/patterns/sub-patterns/ContentGroup/ContentGroup.js
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/ContentGroup.js
@@ -44,7 +44,9 @@ const ContentGroup = ({ children, heading, customClassName, cta }) => {
         {children}
       </div>
       {cta && (
-        <div className={`${prefix}--content-group__cta-row`}>
+        <div
+          data-autoid={`${stablePrefix}--content-group_cta}`}
+          className={`${prefix}--content-group__cta-row`}>
           <CTA
             customClassName={`${prefix}--content-group__cta`}
             style="card"

--- a/packages/react/src/patterns/sub-patterns/ContentGroup/ContentGroup.js
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/ContentGroup.js
@@ -45,7 +45,7 @@ const ContentGroup = ({ children, heading, customClassName, cta }) => {
       </div>
       {cta && (
         <div
-          data-autoid={`${stablePrefix}--content-group_cta}`}
+          data-autoid={`${stablePrefix}--content-group__cta}`}
           className={`${prefix}--content-group__cta-row`}>
           <CTA
             customClassName={`${prefix}--content-group__cta`}

--- a/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
@@ -70,7 +70,7 @@ Add the following line on your `.env` file at the root of your project,
 | Name                           | Description                   |
 | ------------------------------ | ----------------------------- |
 | `dds--content-group`           | Content group wrapper element |
-| `dds--content-group_cta`       | Content group CTA element     |
+| `dds--content-group__cta`      | Content group CTA element     |
 | `dds--content-group__title`    | Content group title element   |
 | `dds--content-group__children` | Wrapper for children elements |
 

--- a/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
@@ -70,7 +70,7 @@ Add the following line on your `.env` file at the root of your project,
 | Name                           | Description                   |
 | ------------------------------ | ----------------------------- |
 | `dds--content-group`           | Content group wrapper element |
-| `dds----content-group_cta`     | Content group CTA element     |
+| `dds--content-group_cta`       | Content group CTA element     |
 | `dds--content-group__title`    | Content group title element   |
 | `dds--content-group__children` | Wrapper for children elements |
 

--- a/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
@@ -70,6 +70,7 @@ Add the following line on your `.env` file at the root of your project,
 | Name                           | Description                   |
 | ------------------------------ | ----------------------------- |
 | `dds--content-group`           | Content group wrapper element |
+| `dds----content-group_cta`     | Content group CTA element     |
 | `dds--content-group__title`    | Content group title element   |
 | `dds--content-group__children` | Wrapper for children elements |
 


### PR DESCRIPTION
### Related Ticket(s)

#1747 #1884

### Description

Adds `data-autoid` to `ContentGroup`'s optional CTA


### Changelog

**New**

- `data-autoid` to `ContentGroup` CTA

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
