### PR TITLE
fix(scss): added max-width to dotcom-shell content

### DIFF
--- a/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
@@ -139,7 +139,7 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
     const gradient = boolean('gradient overlay', true);
 
     return (
-      <div className="bx--grid">
+      <DotcomShell footerType="short">
         <LeadSpace
           type={select('type', type, type.small)}
           theme={select('theme', themes, themes.g100)}
@@ -149,6 +149,6 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
           buttons={buttons}
           image={object('image', images)}
         />
-      </div>
+      </DotcomShell>
     );
   });

--- a/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
@@ -8,7 +8,6 @@ import {
   text,
   withKnobs,
 } from '@storybook/addon-knobs';
-import { DotcomShell } from '../../../../components/DotcomShell';
 import LeadSpace from '../LeadSpace';
 import React from 'react';
 import readme from '../README.md';
@@ -69,15 +68,13 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
     };
 
     return (
-      <DotcomShell footerType="short">
-        <LeadSpace
-          type={select('type', type, type.small)}
-          theme={select('theme', themes, themes.g100)}
-          title={title}
-          copy={copy}
-          buttons={buttons}
-        />
-      </DotcomShell>
+      <LeadSpace
+        type={select('type', type, type.small)}
+        theme={select('theme', themes, themes.g100)}
+        title={title}
+        copy={copy}
+        buttons={buttons}
+      />
     );
   })
   .add('Default with image', () => {
@@ -139,16 +136,14 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
     const gradient = boolean('gradient overlay', true);
 
     return (
-      <DotcomShell footerType="short">
-        <LeadSpace
-          type={select('type', type, type.small)}
-          theme={select('theme', themes, themes.g100)}
-          title={title}
-          copy={copy}
-          gradient={gradient}
-          buttons={buttons}
-          image={object('image', images)}
-        />
-      </DotcomShell>
+      <LeadSpace
+        type={select('type', type, type.small)}
+        theme={select('theme', themes, themes.g100)}
+        title={title}
+        copy={copy}
+        gradient={gradient}
+        buttons={buttons}
+        image={object('image', images)}
+      />
     );
   });

--- a/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
@@ -8,6 +8,7 @@ import {
   text,
   withKnobs,
 } from '@storybook/addon-knobs';
+import { DotcomShell } from '../../../../components/DotcomShell';
 import LeadSpace from '../LeadSpace';
 import React from 'react';
 import readme from '../README.md';
@@ -68,7 +69,7 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
     };
 
     return (
-      <div className="bx--grid">
+      <DotcomShell footerType="short">
         <LeadSpace
           type={select('type', type, type.small)}
           theme={select('theme', themes, themes.g100)}
@@ -76,7 +77,7 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
           copy={copy}
           buttons={buttons}
         />
-      </div>
+      </DotcomShell>
     );
   })
   .add('Default with image', () => {

--- a/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
+++ b/packages/styles/scss/components/dotcom-shell/_dotcom-shell.scss
@@ -17,6 +17,9 @@
 
     &__content {
       flex: 1;
+      margin: auto;
+      max-width: 99rem;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

#1780 

### Description

The `Dotcom-Shell` scss was updated, so it have the default `max-width` based on the masthead, in addition to that, the `Dotcom-Shell` has been added to the `Leadspace` story.
