### PR TITLE
Fix/tabs mobile

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_tabs.scss
+++ b/packages/styles/scss/themes/expressive/components/_tabs.scss
@@ -6,6 +6,7 @@
 //
 
 @import '@carbon/layout/scss/convert';
+@import '@carbon/grid/scss/mixins';
 
 //-----------------------------
 // Tabs (expressive)
@@ -21,5 +22,18 @@
   }
   .#{$prefix}--tabs-trigger {
     height: 3rem;
+  }
+  @include carbon--breakpoint(md) {
+    .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
+      height: 3rem;
+      padding: carbon--rem(11.5px) $carbon--spacing-05;
+    }
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)
+      .#{$prefix}--tabs__nav-link {
+      padding: 0.7188rem 1rem;
+    }
+    a.bx--tabs__nav-link:active {
+      padding: 0.7188rem 1rem;
+    }
   }
 }

--- a/packages/styles/scss/themes/expressive/components/_tabs.scss
+++ b/packages/styles/scss/themes/expressive/components/_tabs.scss
@@ -16,7 +16,10 @@
 /// @group tabs-expressive
 @mixin tabs-expressive {
   .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
+    height: 2.5rem;
+    padding-left: 0;
+  }
+  .#{$prefix}--tabs-trigger {
     height: 3rem;
-    padding: carbon--rem(11.5px) $carbon--spacing-05;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1357

### Description

Fixes styling for mobile tabs. Also adjusted the SCSS for larger screen sizes to not be affected by the mobile class changes (they share classnames)

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
