### PR TITLE
fix(locale): fix locale scroll on mobile landscape

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -17,6 +17,24 @@
 @mixin locale-modal {
   .#{$prefix}--modal-container {
     background-color: $ui-background;
+
+    @media (max-height: rem(450px)) {
+      .#{$prefix}--locale-modal__filtering {
+        overflow-y: scroll;
+
+        .#{$prefix}--locale-modal__filter {
+          overflow-y: initial;
+
+          .#{$prefix}--locale-modal__list {
+            overflow-y: initial;
+          }
+        }
+      }
+
+      .#{$prefix}--locale-modal__search {
+        position: relative;
+      }
+    }
   }
 
   .#{$prefix}--locale-modal-container .#{$prefix}--modal-container {


### PR DESCRIPTION
### Related Ticket(s)

#1764 

### Description

Adds a vertical breakpoint media query for mobile devices in landscape orientation to allow scrolling of locale list

![Apr-22-2020 17-29-51](https://user-images.githubusercontent.com/909118/80036159-3883c080-84bf-11ea-8af9-645f6739b889.gif)


### Changelog

**New**

- media query for max-height of LocaleModal container

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
