### PR TITLE
fix(storybook): add grid classes for mobile content block

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -18482,7 +18482,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                   className="bx--row"
                 >
                   <div
-                    className="bx--offset-lg-4"
+                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
                   >
                     <ContentBlock
                       aside={
@@ -18566,7 +18566,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                   className="bx--row"
                 >
                   <div
-                    className="bx--offset-lg-4"
+                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
                   >
                     <ContentBlock
                       aside={

--- a/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
@@ -107,7 +107,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMedia', module)
           <div
             class={
               showAside
-                ? 'bx--offset-lg-4'
+                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4'
                 : 'bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4'
             }>
             <ContentBlockMedia

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
@@ -153,7 +153,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
           <div
             class={
               showAside
-                ? 'bx--offset-lg-4'
+                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4'
                 : 'bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4'
             }>
             <ContentBlockMixed

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -134,7 +134,7 @@ storiesOf('Patterns (Blocks)|ContentBlockSegmented', module)
           <div
             className={
               showAside
-                ? 'bx--offset-lg-4'
+                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4'
                 : 'bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4'
             }>
             <ContentBlockSegmented

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
@@ -120,7 +120,7 @@ storiesOf('Patterns (Blocks)|ContentBlockSimple', module)
           <div
             class={
               showAside
-                ? 'bx--offset-lg-4 content-block-story'
+                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 content-block-story'
                 : 'bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4 content-block-story'
             }>
             <ContentBlockSimple

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
@@ -112,7 +112,7 @@ storiesOf('Patterns (Sub-Patterns)|ContentBlock', module)
     return (
       <div className="bx--grid">
         <div className="bx--row">
-          <div className="bx--offset-lg-4">
+          <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
             <ContentBlock
               heading={blockProps.heading}
               copy={blockProps.copy}

--- a/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
@@ -80,7 +80,7 @@
     @include carbon--breakpoint('lg') {
       .#{$prefix}--link-list {
         padding-top: 0;
-        margin-right: -1rem;
+        margin-right: -$carbon--spacing-05;
       }
     }
   }

--- a/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
@@ -80,6 +80,7 @@
     @include carbon--breakpoint('lg') {
       .#{$prefix}--link-list {
         padding-top: 0;
+        margin-right: -1rem;
       }
     }
   }

--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -36,9 +36,15 @@
       max-width: none;
       &__wrapper {
         min-height: 116px;
+
         .#{$prefix}--card__copy p {
           color: $link-01;
           @include carbon--type-style('body-short-02');
+        }
+
+        @include carbon--breakpoint('sm') {
+          padding-left: $carbon--spacing-07;
+          padding-right: $carbon--spacing-07;
         }
       }
       &:not(:hover) {


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Content Block(with aside elements):- Copy text and linklist section are not getting displayed properly on mobile devices. #2142

### Description

Needed to add grid class for mobile breakpoint for `ContentBlock` and `ContentBlockMedia`, `ContentBlockSegmented`, `ContentBlockSimple`, `ContentBlockMixed`.

Also needed to add left and right padding to the linklist component for mobile breakpoint

NOW:
<img width="482" alt="Screen Shot 2020-04-21 at 10 38 34 AM" src="https://user-images.githubusercontent.com/54281166/79879422-a3000800-83bc-11ea-9527-403959a595ac.png">


### Changelog

**New**

- add small grid class
- added padding to linklist card wrapper
- set `margin-right: -1rem` for linklist in `ContentBlock`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
