### PR TITLE
Fix/masthead react errors

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -234,7 +234,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                 footerType="default"
                 hasProfile={true}
                 hasSearch={true}
-                navigation="string"
+                navigation="default"
                 platform={null}
               >
                 <div
@@ -629,13 +629,13 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                 footerType="default"
                 hasProfile={true}
                 hasSearch={true}
-                navigation="string"
+                navigation="default"
                 platform={null}
               >
                 <Masthead
                   hasProfile={true}
                   hasSearch={true}
-                  navigation="string"
+                  navigation="default"
                   platform={null}
                 >
                   <HeaderContainer
@@ -5614,7 +5614,7 @@ exports[`Storyshots Components|Masthead Default 1`] = `
               <Masthead
                 hasProfile={true}
                 hasSearch={true}
-                navigation="string"
+                navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
               />
@@ -5648,7 +5648,7 @@ exports[`Storyshots Components|Masthead Default 1`] = `
               <Masthead
                 hasProfile={true}
                 hasSearch={true}
-                navigation="string"
+                navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
               >
@@ -6113,7 +6113,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
               <Masthead
                 hasProfile={true}
                 hasSearch={true}
-                navigation="string"
+                navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
                 searchOpenOnload={true}
@@ -6148,7 +6148,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
               <Masthead
                 hasProfile={true}
                 hasSearch={true}
-                navigation="string"
+                navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
                 searchOpenOnload={true}

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -142,7 +142,7 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
 
   if (navigation) {
     switch (typeof navigation) {
-      case 'string':
+      case 'default':
         // eslint-disable-next-line
         mastheadData = mastheadData;
         break;
@@ -246,7 +246,7 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
  * @type {{mastheadProps: object, navigation: object, hasProfile: boolean, hasSearch: boolean}}
  */
 Masthead.propTypes = {
-  navigation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  navigation: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   hasProfile: PropTypes.bool,
   hasSearch: PropTypes.bool,
   mastheadProps: PropTypes.object,

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -30,7 +30,6 @@ const MastheadL1 = ({ isShort, title, eyebrowText, eyebrowLink }) => {
     [`${prefix}--masthead__l1`]: true,
     [`${prefix}--masthead__l1--short`]: isShort,
   });
-
   return (
     <div className={className}>
       <div className={`${prefix}--masthead__l1-name`}>

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -23,16 +23,6 @@ const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 
 /**
- * Handle <a /> onClick, as javascript:void(0)
- * will no longer be supported in React versions > 16.9
- *
- * @param {*} event Click event
- */
-const linkOnClick = event => {
-  event.preventDefault();
-};
-
-/**
  * Masthead left nav component
  *
  * @typedef {object} navigation Object containing left navigation elements
@@ -54,11 +44,10 @@ const MastheadLeftNav = ({
       return (
         <SideNavMenu title={link.title} key={i}>
           <SideNavMenuItem
-            href
-            onClick={linkOnClick}
+            onClick={event => event.preventDefault()}
             className={`${prefix}--masthead__side-nav--submemu-back`}
             data-autoid={`${stablePrefix}--masthead__l0-sidenav--subnav-back-${i}`}
-            isBackButton
+            isbackbutton="true"
             key={i}>
             <ArrowLeft16 />
             Back

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -23,6 +23,16 @@ const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 
 /**
+ * Handle <a /> onClick, as javascript:void(0)
+ * will no longer be supported in React versions > 16.9
+ *
+ * @param {*} event Click event
+ */
+const linkOnClick = event => {
+  event.preventDefault();
+};
+
+/**
  * Masthead left nav component
  *
  * @typedef {object} navigation Object containing left navigation elements
@@ -44,7 +54,8 @@ const MastheadLeftNav = ({
       return (
         <SideNavMenu title={link.title} key={i}>
           <SideNavMenuItem
-            href="javascript:void(0);"
+            href
+            onClick={linkOnClick}
             className={`${prefix}--masthead__side-nav--submemu-back`}
             data-autoid={`${stablePrefix}--masthead__l0-sidenav--subnav-back-${i}`}
             isBackButton

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -122,13 +122,17 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
   useEffect(() => {
+    const abortController = new AbortController();
     (async () => {
       const response = await LocaleAPI.getLang();
-      if (response) {
+      if (!abortController.signal && response) {
         dispatch({ type: 'setLc', payload: { lc: response.lc } });
         dispatch({ type: 'setCc', payload: { cc: response.cc } });
       }
     })();
+    return () => {
+      abortController.abort();
+    };
   }, []);
 
   /**
@@ -138,7 +142,6 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
    */
   function useSearchVisible() {
     const ref = useRef(null);
-
     /**
      * Close search entirely if autosuggestions collapsed
      *

--- a/packages/react/src/components/Masthead/__stories__/data/Masthead.stories.knobs.js
+++ b/packages/react/src/components/Masthead/__stories__/data/Masthead.stories.knobs.js
@@ -7,7 +7,7 @@ import mastheadLinks from './MastheadLinks.js';
 
 const mastheadKnobs = {
   navigation: {
-    default: 'string',
+    default: 'default',
     custom: mastheadLinks,
     none: null,
   },

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -82,14 +82,6 @@ class HeaderMenu extends React.Component {
   };
 
   /**
-   * Handle <a /> onClick, as javascript:void(0)
-   * will no longer be supported in React versions > 16.9
-   */
-  linkOnClick = event => {
-    event.preventDefault();
-  };
-
-  /**
    * Keyboard event handler for the entire menu.
    */
   handleOnKeyDown = event => {
@@ -189,8 +181,8 @@ class HeaderMenu extends React.Component {
           aria-haspopup="menu" // eslint-disable-line jsx-a11y/aria-proptypes
           aria-expanded={this.state.expanded}
           className={`${prefix}--header__menu-item ${prefix}--header__menu-title`}
-          href
-          onClick={this.linkOnClick}
+          href="#"
+          onClick={event => event.preventDefault()}
           onKeyDown={this.handleOnKeyDown}
           ref={this.handleMenuButtonRef}
           role="menuitem"

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -82,6 +82,14 @@ class HeaderMenu extends React.Component {
   };
 
   /**
+   * Handle <a /> onClick, as javascript:void(0)
+   * will no longer be supported in React versions > 16.9
+   */
+  linkOnClick = event => {
+    event.preventDefault();
+  };
+
+  /**
    * Keyboard event handler for the entire menu.
    */
   handleOnKeyDown = event => {
@@ -181,7 +189,8 @@ class HeaderMenu extends React.Component {
           aria-haspopup="menu" // eslint-disable-line jsx-a11y/aria-proptypes
           aria-expanded={this.state.expanded}
           className={`${prefix}--header__menu-item ${prefix}--header__menu-title`}
-          href="javascript:void(0)"
+          href
+          onClick={this.linkOnClick}
           onKeyDown={this.handleOnKeyDown}
           ref={this.handleMenuButtonRef}
           role="menuitem"

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -66,7 +66,7 @@ export class SideNavMenu extends React.Component {
     /**
      * For submenu back button to toggle expand/collapse
      */
-    isBackButton: PropTypes.bool,
+    isbackbutton: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -117,7 +117,7 @@ export class SideNavMenu extends React.Component {
       isActive,
       title,
       large,
-      isBackButton,
+      isbackbutton,
     } = this.props;
     const { isExpanded } = this.state;
 
@@ -177,7 +177,7 @@ export class SideNavMenu extends React.Component {
     if (item) {
       return React.cloneElement(item, {
         onClick:
-          item.props.isBackButton === true
+          item.props.isbackbutton === 'true'
             ? this.handleToggleExpand.bind(this)
             : null,
       });

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -142,6 +142,7 @@
 
         .#{$prefix}--masthead__side-nav--submemu-back {
           a {
+            cursor: pointer;
             border-bottom: none;
             > .#{$prefix}--side-nav__link-text {
               @include carbon--type-style(body-short-01, true);

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -113,6 +113,7 @@ $search-transition-timing: 95ms;
 
         &:hover {
           background-color: $hover-ui;
+          cursor: pointer;
           > svg {
             fill: $text-01;
           }


### PR DESCRIPTION
### Related Ticket(s)

#2099 

### Description

Fixes various React errors in `Masthead`

### Changelog

**Changed**

- no more `javascript:void(0);` for `href`'s. React no longer allowing for versions > 16.9.0
- updated propType types
- small css changes to `MastheadLeftNav`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
