### PR TITLE
fix(content-block): render optional linklist in layout

### DIFF
--- a/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
@@ -11,8 +11,7 @@ import {
 } from '@carbon/ibmdotcom-utilities';
 import { CTA } from '../../../components/CTA';
 import cx from 'classnames';
-import Layout from '../Layout/Layout';
-import LinkList from '../LinkList/LinkList';
+import { Layout } from '../Layout';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
@@ -29,7 +28,7 @@ const { prefix } = settings;
  * @param {*} props.children JSX Components
  * @param {string} props.customClassName allows user to pass in custom class name
  * @param {*} props.cta CTA props object
- * @param {object} props.linkList LinkList props object
+ * @param {object} props.aside components to be passed into the right panel
  * @returns {*} JSX ContentBlock component
  */
 const ContentBlock = ({
@@ -38,7 +37,7 @@ const ContentBlock = ({
   children,
   customClassName,
   cta,
-  linkList,
+  aside,
 }) => {
   const content = (
     <>
@@ -75,7 +74,7 @@ const ContentBlock = ({
     <div
       data-autoid={`${stablePrefix}--content-block`}
       className={cx(`${prefix}--content-block`, customClassName)}>
-      {linkList
+      {aside.items
         ? _layoutWrap(
             <>
               {title}
@@ -83,14 +82,13 @@ const ContentBlock = ({
             </>
           )
         : title}
-      {linkList
+      {aside.items
         ? _layoutWrap(
             <>
               <div>{content}</div>
-              <div>
-                <LinkList {...linkList} />
-              </div>
-            </>
+              <div>{aside.items}</div>
+            </>,
+            aside.border
           )
         : content}
     </div>
@@ -102,10 +100,13 @@ const ContentBlock = ({
  *
  * @private
  * @param {Element} content content elements
+ * @param {boolean} border set border or not
  * @returns {*} jsx cta component
  */
-const _layoutWrap = content => (
-  <Layout type="2-1">{content.props.children}</Layout>
+const _layoutWrap = (content, border) => (
+  <Layout type="2-1" nested={true} border={border}>
+    {content.props.children}
+  </Layout>
 );
 
 /**
@@ -140,7 +141,7 @@ ContentBlock.propTypes = {
   children: PropTypes.element,
   cta: PropTypes.object,
   customClassName: PropTypes.string,
-  linkList: PropTypes.instanceOf(LinkList),
+  aside: PropTypes.element,
 };
 
 export default ContentBlock;

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
@@ -11,6 +11,8 @@ import {
 } from '@carbon/ibmdotcom-utilities';
 import { CTA } from '../../../components/CTA';
 import cx from 'classnames';
+import Layout from '../Layout/Layout';
+import LinkList from '../LinkList/LinkList';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
@@ -27,10 +29,54 @@ const { prefix } = settings;
  * @param {*} props.children JSX Components
  * @param {string} props.customClassName allows user to pass in custom class name
  * @param {*} props.cta CTA props object
+ * @param {object} props.linkList LinkList props object
  * @returns {*} JSX ContentBlock component
  */
-const ContentBlock = ({ heading, copy, children, customClassName, cta }) => {
-  return (
+const ContentBlock = ({
+  heading,
+  copy,
+  children,
+  customClassName,
+  cta,
+  linkList,
+}) => {
+  return linkList ? (
+    <div
+      data-autoid={`${stablePrefix}--content-block`}
+      className={cx(`${prefix}--content-block`, customClassName)}>
+      {heading && (
+        <Layout type="2-1">
+          <h2
+            data-autoid={`${stablePrefix}--content-block__heading`}
+            className={`${prefix}--content-block__heading`}>
+            {heading}
+          </h2>
+          <div></div>
+        </Layout>
+      )}
+      <Layout type="2-1">
+        <div>
+          {copy && (
+            <div
+              className={`${prefix}--content-block__copy`}
+              dangerouslySetInnerHTML={{
+                __html: markdownToHtml(copy, { bold: false }),
+              }}
+            />
+          )}
+          <div
+            data-autoid={`${stablePrefix}--content-block__children`}
+            className={`${prefix}--content-block__children`}>
+            {children}
+          </div>
+          {cta && _renderCTA(cta)}
+        </div>
+        <div>
+          <LinkList {...linkList} />
+        </div>
+      </Layout>
+    </div>
+  ) : (
     <div
       data-autoid={`${stablePrefix}--content-block`}
       className={cx(`${prefix}--content-block`, customClassName)}>
@@ -41,20 +87,22 @@ const ContentBlock = ({ heading, copy, children, customClassName, cta }) => {
           {heading}
         </h2>
       )}
-      {copy && (
+      <div>
+        {copy && (
+          <div
+            className={`${prefix}--content-block__copy`}
+            dangerouslySetInnerHTML={{
+              __html: markdownToHtml(copy, { bold: false }),
+            }}
+          />
+        )}
         <div
-          className={`${prefix}--content-block__copy`}
-          dangerouslySetInnerHTML={{
-            __html: markdownToHtml(copy, { bold: false }),
-          }}
-        />
-      )}
-      <div
-        data-autoid={`${stablePrefix}--content-block__children`}
-        className={`${prefix}--content-block__children`}>
-        {children}
+          data-autoid={`${stablePrefix}--content-block__children`}
+          className={`${prefix}--content-block__children`}>
+          {children}
+        </div>
+        {cta && _renderCTA(cta)}
       </div>
-      {cta && _renderCTA(cta)}
     </div>
   );
 };
@@ -91,6 +139,7 @@ ContentBlock.propTypes = {
   children: PropTypes.element,
   cta: PropTypes.object,
   customClassName: PropTypes.string,
+  linkList: PropTypes.instanceOf(LinkList),
 };
 
 export default ContentBlock;

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
@@ -40,46 +40,27 @@ const ContentBlock = ({
   cta,
   linkList,
 }) => {
-  return linkList ? (
-    <div
-      data-autoid={`${stablePrefix}--content-block`}
-      className={cx(`${prefix}--content-block`, customClassName)}>
-      {heading && (
-        <Layout type="2-1">
-          <h2
-            data-autoid={`${stablePrefix}--content-block__heading`}
-            className={`${prefix}--content-block__heading`}>
-            {heading}
-          </h2>
-          <div></div>
-        </Layout>
+  const content = (
+    <>
+      {copy && (
+        <div
+          className={`${prefix}--content-block__copy`}
+          dangerouslySetInnerHTML={{
+            __html: markdownToHtml(copy, { bold: false }),
+          }}
+        />
       )}
-      <Layout type="2-1">
-        <div>
-          {copy && (
-            <div
-              className={`${prefix}--content-block__copy`}
-              dangerouslySetInnerHTML={{
-                __html: markdownToHtml(copy, { bold: false }),
-              }}
-            />
-          )}
-          <div
-            data-autoid={`${stablePrefix}--content-block__children`}
-            className={`${prefix}--content-block__children`}>
-            {children}
-          </div>
-          {cta && _renderCTA(cta)}
-        </div>
-        <div>
-          <LinkList {...linkList} />
-        </div>
-      </Layout>
-    </div>
-  ) : (
-    <div
-      data-autoid={`${stablePrefix}--content-block`}
-      className={cx(`${prefix}--content-block`, customClassName)}>
+      <div
+        data-autoid={`${stablePrefix}--content-block__children`}
+        className={`${prefix}--content-block__children`}>
+        {children}
+      </div>
+      {cta && _renderCTA(cta)}
+    </>
+  );
+
+  const title = (
+    <div>
       {heading && (
         <h2
           data-autoid={`${stablePrefix}--content-block__heading`}
@@ -87,25 +68,45 @@ const ContentBlock = ({
           {heading}
         </h2>
       )}
-      <div>
-        {copy && (
-          <div
-            className={`${prefix}--content-block__copy`}
-            dangerouslySetInnerHTML={{
-              __html: markdownToHtml(copy, { bold: false }),
-            }}
-          />
-        )}
-        <div
-          data-autoid={`${stablePrefix}--content-block__children`}
-          className={`${prefix}--content-block__children`}>
-          {children}
-        </div>
-        {cta && _renderCTA(cta)}
-      </div>
+    </div>
+  );
+
+  return (
+    <div
+      data-autoid={`${stablePrefix}--content-block`}
+      className={cx(`${prefix}--content-block`, customClassName)}>
+      {linkList
+        ? _layoutWrap(
+            <>
+              {title}
+              <div></div>
+            </>
+          )
+        : title}
+      {linkList
+        ? _layoutWrap(
+            <>
+              <div>{content}</div>
+              <div>
+                <LinkList {...linkList} />
+              </div>
+            </>
+          )
+        : content}
     </div>
   );
 };
+
+/**
+ * wraps content in layout component
+ *
+ * @private
+ * @param {Element} content content elements
+ * @returns {*} jsx cta component
+ */
+const _layoutWrap = content => (
+  <Layout type="2-1">{content.props.children}</Layout>
+);
 
 /**
  * sets the class name based on theme type

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
@@ -1,6 +1,13 @@
 import './index.scss';
-import { select, withKnobs, text, object } from '@storybook/addon-knobs';
+import {
+  select,
+  withKnobs,
+  text,
+  object,
+  boolean,
+} from '@storybook/addon-knobs';
 import ContentBlock from '../ContentBlock';
+import { LinkList } from '../../LinkList';
 import React from 'react';
 import readme from '../README.md';
 import { settings } from 'carbon-components';
@@ -77,7 +84,7 @@ storiesOf('Patterns (Sub-Patterns)|ContentBlock', module)
       none: null,
     };
 
-    const linkList = {
+    const linkListProps = {
       heading: text('link list heading:', 'Tutorials'),
       items: object('link list items array', [
         {
@@ -97,15 +104,20 @@ storiesOf('Patterns (Sub-Patterns)|ContentBlock', module)
       ]),
     };
 
+    const aside = {
+      items: <LinkList {...linkListProps} />,
+      border: boolean('border', false),
+    };
+
     return (
-      <div className="bx--grid bx--grid--full-width">
-        <div className="bx--row bx--no-gutter">
+      <div className="bx--grid">
+        <div className="bx--row">
           <div className="bx--offset-lg-4">
             <ContentBlock
               heading={blockProps.heading}
               copy={blockProps.copy}
               cta={select('CTA (optional)', cta, cta.cta)}
-              linkList={linkList}
+              aside={aside}
               customClassName={`${prefix}--content-block-story`}>
               {blockProps.content}
             </ContentBlock>

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
@@ -1,5 +1,5 @@
 import './index.scss';
-import { select, withKnobs } from '@storybook/addon-knobs';
+import { select, withKnobs, text, object } from '@storybook/addon-knobs';
 import ContentBlock from '../ContentBlock';
 import React from 'react';
 import readme from '../README.md';
@@ -46,6 +46,66 @@ storiesOf('Patterns (Sub-Patterns)|ContentBlock', module)
               heading={blockProps.heading}
               copy={blockProps.copy}
               cta={select('CTA (optional)', cta, cta.cta)}
+              customClassName={`${prefix}--content-block-story`}>
+              {blockProps.content}
+            </ContentBlock>
+          </div>
+        </div>
+      </div>
+    );
+  })
+  .add('With LinkList', () => {
+    const blockProps = {
+      heading: 'This is the Content Block heading',
+      copy: `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.`,
+      content: `This is the Content Block children.`,
+    };
+
+    const ctaProps = {
+      style: 'card',
+      type: 'external',
+      copy: 'Lorem ipsum dolor sit amet',
+      cta: {
+        href: 'https://www.example.com',
+      },
+    };
+
+    const cta = {
+      cta: ctaProps,
+      none: null,
+    };
+
+    const linkList = {
+      heading: text('link list heading:', 'Tutorials'),
+      items: object('link list items array', [
+        {
+          type: 'local',
+          copy: 'Containerization A Complete Guide',
+          cta: {
+            href: 'https://ibm.com',
+          },
+        },
+        {
+          type: 'external',
+          copy: 'Why should you use microservices and containers',
+          cta: {
+            href: 'https://ibm.com',
+          },
+        },
+      ]),
+    };
+
+    return (
+      <div className="bx--grid bx--grid--full-width">
+        <div className="bx--row bx--no-gutter">
+          <div className="bx--offset-lg-4">
+            <ContentBlock
+              heading={blockProps.heading}
+              copy={blockProps.copy}
+              cta={select('CTA (optional)', cta, cta.cta)}
+              linkList={linkList}
               customClassName={`${prefix}--content-block-story`}>
               {blockProps.content}
             </ContentBlock>

--- a/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
@@ -76,6 +76,12 @@
       // TO DO: aspect ratio 2x1
       @include hang;
     }
+
+    @include carbon--breakpoint('lg') {
+      .#{$prefix}--link-list {
+        padding-top: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Linklist is rendering too high on a pattern #1920

### Description

wrap `ContentBlock` content and heading in `Layout` component to ensure the `LinkList` aligns properly with the copy.

<img width="1461" alt="Screen Shot 2020-04-10 at 12 15 46 PM" src="https://user-images.githubusercontent.com/54281166/79005890-e4bfc180-7b25-11ea-8280-1cca7efc4d02.png">

### Changelog

**Changed**

- wrap the `heading` and `content` in `Layout` component if `LinkList` is passed in

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
