### PR TITLE
fix(css): fix footer visited link hover color

### DIFF
--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -43,7 +43,8 @@
 
     .#{$prefix}--link {
       &,
-      &:visited {
+      &:visited,
+      &:visited:hover {
         color: $text-02;
       }
 


### PR DESCRIPTION
### Related Ticket(s)

#2048 

### Description

Fixes hover color for visited footer links.

### Changelog

**Changed**

- footer link styles for `visited:hover`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
