### PR TITLE
fix(scss): lightbox video now fills the whole container height

### DIFF
--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -42,24 +42,30 @@
 
       @include carbon--breakpoint('lg') {
         flex-direction: row;
+        height: 100%;
       }
     }
     &__media {
       @include carbon--breakpoint-down('lg') {
         position: relative;
+        height: 100%;
       }
 
       img {
         width: auto;
         max-width: 100%;
         height: auto;
+        max-height: 100%;
 
         @include carbon--breakpoint-down('lg') {
           position: absolute;
           margin: auto;
           top: 0;
           bottom: 0;
-          max-height: 100%;
+        }
+
+        @include carbon--breakpoint('lg') {
+          height: 100%;
         }
       }
 
@@ -74,12 +80,18 @@
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
+
+      @include carbon--breakpoint('lg') {
+        height: 100%;
+      }
     }
 
     &__content {
       max-width: 95%;
-
       @include carbon--type-style('body-long-02');
+      @include carbon--breakpoint('lg') {
+        overflow: scroll;
+      }
 
       &__title {
         padding-top: $carbon--spacing-05;


### PR DESCRIPTION
### Related Ticket(s)

#1931 

### Description

Fixed a bug that happened when the image was bigger than the lightbox, so it would add scroll instead of resize to fit the container
