### PR TITLE
fix(content-block): remove bottom margin from last child

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-media/_content-block-media.scss
@@ -17,6 +17,10 @@
 @mixin content-block-media {
   .#{$prefix}--content-block-media {
     @include themed-items;
+
+    .#{$prefix}--content-group:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .#{$prefix}--content-block-media--g100 {


### PR DESCRIPTION
### Related Ticket(s)

Learn Page Template - The spacing between feature card , card with images and cards is too large. #1654

### Description

Remove the bottom margin spacing from the last `ContentGroup` element in the `ContentBlockMedia` pattern to reduce the overall bottom spacing.

### Changelog

**Changed**

- remove bottom margin from the last `contentgroup` element in `contentblockmedia`


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
