### PR TITLE
fix(css): masthead platform hover color

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -61,7 +61,7 @@
       position: relative;
 
       &:hover {
-        background-color: $ui-01;
+        background-color: $hover-ui;
         color: $text-01;
       }
 

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -70,7 +70,7 @@ $search-transition-timing: 95ms;
         outline: none;
 
         &:hover {
-          background-color: $ui-01;
+          background-color: $hover-ui;
         }
 
         &:active,


### PR DESCRIPTION
### Related Ticket(s)

#2066 

### Description

Fixes `Masthead` platform and logo hover color

### Changelog


**Changed**

- platform and logo hover color to `$hover-ui`


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
