### PR TITLE
fix(yarn): downgrading yarn to 1.19.0 for install issues

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -6,4 +6,4 @@ version "1.22.4"
 lastUpdateCheck 1586901873240
 yarn-offline-mirror "./.yarn/offline-mirror"
 yarn-offline-mirror-pruning true
-yarn-path ".yarn/releases/yarn-1.22.4.js"
+yarn-path ".yarn/releases/yarn-1.19.0.js"


### PR DESCRIPTION
### Related Ticket(s)

#2134 

### Description

Best workaround at the moment is to downgrade Yarn until this is fixed on the Yarn side. This PR downgrades the repo to 1.19.0.

### Changelog

**Changed**

- Downgrade Yarn to 1.19.0