### PR TITLE
fix(scss): added max-width to video-player description

### DIFF
--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -32,6 +32,10 @@
     &__video-description {
       padding-top: $spacing-05;
       color: $text-05;
+      max-width: 90%;
+      @include carbon--breakpoint('lg') {
+        max-width: 496px;
+      }
     }
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

#1971 

### Description

Added `max-width` for the description of the `VideoPlayer` component.
