### PR TITLE
fix(css): fix lightbox content overflow

### DIFF
--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -90,7 +90,7 @@
       max-width: 95%;
       @include carbon--type-style('body-long-02');
       @include carbon--breakpoint('lg') {
-        overflow: scroll;
+        overflow: auto;
       }
 
       &__title {


### PR DESCRIPTION
### Related Ticket(s)

#2125 

### Description

Removes persistent scrollbars on content container, which are visible even when the content does not require scrolling.

### Changelog

**Changed**

- `LightboxMediaViewer` content overflow to `auto`.


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
