### PR TITLE
fix(lightbox): display videoplayer and desc copy without distortion

### DIFF
--- a/packages/services/src/services/VideoPlayer/VideoPlayer.js
+++ b/packages/services/src/services/VideoPlayer/VideoPlayer.js
@@ -190,8 +190,8 @@ class VideoPlayerAPI {
    */
   static async api(videoId) {
     return await this.checkScript().then(() => {
-      if (videoData && videoData.id === videoId) {
-        return videoData;
+      if (videoData && videoData[videoId]) {
+        return videoData[videoId];
       } else {
         return new Promise(resolve => {
           return new root.kWidget.api({ wid: _partnerId }).doRequest(
@@ -201,7 +201,7 @@ class VideoPlayerAPI {
               entryId: videoId,
             },
             function(jsonObj) {
-              videoData = jsonObj;
+              videoData[jsonObj.id] = jsonObj;
               resolve(jsonObj);
             }
           );

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -25,12 +25,17 @@
       }
     }
 
+    .#{$prefix}--modal-container .#{$prefix}--modal-content {
+      padding-right: 0;
+    }
+
     .#{$prefix}--video-player {
       width: 100%;
     }
 
     &__container {
       display: flex;
+      width: 100%;
       padding-bottom: 0;
     }
 
@@ -39,34 +44,18 @@
 
       flex-direction: column;
       flex-wrap: nowrap;
+      width: 100%;
 
       @include carbon--breakpoint('lg') {
         flex-direction: row;
-        height: 100%;
       }
     }
     &__media {
-      @include carbon--breakpoint-down('lg') {
-        position: relative;
-        height: 100%;
-      }
-
       img {
         width: auto;
         max-width: 100%;
         height: auto;
         max-height: 100%;
-
-        @include carbon--breakpoint-down('lg') {
-          position: absolute;
-          margin: auto;
-          top: 0;
-          bottom: 0;
-        }
-
-        @include carbon--breakpoint('lg') {
-          height: 100%;
-        }
       }
 
       @include carbon--breakpoint-down('lg') {

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -51,11 +51,23 @@
       }
     }
     &__media {
+      @include carbon--breakpoint-down('lg') {
+        position: relative;
+        height: 100%;
+      }
+
       img {
         width: auto;
         max-width: 100%;
         height: auto;
         max-height: 100%;
+
+        @include carbon--breakpoint-down('lg') {
+          position: absolute;
+          margin: auto;
+          top: 0;
+          bottom: 0;
+        }
       }
 
       @include carbon--breakpoint-down('lg') {
@@ -69,10 +81,6 @@
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
-
-      @include carbon--breakpoint('lg') {
-        height: 100%;
-      }
     }
 
     &__content {


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

If description or title was too short, the video player would shrink

BEFORE: 
<img width="1278" alt="Screen Shot 2020-04-22 at 1 42 38 PM" src="https://user-images.githubusercontent.com/54281166/80015097-3f9ad680-849f-11ea-8d9d-26e5111ebb55.png">

AFTER: videoplayer doesn't shrink even if there is no title or description
<img width="1421" alt="Screen Shot 2020-04-22 at 1 43 04 PM" src="https://user-images.githubusercontent.com/54281166/80015155-55100080-849f-11ea-9f8f-7d1393eef995.png">

### Changelog

**Changed**

- override carbon's `padding-right: 20%` on the `modal-content`

**Removed**

- styles setting media to the top of the modal, media should be vertically centered

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
