### PR TITLE
fix(scss): fixed border size for layout pattern

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/layout/_layout.scss
+++ b/packages/styles/scss/patterns/sub-patterns/layout/_layout.scss
@@ -41,6 +41,22 @@
     }
 
     &--border {
+      @include carbon--breakpoint('md') {
+        margin-left: -2rem;
+        margin-right: -2rem;
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }
+
+      @include carbon--breakpoint('lg') {
+        padding-left: 0;
+        margin-left: -1rem;
+      }
+
+      @include carbon--breakpoint('max') {
+        margin-right: -1rem;
+      }
+
       border-bottom: solid 1px $ui-04;
     }
 


### PR DESCRIPTION
### Related Ticket(s)

#1193 

### Description

The border for the `Layout` pattern was updated on `md`, `lg`, `xlg` and `max` breakpoints, so it better fits the design specs.