### PR TITLE
fix(css): fix profile menu item height

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -324,6 +324,7 @@ $search-transition-timing: 95ms;
     }
 
     &__option {
+      height: $layout-04;
       &:hover {
         background-color: $ui-01;
       }


### PR DESCRIPTION
### Related Ticket(s)

#2065 

### Description

Fixes profile menu height

### Changelog

**Changed**

- profile menu item height changed to 48px


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
