### PR TITLE
Fix/masthead search combobox reader

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -751,7 +751,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                 </div>
                               </IbmLogo>
                               <div
-                                aria-hidden="false"
                                 className="bx--header__search "
                               >
                                 <MastheadTopNav
@@ -5769,7 +5768,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                               </div>
                             </IbmLogo>
                             <div
-                              aria-hidden="false"
                               className="bx--header__search "
                             >
                               <MastheadTopNav
@@ -6271,7 +6269,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                               </div>
                             </IbmLogo>
                             <div
-                              aria-hidden="false"
                               className="bx--header__search "
                             >
                               <MastheadTopNav

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -751,28 +751,33 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                 </div>
                               </IbmLogo>
                               <div
+                                aria-hidden="false"
                                 className="bx--header__search "
                               >
                                 <MastheadTopNav
                                   navigation={Array []}
                                   platform={null}
                                 >
-                                  <HeaderNavigation
-                                    aria-label="IBM"
-                                    data-autoid="dds--masthead__l0-nav"
+                                  <div
+                                    className="bx--header__nav-container"
                                   >
-                                    <nav
+                                    <HeaderNavigation
                                       aria-label="IBM"
-                                      className="bx--header__nav"
                                       data-autoid="dds--masthead__l0-nav"
                                     >
-                                      <ul
+                                      <nav
                                         aria-label="IBM"
-                                        className="bx--header__menu-bar"
-                                        role="menubar"
-                                      />
-                                    </nav>
-                                  </HeaderNavigation>
+                                        className="bx--header__nav"
+                                        data-autoid="dds--masthead__l0-nav"
+                                      >
+                                        <ul
+                                          aria-label="IBM"
+                                          className="bx--header__menu-bar"
+                                          role="menubar"
+                                        />
+                                      </nav>
+                                    </HeaderNavigation>
+                                  </div>
                                 </MastheadTopNav>
                                 <MastheadSearch
                                   placeHolderText="Search all of IBM"
@@ -783,262 +788,98 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     className="bx--masthead__search"
                                     data-autoid="dds--masthead__search"
                                   >
-                                    <form
-                                      action="https://www.ibm.com/search?lnk=mhsrch"
-                                      method="get"
+                                    <div
+                                      className="bx--header__search--actions"
                                     >
-                                      <input
-                                        name="lang"
-                                        type="hidden"
-                                        value="en"
-                                      />
-                                      <input
-                                        name="cc"
-                                        type="hidden"
-                                        value="us"
-                                      />
-                                      <input
-                                        name="lnk"
-                                        type="hidden"
-                                        value="mhsrch"
-                                      />
-                                      <Autosuggest
-                                        alwaysRenderSuggestions={false}
-                                        focusInputOnSuggestionClick={true}
-                                        getSuggestionValue={[Function]}
-                                        highlightFirstSuggestion={true}
-                                        id="1"
-                                        inputProps={
-                                          Object {
-                                            "className": "bx--header__search--input",
-                                            "onChange": [Function],
-                                            "onKeyDown": [Function],
-                                            "placeholder": "Search all of IBM",
-                                            "value": "",
-                                          }
-                                        }
-                                        multiSection={false}
-                                        onSuggestionSelected={[Function]}
-                                        onSuggestionsClearRequested={[Function]}
-                                        onSuggestionsFetchRequested={[Function]}
-                                        renderInputComponent={[Function]}
-                                        renderSuggestion={[Function]}
-                                        renderSuggestionsContainer={[Function]}
-                                        shouldRenderSuggestions={[Function]}
-                                        suggestions={Array []}
-                                        theme={
-                                          Object {
-                                            "container": "react-autosuggest__container",
-                                            "containerOpen": "react-autosuggest__container--open",
-                                            "input": "react-autosuggest__input",
-                                            "inputFocused": "react-autosuggest__input--focused",
-                                            "inputOpen": "react-autosuggest__input--open",
-                                            "sectionContainer": "react-autosuggest__section-container",
-                                            "sectionContainerFirst": "react-autosuggest__section-container--first",
-                                            "sectionTitle": "react-autosuggest__section-title",
-                                            "suggestion": "react-autosuggest__suggestion",
-                                            "suggestionFirst": "react-autosuggest__suggestion--first",
-                                            "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-                                            "suggestionsContainer": "react-autosuggest__suggestions-container",
-                                            "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-                                            "suggestionsList": "react-autosuggest__suggestions-list",
-                                          }
-                                        }
+                                      <HeaderGlobalAction
+                                        aria-label="Open IBM search field"
+                                        className="bx--header__search--search"
+                                        data-autoid="dds--header__search--search"
+                                        onClick={[Function]}
+                                        tabIndex="0"
                                       >
-                                        <Autowhatever
-                                          containerProps={Object {}}
-                                          getSectionItems={[Function]}
-                                          highlightedItemIndex={null}
-                                          highlightedSectionIndex={null}
-                                          id="1"
-                                          inputProps={
-                                            Object {
-                                              "className": "bx--header__search--input",
-                                              "onBlur": [Function],
-                                              "onChange": [Function],
-                                              "onFocus": [Function],
-                                              "onKeyDown": [Function],
-                                              "placeholder": "Search all of IBM",
-                                              "value": "",
-                                            }
-                                          }
-                                          itemProps={[Function]}
-                                          items={Array []}
-                                          multiSection={false}
-                                          renderInputComponent={[Function]}
-                                          renderItem={[Function]}
-                                          renderItemData={
-                                            Object {
-                                              "query": "",
-                                            }
-                                          }
-                                          renderItemsContainer={[Function]}
-                                          renderSectionTitle={[Function]}
-                                          theme={
-                                            Object {
-                                              "container": "react-autosuggest__container",
-                                              "containerOpen": "react-autosuggest__container--open",
-                                              "input": "react-autosuggest__input",
-                                              "inputFocused": "react-autosuggest__input--focused",
-                                              "inputOpen": "react-autosuggest__input--open",
-                                              "item": "react-autosuggest__suggestion",
-                                              "itemFirst": "react-autosuggest__suggestion--first",
-                                              "itemHighlighted": "react-autosuggest__suggestion--highlighted",
-                                              "itemsContainer": "react-autosuggest__suggestions-container",
-                                              "itemsContainerOpen": "react-autosuggest__suggestions-container--open",
-                                              "itemsList": "react-autosuggest__suggestions-list",
-                                              "sectionContainer": "react-autosuggest__section-container",
-                                              "sectionContainerFirst": "react-autosuggest__section-container--first",
-                                              "sectionTitle": "react-autosuggest__section-title",
-                                            }
-                                          }
+                                        <button
+                                          aria-label="Open IBM search field"
+                                          className="bx--header__search--search bx--header__action"
+                                          data-autoid="dds--header__search--search"
+                                          onClick={[Function]}
+                                          tabIndex="0"
+                                          type="button"
                                         >
-                                          <div
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="react-autowhatever-1"
-                                            className="react-autosuggest__container"
-                                            key="react-autowhatever-1-container"
-                                            role="combobox"
-                                          >
-                                            <MastheadSearchInput
-                                              componentInputProps={
-                                                Object {
-                                                  "aria-activedescendant": null,
-                                                  "aria-autocomplete": "list",
-                                                  "aria-controls": "react-autowhatever-1",
-                                                  "autoComplete": "off",
-                                                  "className": "bx--header__search--input",
-                                                  "key": "react-autowhatever-1-input",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "onFocus": [Function],
-                                                  "onKeyDown": [Function],
-                                                  "placeholder": "Search all of IBM",
-                                                  "ref": [Function],
-                                                  "type": "text",
-                                                  "value": "",
-                                                }
-                                              }
-                                              dispatch={[Function]}
-                                              isActive={false}
-                                              searchIconClick={[Function]}
+                                          <ForwardRef(Search20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <input
-                                                aria-activedescendant={null}
-                                                aria-autocomplete="list"
-                                                aria-controls="react-autowhatever-1"
-                                                autoComplete="off"
-                                                className="bx--header__search--input"
-                                                data-autoid="dds--header__search--input"
-                                                key="react-autowhatever-1-input"
-                                                name="q"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                onFocus={[Function]}
-                                                onKeyDown={[Function]}
-                                                placeholder="Search all of IBM"
-                                                tabIndex="-1"
-                                                type="text"
-                                                value=""
-                                              />
-                                              <HeaderGlobalAction
-                                                aria-label="Search all of IBM"
-                                                className="bx--header__search--search"
-                                                data-autoid="dds--header__search--search"
-                                                onClick={[Function]}
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                style={
+                                                  Object {
+                                                    "willChange": "transform",
+                                                  }
+                                                }
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
                                               >
-                                                <button
-                                                  aria-label="Search all of IBM"
-                                                  className="bx--header__search--search bx--header__action"
-                                                  data-autoid="dds--header__search--search"
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <ForwardRef(Search20)>
-                                                    <Icon
-                                                      height={20}
-                                                      preserveAspectRatio="xMidYMid meet"
-                                                      viewBox="0 0 32 32"
-                                                      width={20}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        focusable="false"
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        style={
-                                                          Object {
-                                                            "willChange": "transform",
-                                                          }
-                                                        }
-                                                        viewBox="0 0 32 32"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      >
-                                                        <path
-                                                          d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
-                                                        />
-                                                      </svg>
-                                                    </Icon>
-                                                  </ForwardRef(Search20)>
-                                                </button>
-                                              </HeaderGlobalAction>
-                                              <HeaderGlobalAction
-                                                aria-label="Close"
-                                                className="bx--header__search--close"
-                                                data-autoid="dds--header__search--close"
-                                                onClick={[Function]}
+                                                <path
+                                                  d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Search20)>
+                                        </button>
+                                      </HeaderGlobalAction>
+                                      <HeaderGlobalAction
+                                        aria-label="Close"
+                                        className="bx--header__search--close"
+                                        data-autoid="dds--header__search--close"
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          aria-label="Close"
+                                          className="bx--header__search--close bx--header__action"
+                                          data-autoid="dds--header__search--close"
+                                          onClick={[Function]}
+                                          type="button"
+                                        >
+                                          <ForwardRef(Close20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                style={
+                                                  Object {
+                                                    "willChange": "transform",
+                                                  }
+                                                }
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
                                               >
-                                                <button
-                                                  aria-label="Close"
-                                                  className="bx--header__search--close bx--header__action"
-                                                  data-autoid="dds--header__search--close"
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <ForwardRef(Close20)>
-                                                    <Icon
-                                                      height={20}
-                                                      preserveAspectRatio="xMidYMid meet"
-                                                      viewBox="0 0 32 32"
-                                                      width={20}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        focusable="false"
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        style={
-                                                          Object {
-                                                            "willChange": "transform",
-                                                          }
-                                                        }
-                                                        viewBox="0 0 32 32"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      >
-                                                        <path
-                                                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                                        />
-                                                      </svg>
-                                                    </Icon>
-                                                  </ForwardRef(Close20)>
-                                                </button>
-                                              </HeaderGlobalAction>
-                                            </MastheadSearchInput>
-                                            <div
-                                              className="react-autosuggest__suggestions-container"
-                                              id="react-autowhatever-1"
-                                              key="react-autowhatever-1-items-container"
-                                              role="listbox"
-                                            />
-                                          </div>
-                                        </Autowhatever>
-                                      </Autosuggest>
-                                    </form>
+                                                <path
+                                                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Close20)>
+                                        </button>
+                                      </HeaderGlobalAction>
+                                    </div>
                                   </div>
                                 </MastheadSearch>
                               </div>
@@ -5928,6 +5769,7 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                               </div>
                             </IbmLogo>
                             <div
+                              aria-hidden="false"
                               className="bx--header__search "
                             >
                               <MastheadTopNav
@@ -5935,22 +5777,26 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                                 placeHolderText="Search all of IBM"
                                 platform={null}
                               >
-                                <HeaderNavigation
-                                  aria-label="IBM"
-                                  data-autoid="dds--masthead__l0-nav"
+                                <div
+                                  className="bx--header__nav-container"
                                 >
-                                  <nav
+                                  <HeaderNavigation
                                     aria-label="IBM"
-                                    className="bx--header__nav"
                                     data-autoid="dds--masthead__l0-nav"
                                   >
-                                    <ul
+                                    <nav
                                       aria-label="IBM"
-                                      className="bx--header__menu-bar"
-                                      role="menubar"
-                                    />
-                                  </nav>
-                                </HeaderNavigation>
+                                      className="bx--header__nav"
+                                      data-autoid="dds--masthead__l0-nav"
+                                    >
+                                      <ul
+                                        aria-label="IBM"
+                                        className="bx--header__menu-bar"
+                                        role="menubar"
+                                      />
+                                    </nav>
+                                  </HeaderNavigation>
+                                </div>
                               </MastheadTopNav>
                               <MastheadSearch
                                 placeHolderText="Search all of IBM"
@@ -5961,262 +5807,98 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                                   className="bx--masthead__search"
                                   data-autoid="dds--masthead__search"
                                 >
-                                  <form
-                                    action="https://www.ibm.com/search?lnk=mhsrch"
-                                    method="get"
+                                  <div
+                                    className="bx--header__search--actions"
                                   >
-                                    <input
-                                      name="lang"
-                                      type="hidden"
-                                      value="en"
-                                    />
-                                    <input
-                                      name="cc"
-                                      type="hidden"
-                                      value="us"
-                                    />
-                                    <input
-                                      name="lnk"
-                                      type="hidden"
-                                      value="mhsrch"
-                                    />
-                                    <Autosuggest
-                                      alwaysRenderSuggestions={false}
-                                      focusInputOnSuggestionClick={true}
-                                      getSuggestionValue={[Function]}
-                                      highlightFirstSuggestion={true}
-                                      id="1"
-                                      inputProps={
-                                        Object {
-                                          "className": "bx--header__search--input",
-                                          "onChange": [Function],
-                                          "onKeyDown": [Function],
-                                          "placeholder": "Search all of IBM",
-                                          "value": "",
-                                        }
-                                      }
-                                      multiSection={false}
-                                      onSuggestionSelected={[Function]}
-                                      onSuggestionsClearRequested={[Function]}
-                                      onSuggestionsFetchRequested={[Function]}
-                                      renderInputComponent={[Function]}
-                                      renderSuggestion={[Function]}
-                                      renderSuggestionsContainer={[Function]}
-                                      shouldRenderSuggestions={[Function]}
-                                      suggestions={Array []}
-                                      theme={
-                                        Object {
-                                          "container": "react-autosuggest__container",
-                                          "containerOpen": "react-autosuggest__container--open",
-                                          "input": "react-autosuggest__input",
-                                          "inputFocused": "react-autosuggest__input--focused",
-                                          "inputOpen": "react-autosuggest__input--open",
-                                          "sectionContainer": "react-autosuggest__section-container",
-                                          "sectionContainerFirst": "react-autosuggest__section-container--first",
-                                          "sectionTitle": "react-autosuggest__section-title",
-                                          "suggestion": "react-autosuggest__suggestion",
-                                          "suggestionFirst": "react-autosuggest__suggestion--first",
-                                          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-                                          "suggestionsContainer": "react-autosuggest__suggestions-container",
-                                          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-                                          "suggestionsList": "react-autosuggest__suggestions-list",
-                                        }
-                                      }
+                                    <HeaderGlobalAction
+                                      aria-label="Open IBM search field"
+                                      className="bx--header__search--search"
+                                      data-autoid="dds--header__search--search"
+                                      onClick={[Function]}
+                                      tabIndex="0"
                                     >
-                                      <Autowhatever
-                                        containerProps={Object {}}
-                                        getSectionItems={[Function]}
-                                        highlightedItemIndex={null}
-                                        highlightedSectionIndex={null}
-                                        id="1"
-                                        inputProps={
-                                          Object {
-                                            "className": "bx--header__search--input",
-                                            "onBlur": [Function],
-                                            "onChange": [Function],
-                                            "onFocus": [Function],
-                                            "onKeyDown": [Function],
-                                            "placeholder": "Search all of IBM",
-                                            "value": "",
-                                          }
-                                        }
-                                        itemProps={[Function]}
-                                        items={Array []}
-                                        multiSection={false}
-                                        renderInputComponent={[Function]}
-                                        renderItem={[Function]}
-                                        renderItemData={
-                                          Object {
-                                            "query": "",
-                                          }
-                                        }
-                                        renderItemsContainer={[Function]}
-                                        renderSectionTitle={[Function]}
-                                        theme={
-                                          Object {
-                                            "container": "react-autosuggest__container",
-                                            "containerOpen": "react-autosuggest__container--open",
-                                            "input": "react-autosuggest__input",
-                                            "inputFocused": "react-autosuggest__input--focused",
-                                            "inputOpen": "react-autosuggest__input--open",
-                                            "item": "react-autosuggest__suggestion",
-                                            "itemFirst": "react-autosuggest__suggestion--first",
-                                            "itemHighlighted": "react-autosuggest__suggestion--highlighted",
-                                            "itemsContainer": "react-autosuggest__suggestions-container",
-                                            "itemsContainerOpen": "react-autosuggest__suggestions-container--open",
-                                            "itemsList": "react-autosuggest__suggestions-list",
-                                            "sectionContainer": "react-autosuggest__section-container",
-                                            "sectionContainerFirst": "react-autosuggest__section-container--first",
-                                            "sectionTitle": "react-autosuggest__section-title",
-                                          }
-                                        }
+                                      <button
+                                        aria-label="Open IBM search field"
+                                        className="bx--header__search--search bx--header__action"
+                                        data-autoid="dds--header__search--search"
+                                        onClick={[Function]}
+                                        tabIndex="0"
+                                        type="button"
                                       >
-                                        <div
-                                          aria-expanded={false}
-                                          aria-haspopup="listbox"
-                                          aria-owns="react-autowhatever-1"
-                                          className="react-autosuggest__container"
-                                          key="react-autowhatever-1-container"
-                                          role="combobox"
-                                        >
-                                          <MastheadSearchInput
-                                            componentInputProps={
-                                              Object {
-                                                "aria-activedescendant": null,
-                                                "aria-autocomplete": "list",
-                                                "aria-controls": "react-autowhatever-1",
-                                                "autoComplete": "off",
-                                                "className": "bx--header__search--input",
-                                                "key": "react-autowhatever-1-input",
-                                                "onBlur": [Function],
-                                                "onChange": [Function],
-                                                "onFocus": [Function],
-                                                "onKeyDown": [Function],
-                                                "placeholder": "Search all of IBM",
-                                                "ref": [Function],
-                                                "type": "text",
-                                                "value": "",
-                                              }
-                                            }
-                                            dispatch={[Function]}
-                                            isActive={false}
-                                            searchIconClick={[Function]}
+                                        <ForwardRef(Search20)>
+                                          <Icon
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <input
-                                              aria-activedescendant={null}
-                                              aria-autocomplete="list"
-                                              aria-controls="react-autowhatever-1"
-                                              autoComplete="off"
-                                              className="bx--header__search--input"
-                                              data-autoid="dds--header__search--input"
-                                              key="react-autowhatever-1-input"
-                                              name="q"
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              onKeyDown={[Function]}
-                                              placeholder="Search all of IBM"
-                                              tabIndex="-1"
-                                              type="text"
-                                              value=""
-                                            />
-                                            <HeaderGlobalAction
-                                              aria-label="Search all of IBM"
-                                              className="bx--header__search--search"
-                                              data-autoid="dds--header__search--search"
-                                              onClick={[Function]}
+                                            <svg
+                                              aria-hidden={true}
+                                              focusable="false"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              style={
+                                                Object {
+                                                  "willChange": "transform",
+                                                }
+                                              }
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <button
-                                                aria-label="Search all of IBM"
-                                                className="bx--header__search--search bx--header__action"
-                                                data-autoid="dds--header__search--search"
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <ForwardRef(Search20)>
-                                                  <Icon
-                                                    height={20}
-                                                    preserveAspectRatio="xMidYMid meet"
-                                                    viewBox="0 0 32 32"
-                                                    width={20}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      focusable="false"
-                                                      height={20}
-                                                      preserveAspectRatio="xMidYMid meet"
-                                                      style={
-                                                        Object {
-                                                          "willChange": "transform",
-                                                        }
-                                                      }
-                                                      viewBox="0 0 32 32"
-                                                      width={20}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
-                                                      />
-                                                    </svg>
-                                                  </Icon>
-                                                </ForwardRef(Search20)>
-                                              </button>
-                                            </HeaderGlobalAction>
-                                            <HeaderGlobalAction
-                                              aria-label="Close"
-                                              className="bx--header__search--close"
-                                              data-autoid="dds--header__search--close"
-                                              onClick={[Function]}
+                                              <path
+                                                d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
+                                              />
+                                            </svg>
+                                          </Icon>
+                                        </ForwardRef(Search20)>
+                                      </button>
+                                    </HeaderGlobalAction>
+                                    <HeaderGlobalAction
+                                      aria-label="Close"
+                                      className="bx--header__search--close"
+                                      data-autoid="dds--header__search--close"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        aria-label="Close"
+                                        className="bx--header__search--close bx--header__action"
+                                        data-autoid="dds--header__search--close"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <ForwardRef(Close20)>
+                                          <Icon
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              focusable="false"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              style={
+                                                Object {
+                                                  "willChange": "transform",
+                                                }
+                                              }
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <button
-                                                aria-label="Close"
-                                                className="bx--header__search--close bx--header__action"
-                                                data-autoid="dds--header__search--close"
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <ForwardRef(Close20)>
-                                                  <Icon
-                                                    height={20}
-                                                    preserveAspectRatio="xMidYMid meet"
-                                                    viewBox="0 0 32 32"
-                                                    width={20}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      focusable="false"
-                                                      height={20}
-                                                      preserveAspectRatio="xMidYMid meet"
-                                                      style={
-                                                        Object {
-                                                          "willChange": "transform",
-                                                        }
-                                                      }
-                                                      viewBox="0 0 32 32"
-                                                      width={20}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                                      />
-                                                    </svg>
-                                                  </Icon>
-                                                </ForwardRef(Close20)>
-                                              </button>
-                                            </HeaderGlobalAction>
-                                          </MastheadSearchInput>
-                                          <div
-                                            className="react-autosuggest__suggestions-container"
-                                            id="react-autowhatever-1"
-                                            key="react-autowhatever-1-items-container"
-                                            role="listbox"
-                                          />
-                                        </div>
-                                      </Autowhatever>
-                                    </Autosuggest>
-                                  </form>
+                                              <path
+                                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                              />
+                                            </svg>
+                                          </Icon>
+                                        </ForwardRef(Close20)>
+                                      </button>
+                                    </HeaderGlobalAction>
+                                  </div>
                                 </div>
                               </MastheadSearch>
                             </div>
@@ -6589,6 +6271,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                               </div>
                             </IbmLogo>
                             <div
+                              aria-hidden="false"
                               className="bx--header__search "
                             >
                               <MastheadTopNav
@@ -6597,22 +6280,26 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                 platform={null}
                                 searchOpenOnload={true}
                               >
-                                <HeaderNavigation
-                                  aria-label="IBM"
-                                  data-autoid="dds--masthead__l0-nav"
+                                <div
+                                  className="bx--header__nav-container"
                                 >
-                                  <nav
+                                  <HeaderNavigation
                                     aria-label="IBM"
-                                    className="bx--header__nav"
                                     data-autoid="dds--masthead__l0-nav"
                                   >
-                                    <ul
+                                    <nav
                                       aria-label="IBM"
-                                      className="bx--header__menu-bar"
-                                      role="menubar"
-                                    />
-                                  </nav>
-                                </HeaderNavigation>
+                                      className="bx--header__nav"
+                                      data-autoid="dds--masthead__l0-nav"
+                                    >
+                                      <ul
+                                        aria-label="IBM"
+                                        className="bx--header__menu-bar"
+                                        role="menubar"
+                                      />
+                                    </nav>
+                                  </HeaderNavigation>
+                                </div>
                               </MastheadTopNav>
                               <MastheadSearch
                                 placeHolderText="Search all of IBM"
@@ -6625,6 +6312,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                 >
                                   <form
                                     action="https://www.ibm.com/search?lnk=mhsrch"
+                                    id="bx--masthead__search--form"
                                     method="get"
                                   >
                                     <input
@@ -6652,7 +6340,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                         Object {
                                           "className": "bx--header__search--input",
                                           "onChange": [Function],
-                                          "onKeyDown": [Function],
                                           "placeholder": "Search all of IBM",
                                           "value": "",
                                         }
@@ -6782,92 +6469,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                               type="text"
                                               value=""
                                             />
-                                            <HeaderGlobalAction
-                                              aria-label="Search all of IBM"
-                                              className="bx--header__search--search"
-                                              data-autoid="dds--header__search--search"
-                                              onClick={[Function]}
-                                            >
-                                              <button
-                                                aria-label="Search all of IBM"
-                                                className="bx--header__search--search bx--header__action"
-                                                data-autoid="dds--header__search--search"
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <ForwardRef(Search20)>
-                                                  <Icon
-                                                    height={20}
-                                                    preserveAspectRatio="xMidYMid meet"
-                                                    viewBox="0 0 32 32"
-                                                    width={20}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      focusable="false"
-                                                      height={20}
-                                                      preserveAspectRatio="xMidYMid meet"
-                                                      style={
-                                                        Object {
-                                                          "willChange": "transform",
-                                                        }
-                                                      }
-                                                      viewBox="0 0 32 32"
-                                                      width={20}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
-                                                      />
-                                                    </svg>
-                                                  </Icon>
-                                                </ForwardRef(Search20)>
-                                              </button>
-                                            </HeaderGlobalAction>
-                                            <HeaderGlobalAction
-                                              aria-label="Close"
-                                              className="bx--header__search--close"
-                                              data-autoid="dds--header__search--close"
-                                              onClick={[Function]}
-                                            >
-                                              <button
-                                                aria-label="Close"
-                                                className="bx--header__search--close bx--header__action"
-                                                data-autoid="dds--header__search--close"
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <ForwardRef(Close20)>
-                                                  <Icon
-                                                    height={20}
-                                                    preserveAspectRatio="xMidYMid meet"
-                                                    viewBox="0 0 32 32"
-                                                    width={20}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      focusable="false"
-                                                      height={20}
-                                                      preserveAspectRatio="xMidYMid meet"
-                                                      style={
-                                                        Object {
-                                                          "willChange": "transform",
-                                                        }
-                                                      }
-                                                      viewBox="0 0 32 32"
-                                                      width={20}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
-                                                      />
-                                                    </svg>
-                                                  </Icon>
-                                                </ForwardRef(Close20)>
-                                              </button>
-                                            </HeaderGlobalAction>
                                           </MastheadSearchInput>
                                           <div
                                             className="react-autosuggest__suggestions-container"
@@ -6879,6 +6480,98 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                       </Autowhatever>
                                     </Autosuggest>
                                   </form>
+                                  <div
+                                    className="bx--header__search--actions"
+                                  >
+                                    <HeaderGlobalAction
+                                      aria-label="Search all of IBM"
+                                      className="bx--header__search--search"
+                                      data-autoid="dds--header__search--search"
+                                      onClick={[Function]}
+                                      tabIndex="0"
+                                    >
+                                      <button
+                                        aria-label="Search all of IBM"
+                                        className="bx--header__search--search bx--header__action"
+                                        data-autoid="dds--header__search--search"
+                                        onClick={[Function]}
+                                        tabIndex="0"
+                                        type="button"
+                                      >
+                                        <ForwardRef(Search20)>
+                                          <Icon
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              focusable="false"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              style={
+                                                Object {
+                                                  "willChange": "transform",
+                                                }
+                                              }
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
+                                              />
+                                            </svg>
+                                          </Icon>
+                                        </ForwardRef(Search20)>
+                                      </button>
+                                    </HeaderGlobalAction>
+                                    <HeaderGlobalAction
+                                      aria-label="Close"
+                                      className="bx--header__search--close"
+                                      data-autoid="dds--header__search--close"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        aria-label="Close"
+                                        className="bx--header__search--close bx--header__action"
+                                        data-autoid="dds--header__search--close"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <ForwardRef(Close20)>
+                                          <Icon
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              focusable="false"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              style={
+                                                Object {
+                                                  "willChange": "transform",
+                                                }
+                                              }
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                              />
+                                            </svg>
+                                          </Icon>
+                                        </ForwardRef(Close20)>
+                                      </button>
+                                    </HeaderGlobalAction>
+                                  </div>
                                 </div>
                               </MastheadSearch>
                             </div>

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -5,16 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useReducer } from 'react';
+import React, { useCallback, useEffect, useReducer } from 'react';
 import Autosuggest from 'react-autosuggest';
+import { Close20 } from '@carbon/icons-react';
 import cx from 'classnames';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import { escapeRegExp } from '@carbon/ibmdotcom-utilities';
+import { HeaderGlobalAction } from 'carbon-components-react';
 import { LocaleAPI } from '@carbon/ibmdotcom-services';
 import MastheadSearchInput from './MastheadSearchInput';
 import MastheadSearchSuggestion from './MastheadSearchSuggestion';
 import PropTypes from 'prop-types';
 import root from 'window-or-global';
+import { Search20 } from '@carbon/icons-react';
 import { SearchTypeaheadAPI } from '@carbon/ibmdotcom-services';
 import { settings } from 'carbon-components';
 
@@ -177,6 +180,28 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
   }
 
   /**
+   * Clear search and clear input when called
+   */
+  const resetSearch = useCallback(() => {
+    dispatch({ type: 'setSearchClosed' });
+    dispatch({
+      type: 'setVal',
+      payload: { val: '' },
+    });
+  }, [dispatch]);
+
+  /**
+   * closeBtnAction resets and sets focus after search is closed
+   */
+  function closeBtnAction() {
+    resetSearch();
+    const searchIconRef = root.document.querySelectorAll(
+      `[data-autoid="${stablePrefix}--header__search--search"]`
+    );
+    searchIconRef && searchIconRef[0].focus();
+  }
+
+  /**
    * Renders the input bar with the search icon
    *
    * @param {object} componentInputProps contains the input props
@@ -293,7 +318,10 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
     <div
       data-autoid={`${stablePrefix}--masthead__search`}
       className={className}>
-      <form action={_redirectUrl} method="get">
+      <form
+        id={`${prefix}--masthead__search--form`}
+        action={_redirectUrl}
+        method="get">
         <input type="hidden" name="lang" value={state.lc} />
         <input type="hidden" name="cc" value={state.cc} />
         <input type="hidden" name="lnk" value="mhsrch" />
@@ -310,6 +338,23 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
           shouldRenderSuggestions={shouldRenderSuggestions}
         />
       </form>
+      <div className={`${prefix}--header__search--actions`}>
+        <HeaderGlobalAction
+          onClick={searchIconClick}
+          aria-label="Search all of IBM"
+          className={`${prefix}--header__search--search`}
+          data-autoid={`${stablePrefix}--header__search--search`}
+          tabindex="0">
+          <Search20 />
+        </HeaderGlobalAction>
+        <HeaderGlobalAction
+          onClick={closeBtnAction}
+          aria-label="Close"
+          className={`${prefix}--header__search--close`}
+          data-autoid={`${stablePrefix}--header__search--close`}>
+          <Close20 />
+        </HeaderGlobalAction>
+      </div>
     </div>
   );
 };

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -5,13 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {
-  useCallback,
-  useEffect,
-  useReducer,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import Autosuggest from 'react-autosuggest';
 import { Close20 } from '@carbon/icons-react';
 import cx from 'classnames';
@@ -107,7 +101,8 @@ function _reducer(state, action) {
  * @class
  */
 const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
-  const { ref, isSearchVisible, setIsSearchVisible } = useSearchVisible(true);
+  const { ref } = useSearchVisible(false);
+
   /**
    * Initial state of the autocomplete component
    *
@@ -139,11 +134,9 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
   /**
    * Event handlers to toggle visiblity of search
    *
-   * @param {boolean} initialIsVisible Search visibility
-   * @returns {*} search visibility object
+   * @returns {*} search ref
    */
-  function useSearchVisible(initialIsVisible) {
-    const [isSearchVisible, setIsSearchVisible] = useState(initialIsVisible);
+  function useSearchVisible() {
     const ref = useRef(null);
 
     /**
@@ -154,7 +147,6 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
     const handleHideSearch = event => {
       if (event.key === 'Escape') {
         if (!state.suggestionContainerVisible) {
-          setIsSearchVisible(false);
           dispatch({ type: 'setSearchClosed' });
         }
       }
@@ -169,7 +161,6 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
      */
     const handleClickOutside = event => {
       if (ref.current && !ref.current.contains(event.target)) {
-        setIsSearchVisible(false);
         dispatch({ type: 'setSearchClosed' });
       }
     };
@@ -183,7 +174,7 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
       };
     });
 
-    return { ref, isSearchVisible, setIsSearchVisible };
+    return { ref };
   }
 
   const className = cx({
@@ -218,14 +209,12 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
    * This will execute the search if the search is open, or will open the
    * search field if closed.
    *
-   * @returns {*} search visibility object
    */
   function searchIconClick() {
     if (state.isSearchOpen) {
       root.parent.location.href = getRedirect(state.val);
     } else {
       dispatch({ type: 'setSearchOpen' });
-      return setIsSearchVisible(true);
     }
   }
 
@@ -369,7 +358,7 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
       data-autoid={`${stablePrefix}--masthead__search`}
       className={className}
       ref={ref}>
-      {isSearchVisible && (
+      {state.isSearchOpen && (
         <form
           id={`${prefix}--masthead__search--form`}
           action={_redirectUrl}
@@ -394,7 +383,9 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
       <div className={`${prefix}--header__search--actions`}>
         <HeaderGlobalAction
           onClick={searchIconClick}
-          aria-label="Search all of IBM"
+          aria-label={
+            state.isSearchOpen ? 'Search all of IBM' : 'Open IBM search field'
+          }
           className={`${prefix}--header__search--search`}
           data-autoid={`${stablePrefix}--header__search--search`}
           tabIndex="0">

--- a/packages/react/src/components/Masthead/MastheadSearchInput.js
+++ b/packages/react/src/components/Masthead/MastheadSearchInput.js
@@ -1,14 +1,8 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Close20 } from '@carbon/icons-react';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import { HeaderGlobalAction } from 'carbon-components-react';
 import PropTypes from 'prop-types';
-import root from 'window-or-global';
-import { Search20 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;
-const { prefix } = settings;
 
 /**
  * Renders the input bar with the search icon
@@ -19,12 +13,7 @@ const { prefix } = settings;
  * @param {Function} props.searchIconClick executes when the search icon is clicked
  * @returns {*} The rendered component
  */
-const MastheadSearchInput = ({
-  componentInputProps,
-  dispatch,
-  isActive,
-  searchIconClick,
-}) => {
+const MastheadSearchInput = ({ componentInputProps, dispatch, isActive }) => {
   const searchRef = useRef();
 
   /**
@@ -37,17 +26,6 @@ const MastheadSearchInput = ({
       payload: { val: '' },
     });
   }, [dispatch]);
-
-  /**
-   * closeBtnAction resets and sets focus after search is closed
-   */
-  function closeBtnAction() {
-    resetSearch();
-    const searchIconRef = root.document.querySelectorAll(
-      `[data-autoid="${stablePrefix}--header__search--search"]`
-    );
-    searchIconRef && searchIconRef[0].focus();
-  }
 
   useEffect(() => {
     if (isActive) {
@@ -64,20 +42,6 @@ const MastheadSearchInput = ({
         name="q"
         tabIndex={isActive ? null : '-1'}
       />
-      <HeaderGlobalAction
-        onClick={searchIconClick}
-        aria-label="Search all of IBM"
-        className={`${prefix}--header__search--search`}
-        data-autoid={`${stablePrefix}--header__search--search`}>
-        <Search20 />
-      </HeaderGlobalAction>
-      <HeaderGlobalAction
-        onClick={closeBtnAction}
-        aria-label="Close"
-        className={`${prefix}--header__search--close`}
-        data-autoid={`${stablePrefix}--header__search--close`}>
-        <Close20 />
-      </HeaderGlobalAction>
     </>
   );
 };

--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -14,8 +14,10 @@ import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import HeaderMenu from '../carbon-components-react/UIShell/HeaderMenu';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { settings } from 'carbon-components';
 
 const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
 
 /**
  * Masthead top nav component
@@ -53,7 +55,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
   });
 
   return (
-    <>
+    <div className={`${prefix}--header__nav-container`}>
       {topNavProps.platform && (
         <HeaderName
           prefix=""
@@ -67,7 +69,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
         data-autoid={`${stablePrefix}--masthead__l0-nav`}>
         {mastheadLinks}
       </HeaderNavigation>
-    </>
+    </div>
   );
 };
 

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -25,14 +25,11 @@
       }
     }
 
-    &--search {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      svg {
-        top: 0;
-      }
+    &--actions {
+      position: absolute;
+      z-index: 10001;
+      top: 0;
+      right: 0;
     }
 
     .#{$prefix}--header__nav {
@@ -92,6 +89,7 @@
   // search container
   .#{$prefix}--masthead__search {
     flex: 1;
+    height: $carbon--spacing-09;
 
     &.#{$prefix}--masthead__search--active {
       position: absolute;
@@ -108,7 +106,7 @@
           border-bottom: 2px solid $interactive-01;
           width: 100%;
           height: 2px;
-          z-index: 10001;
+          z-index: 10002;
         }
       }
 
@@ -137,7 +135,7 @@
 
       .#{$prefix}--header__search--close {
         width: $carbon--spacing-09;
-        display: block;
+        display: inline-block;
       }
 
       .#{$prefix}--header__search--close,
@@ -155,8 +153,6 @@
         transition-property: width;
         transition-delay: 380ms;
         transition-duration: 112ms;
-        z-index: 10000;
-        position: relative;
       }
     }
   }
@@ -166,6 +162,7 @@
       display: flex;
       justify-content: flex-end;
       position: relative;
+      height: $carbon--spacing-09;
     }
 
     &__suggestions-container {

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -101,6 +101,10 @@ $search-transition-timing: 95ms;
       flex: 0;
     }
 
+    &__nav-container {
+      height: 100%;
+    }
+
     &__nav {
       a.#{$prefix}--header__menu-item[role='menuitem'] {
         @include carbon--type-style(body-short-02, true);


### PR DESCRIPTION
### Related Ticket(s)

#2056, #2057, #2059, #2061

### Description

Various accessibility fixes to the Masthead, specifically the search component. This includes preventing hidden elements being read by screen readers until they are present on the screen, more descriptive aria-labels for icons, as well as updating search visibility functionality. The search bar now closes when a click is detected anywhere outside of the component boundaries.

### Changelog

**New**

- search closes when click detected outside component

**Changed**

- search icon `aria-label` updated based on search visibility (translations required for this)
- search action buttons (search, close) moved out of React Autosuggest in order to hide combobox from screen reader


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
