### PR TITLE
fix(tooltip): fixed tooltip link fontsize

### DIFF
--- a/packages/styles/scss/themes/expressive/components/_file-uploader.scss
+++ b/packages/styles/scss/themes/expressive/components/_file-uploader.scss
@@ -28,4 +28,7 @@
     height: rem(20px);
     width: rem(20px);
   }
+  .#{$prefix}--tooltip .#{$prefix}--link {
+    font-size: 1rem;
+  }
 }

--- a/packages/styles/scss/themes/expressive/components/_file-uploader.scss
+++ b/packages/styles/scss/themes/expressive/components/_file-uploader.scss
@@ -28,7 +28,4 @@
     height: rem(20px);
     width: rem(20px);
   }
-  .#{$prefix}--tooltip .#{$prefix}--link {
-    font-size: 1rem;
-  }
 }

--- a/packages/styles/scss/themes/expressive/components/_tooltip.scss
+++ b/packages/styles/scss/themes/expressive/components/_tooltip.scss
@@ -11,7 +11,7 @@
 // Tooltip (expressive)
 //-----------------------------
 
-/// Tooltip styles (expressive)
+/// Tooltip Styles (expressive)
 /// @access private
 /// @group tooltip-expressive
 @mixin tooltip-expressive {

--- a/packages/styles/scss/themes/expressive/components/_tooltip.scss
+++ b/packages/styles/scss/themes/expressive/components/_tooltip.scss
@@ -30,4 +30,7 @@
       border-width: rem(4px) 0 rem(4px) rem(5.5px);
     }
   }
+  .#{$prefix}--tooltip .#{$prefix}--link {
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1274

### Description

Updated tooltip link to expressive size. 

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
