### PR TITLE
fix(leadspace): properly point to defaultSrc for the Image

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -16490,7 +16490,7 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
                 image={
                   Object {
                     "alt": "lead space image",
-                    "default": "https://picsum.photos/id/1076/1056/480",
+                    "defaultSrc": "https://picsum.photos/id/1076/1056/480",
                     "sources": Array [
                       Object {
                         "breakpoint": "sm",
@@ -16562,7 +16562,7 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
                 image={
                   Object {
                     "alt": "lead space image",
-                    "default": "https://picsum.photos/id/1076/1056/480",
+                    "defaultSrc": "https://picsum.photos/id/1076/1056/480",
                     "sources": Array [
                       Object {
                         "breakpoint": "sm",
@@ -16866,7 +16866,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                     Object {
                       "copy": "Button 1",
                       "href": "https://www.example.com",
-                      "link": "",
                       "renderIcon": Object {
                         "$$typeof": Symbol(react.forward_ref),
                         "render": [Function],
@@ -16875,7 +16874,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                     Object {
                       "copy": "Button 2",
                       "href": "https://www.example.com",
-                      "link": "",
                       "renderIcon": Object {
                         "$$typeof": Symbol(react.forward_ref),
                         "render": [Function],
@@ -16921,7 +16919,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                     Object {
                       "copy": "Button 1",
                       "href": "https://www.example.com",
-                      "link": "",
                       "renderIcon": Object {
                         "$$typeof": Symbol(react.forward_ref),
                         "render": [Function],
@@ -16930,7 +16927,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                     Object {
                       "copy": "Button 2",
                       "href": "https://www.example.com",
-                      "link": "",
                       "renderIcon": Object {
                         "$$typeof": Symbol(react.forward_ref),
                         "render": [Function],
@@ -16984,7 +16980,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                                 Object {
                                   "copy": "Button 1",
                                   "href": "https://www.example.com",
-                                  "link": "",
                                   "renderIcon": Object {
                                     "$$typeof": Symbol(react.forward_ref),
                                     "render": [Function],
@@ -16993,7 +16988,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                                 Object {
                                   "copy": "Button 2",
                                   "href": "https://www.example.com",
-                                  "link": "",
                                   "renderIcon": Object {
                                     "$$typeof": Symbol(react.forward_ref),
                                     "render": [Function],
@@ -17016,7 +17010,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                                   disabled={false}
                                   href="https://www.example.com"
                                   kind="primary"
-                                  link=""
                                   renderIcon={
                                     Object {
                                       "$$typeof": Symbol(react.forward_ref),
@@ -17031,7 +17024,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                                     copy="Button 1"
                                     data-autoid="dds--button-group-0"
                                     href="https://www.example.com"
-                                    link=""
                                     role="button"
                                     tabIndex={2}
                                   >
@@ -17083,7 +17075,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                                   disabled={false}
                                   href="https://www.example.com"
                                   kind="tertiary"
-                                  link=""
                                   renderIcon={
                                     Object {
                                       "$$typeof": Symbol(react.forward_ref),
@@ -17098,7 +17089,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                                     copy="Button 2"
                                     data-autoid="dds--button-group-1"
                                     href="https://www.example.com"
-                                    link=""
                                     role="button"
                                     tabIndex={1}
                                   >
@@ -17210,7 +17200,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                         Array [
                           Object {
                             "copy": "Button 1",
-                            "link": "https://example.com",
+                            "href": "https://example.com",
                             "renderIcon": Object {
                               "$$typeof": Symbol(react.forward_ref),
                               "render": [Function],
@@ -17218,7 +17208,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                           },
                           Object {
                             "copy": "Button 2",
-                            "link": "https://example.com",
+                            "href": "https://example.com",
                             "renderIcon": Object {
                               "$$typeof": Symbol(react.forward_ref),
                               "render": [Function],
@@ -17244,7 +17234,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                     Array [
                       Object {
                         "copy": "Button 1",
-                        "link": "https://example.com",
+                        "href": "https://example.com",
                         "renderIcon": Object {
                           "$$typeof": Symbol(react.forward_ref),
                           "render": [Function],
@@ -17252,7 +17242,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                       },
                       Object {
                         "copy": "Button 2",
-                        "link": "https://example.com",
+                        "href": "https://example.com",
                         "renderIcon": Object {
                           "$$typeof": Symbol(react.forward_ref),
                           "render": [Function],
@@ -17318,7 +17308,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                         Array [
                           Object {
                             "copy": "Button 1",
-                            "link": "https://example.com",
+                            "href": "https://example.com",
                             "renderIcon": Object {
                               "$$typeof": Symbol(react.forward_ref),
                               "render": [Function],
@@ -17326,7 +17316,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                           },
                           Object {
                             "copy": "Button 2",
-                            "link": "https://example.com",
+                            "href": "https://example.com",
                             "renderIcon": Object {
                               "$$typeof": Symbol(react.forward_ref),
                               "render": [Function],
@@ -17347,8 +17337,8 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                             copy="Button 1"
                             data-autoid="dds--button-group-0"
                             disabled={false}
+                            href="https://example.com"
                             kind="primary"
-                            link="https://example.com"
                             renderIcon={
                               Object {
                                 "$$typeof": Symbol(react.forward_ref),
@@ -17358,14 +17348,13 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                             tabIndex={2}
                             type="button"
                           >
-                            <button
+                            <a
                               className="bx--btn bx--btn--primary"
                               copy="Button 1"
                               data-autoid="dds--button-group-0"
-                              disabled={false}
-                              link="https://example.com"
+                              href="https://example.com"
+                              role="button"
                               tabIndex={2}
-                              type="button"
                             >
                               Button 1
                               <ForwardRef(ArrowRight20)
@@ -17402,7 +17391,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                                   </svg>
                                 </Icon>
                               </ForwardRef(ArrowRight20)>
-                            </button>
+                            </a>
                           </ForwardRef(Button)>
                         </li>
                         <li
@@ -17413,8 +17402,8 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                             copy="Button 2"
                             data-autoid="dds--button-group-1"
                             disabled={false}
+                            href="https://example.com"
                             kind="tertiary"
-                            link="https://example.com"
                             renderIcon={
                               Object {
                                 "$$typeof": Symbol(react.forward_ref),
@@ -17424,14 +17413,13 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                             tabIndex={1}
                             type="button"
                           >
-                            <button
+                            <a
                               className="bx--btn bx--btn--tertiary"
                               copy="Button 2"
                               data-autoid="dds--button-group-1"
-                              disabled={false}
-                              link="https://example.com"
+                              href="https://example.com"
+                              role="button"
                               tabIndex={1}
-                              type="button"
                             >
                               Button 2
                               <ForwardRef(ArrowRight20)
@@ -17468,7 +17456,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                                   </svg>
                                 </Icon>
                               </ForwardRef(ArrowRight20)>
-                            </button>
+                            </a>
                           </ForwardRef(Button)>
                         </li>
                       </ol>
@@ -17490,7 +17478,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                     Array [
                       Object {
                         "copy": "Button 1",
-                        "link": "https://example.com",
+                        "href": "https://example.com",
                         "renderIcon": Object {
                           "$$typeof": Symbol(react.forward_ref),
                           "render": [Function],
@@ -17498,7 +17486,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                       },
                       Object {
                         "copy": "Button 2",
-                        "link": "https://example.com",
+                        "href": "https://example.com",
                         "renderIcon": Object {
                           "$$typeof": Symbol(react.forward_ref),
                           "render": [Function],
@@ -17519,8 +17507,8 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                         copy="Button 1"
                         data-autoid="dds--button-group-0"
                         disabled={false}
+                        href="https://example.com"
                         kind="primary"
-                        link="https://example.com"
                         renderIcon={
                           Object {
                             "$$typeof": Symbol(react.forward_ref),
@@ -17530,14 +17518,13 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                         tabIndex={2}
                         type="button"
                       >
-                        <button
+                        <a
                           className="bx--btn bx--btn--primary"
                           copy="Button 1"
                           data-autoid="dds--button-group-0"
-                          disabled={false}
-                          link="https://example.com"
+                          href="https://example.com"
+                          role="button"
                           tabIndex={2}
-                          type="button"
                         >
                           Button 1
                           <ForwardRef(ArrowRight20)
@@ -17574,7 +17561,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                               </svg>
                             </Icon>
                           </ForwardRef(ArrowRight20)>
-                        </button>
+                        </a>
                       </ForwardRef(Button)>
                     </li>
                     <li
@@ -17585,8 +17572,8 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                         copy="Button 2"
                         data-autoid="dds--button-group-1"
                         disabled={false}
+                        href="https://example.com"
                         kind="tertiary"
-                        link="https://example.com"
                         renderIcon={
                           Object {
                             "$$typeof": Symbol(react.forward_ref),
@@ -17596,14 +17583,13 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                         tabIndex={1}
                         type="button"
                       >
-                        <button
+                        <a
                           className="bx--btn bx--btn--tertiary"
                           copy="Button 2"
                           data-autoid="dds--button-group-1"
-                          disabled={false}
-                          link="https://example.com"
+                          href="https://example.com"
+                          role="button"
                           tabIndex={1}
-                          type="button"
                         >
                           Button 2
                           <ForwardRef(ArrowRight20)
@@ -17640,7 +17626,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ButtonGroup Default 1`] = `
                               </svg>
                             </Icon>
                           </ForwardRef(ArrowRight20)>
-                        </button>
+                        </a>
                       </ForwardRef(Button)>
                     </li>
                   </ol>

--- a/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
+++ b/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
@@ -79,17 +79,10 @@ function imageClassname(type, image) {
       <div
         data-autoid={`${stablePrefix}--leadspace--centered--mobile__image`}
         className={`${prefix}--leadspace--centered--mobile__image`}>
-        <img src={image.default} alt={image.alt} />
+        <img src={image.defaultSrc} alt={image.alt} />
       </div>
     );
-  } else
-    return (
-      <Image
-        sources={image.sources}
-        defaultSrc={image.default}
-        alt={image.alt}
-      />
-    );
+  } else return <Image {...image} />;
 }
 
 /**
@@ -107,7 +100,7 @@ function imageClassname(type, image) {
  */
 const LeadSpace = ({ buttons, copy, gradient, image, theme, title, type }) => {
   const background = image && {
-    backgroundImage: `url(${image.default})`,
+    backgroundImage: `url(${image.defaultSrc})`,
   };
 
   return (

--- a/packages/react/src/patterns/sections/LeadSpace/README.md
+++ b/packages/react/src/patterns/sections/LeadSpace/README.md
@@ -24,10 +24,39 @@ Here's a quick example to get you started.
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { LeadSpace } from '@carbon/ibmdotcom-react';
+import { ArrowRight20 } from '@carbon/icons-react';
 import 'yourapplication.scss';
 
 function App() {
-  return <LeadSpace />;
+  return (
+    <LeadSpace
+      type="default"
+      theme="g100"
+      title="Lorem Ipsum"
+      copy="Lorem Ipsum Dolor"
+      gradient={true}
+      buttons={[
+        {
+          copy: 'Button 1',
+          renderIcon: ArrowRight20,
+          href: 'https://www.example.com',
+        },
+        {
+          copy: 'Button 2',
+          renderIcon: ArrowRight20,
+          href: 'https://www.example.com',
+        },
+      ]}
+      image={{
+        sources: [
+          { src: 'https://picsum.photos/id/1076/320/370', breakpoint: 'sm' },
+          { src: 'https://picsum.photos/id/1076/672/400', breakpoint: 'md' },
+        ],
+        defaultSrc: 'https://picsum.photos/id/1076/1056/480',
+        alt: 'lead space image',
+      }}
+    />
+  );
 }
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```

--- a/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/react/src/patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js
@@ -52,7 +52,6 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
 
     for (let i = 0; i < buttonCount; i++) {
       buttons.push({
-        link: '',
         copy: text(`Button ${i + 1}`, `Button ${i + 1}`),
         renderIcon:
           iconMap[
@@ -96,7 +95,7 @@ storiesOf('Patterns (Sections)|LeadSpace', module)
         { src: 'https://picsum.photos/id/1076/320/370', breakpoint: 'sm' },
         { src: 'https://picsum.photos/id/1076/672/400', breakpoint: 'md' },
       ],
-      default: 'https://picsum.photos/id/1076/1056/480',
+      defaultSrc: 'https://picsum.photos/id/1076/1056/480',
       alt: 'lead space image',
     };
 

--- a/packages/react/src/patterns/sub-patterns/ButtonGroup/__stories__/ButtonGroup.stories.js
+++ b/packages/react/src/patterns/sub-patterns/ButtonGroup/__stories__/ButtonGroup.stories.js
@@ -32,7 +32,7 @@ storiesOf('Patterns (Sub-Patterns)|ButtonGroup', module)
 
     for (let i = 0; i < buttonCount; i++) {
       buttons.push({
-        link: text(`Link ${i + 1}`, `https://example.com`),
+        href: text(`Link ${i + 1}`, `https://example.com`),
         copy: text(`Button ${i + 1}`, `Button ${i + 1}`),
         renderIcon:
           iconMap[


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

I can't seem to find the issue that this was related to, but wondering if this should get patched in. The Leadspace is pointing to `image.default` and not `image.defaultSrc`. 

### Changelog

**Changed**

- Fix to Leadspace to properly point to `defaultSrc`