### PR TITLE
docs(proxy): Adding note to leave CORS_PROXY blank for production

### DIFF
--- a/packages/react/src/components/DotcomShell/README.md
+++ b/packages/react/src/components/DotcomShell/README.md
@@ -102,6 +102,8 @@ A cors proxy can be configured using the following
 
 `CORS_PROXY=https://myproxy.com/`
 
+NOTE: The `CORS_PROXY` is not necessary when publishing to production (www.ibm.com). Be sure to either set `CORS_PROXY` as blank or leave it unconfigured when pushing your application to production.
+
 ## 🙌 Contributing
 
 We're always looking for contributors to help us fix bugs, build new features,


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds a note to keep the `CORS_PROXY` blank if pushing code to production.

### Changelog

**Changed**

- Documentation for CORS_PROXY for production