### PR TITLE
style(content-section): fixing theme error on storybook

### DIFF
--- a/packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss
+++ b/packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss
@@ -8,23 +8,23 @@
 .#{$prefix}--content-section-story .#{$prefix}--content-section__children {
   height: carbon--mini-units(60);
   padding: $carbon--spacing-05;
-  @include themed-items;
+  @include content-section-themed-items;
 }
 
 .#{$prefix}--content-section--g10 .#{$prefix}--content-section__children {
   @include carbon--theme($carbon--theme--g10) {
-    @include themed-items;
+    @include content-section-themed-items;
   }
 }
 
 .#{$prefix}--content-section--g90 .#{$prefix}--content-section__children {
   @include carbon--theme($carbon--theme--g90) {
-    @include themed-items;
+    @include content-section-themed-items;
   }
 }
 
 .#{$prefix}--content-section--g100 .#{$prefix}--content-section__children {
   @include carbon--theme($carbon--theme--g100) {
-    @include themed-items;
+    @include content-section-themed-items;
   }
 }

--- a/packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss
+++ b/packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss
@@ -1,6 +1,6 @@
 @import '../../../../../../styles/scss/patterns/sub-patterns/content-section/content-section';
 
-@mixin themed-items {
+@mixin content-section-themed-items {
   color: $text-01;
   background: $ui-01;
 }

--- a/packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss
+++ b/packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss
@@ -1,7 +1,30 @@
 @import '../../../../../../styles/scss/patterns/sub-patterns/content-section/content-section';
 
+@mixin themed-items {
+  color: $text-01;
+  background: $ui-01;
+}
+
 .#{$prefix}--content-section-story .#{$prefix}--content-section__children {
   height: carbon--mini-units(60);
-  background-color: #f4f4f4;
   padding: $carbon--spacing-05;
+  @include themed-items;
+}
+
+.#{$prefix}--content-section--g10 .#{$prefix}--content-section__children {
+  @include carbon--theme($carbon--theme--g10) {
+    @include themed-items;
+  }
+}
+
+.#{$prefix}--content-section--g90 .#{$prefix}--content-section__children {
+  @include carbon--theme($carbon--theme--g90) {
+    @include themed-items;
+  }
+}
+
+.#{$prefix}--content-section--g100 .#{$prefix}--content-section__children {
+  @include carbon--theme($carbon--theme--g100) {
+    @include themed-items;
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

[Content Section: Theme issue in Storybook: On applying g100, g90 , g10 text in children section is not visible #1656](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1656)

### Description

The themes were not being applied correctly. This problem seems to related only with the storybook appearance.

### Changelog

**Changed**

- `packages/react/src/patterns/sub-patterns/ContentSection/__stories__/index.scss`