### PR TITLE
fix(textarea): updated invalid icon to expressive sizing

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_text-area.scss
+++ b/packages/styles/scss/themes/expressive/components/_text-area.scss
@@ -1,0 +1,22 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/layout/scss/convert';
+
+//-----------------------------
+// Text Area (expressive)
+//-----------------------------
+
+/// Text area styles (expressive)
+/// @access private
+/// @group text-area-expressive
+@mixin text-area-expressive {
+  .#{$prefix}--text-area__invalid-icon {
+    height: 1.25rem;
+    width: 1.25rem;
+  }
+}

--- a/packages/styles/scss/themes/expressive/index.scss
+++ b/packages/styles/scss/themes/expressive/index.scss
@@ -29,6 +29,7 @@
 @import 'components/overflow-menu';
 @import 'components/progressive-indicator';
 @import 'components/tabs';
+@import 'components/text-area';
 @import 'components/text-input';
 @import 'components/tile';
 @import 'components/time-picker';
@@ -69,6 +70,7 @@
     @include overflow-menu-expressive;
     @include progressive-indicator-expressive;
     @include tabs-expressive;
+    @include text-area-expressive;
     @include text-input-expressive;
     @include tile-expressive;
     @include time-picker-expressive;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1358

### Description

Updates text area invalid icon to 20x20 

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
