### PR TITLE
fix(storybook): put aside elements in separate story for content block decorators

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -7000,7 +7000,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia Default 1`] = `
                     class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
                   >
                     <ContentBlockMedia
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
@@ -7162,7 +7161,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia Default 1`] = `
                     class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
                   >
                     <ContentBlockMedia
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
@@ -7289,7 +7287,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia Default 1`] = `
                         data-autoid="dds--content-block-media"
                       >
                         <ContentBlock
-                          aside={false}
                           copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
@@ -8386,6 +8383,1902 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia Default 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  class="bx--row"
+                >
+                  <div
+                    class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                  >
+                    <ContentBlockMedia
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                      cta={
+                        Object {
+                          "card": Object {
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                              "icon": Object {
+                                "src": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                },
+                              },
+                            },
+                            "handleClick": [Function],
+                            "heading": "Consectetur adipisicing elit",
+                            "image": Object {
+                              "alt": "Image alt text",
+                              "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                            },
+                            "target": null,
+                            "type": "link",
+                          },
+                          "heading": "Lorem ipsum dolor sit amet",
+                          "style": "feature",
+                          "type": "local",
+                        }
+                      }
+                      heading="Curabitur malesuada varius mi eu posuere"
+                      items={
+                        Array [
+                          Object {
+                            "cta": Object {
+                              "copy": "Lorem ipsum dolor sit ametttt",
+                              "cta": Object {
+                                "href": "https://www.example.com",
+                              },
+                              "style": "card",
+                              "type": "local",
+                            },
+                            "heading": "Lorem ipsum dolor sit amet",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                            ],
+                            "mediaData": Object {
+                              "heading": "Lorem ipsum dolor sit amet.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                            "mediaType": "image",
+                          },
+                          Object {
+                            "cta": Object {
+                              "copy": "Lorem ipsum dolor sit ametttt",
+                              "cta": Object {
+                                "href": "https://www.example.com",
+                              },
+                              "style": "card",
+                              "type": "local",
+                            },
+                            "heading": "Lorem ipsum dolor sit amet",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                            ],
+                            "mediaData": Object {
+                              "heading": "Lorem ipsum dolor sit amet.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                            "mediaType": "image",
+                          },
+                        ]
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  class="bx--row"
+                >
+                  <div
+                    class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                  >
+                    <ContentBlockMedia
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                      cta={
+                        Object {
+                          "card": Object {
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                              "icon": Object {
+                                "src": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                },
+                              },
+                            },
+                            "handleClick": [Function],
+                            "heading": "Consectetur adipisicing elit",
+                            "image": Object {
+                              "alt": "Image alt text",
+                              "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                            },
+                            "target": null,
+                            "type": "link",
+                          },
+                          "heading": "Lorem ipsum dolor sit amet",
+                          "style": "feature",
+                          "type": "local",
+                        }
+                      }
+                      heading="Curabitur malesuada varius mi eu posuere"
+                      items={
+                        Array [
+                          Object {
+                            "cta": Object {
+                              "copy": "Lorem ipsum dolor sit ametttt",
+                              "cta": Object {
+                                "href": "https://www.example.com",
+                              },
+                              "style": "card",
+                              "type": "local",
+                            },
+                            "heading": "Lorem ipsum dolor sit amet",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                            ],
+                            "mediaData": Object {
+                              "heading": "Lorem ipsum dolor sit amet.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                            "mediaType": "image",
+                          },
+                          Object {
+                            "cta": Object {
+                              "copy": "Lorem ipsum dolor sit ametttt",
+                              "cta": Object {
+                                "href": "https://www.example.com",
+                              },
+                              "style": "card",
+                              "type": "local",
+                            },
+                            "heading": "Lorem ipsum dolor sit amet",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                            ],
+                            "mediaData": Object {
+                              "heading": "Lorem ipsum dolor sit amet.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                            "mediaType": "image",
+                          },
+                        ]
+                      }
+                    >
+                      <div
+                        className="bx--content-block-media"
+                        data-autoid="dds--content-block-media"
+                      >
+                        <ContentBlock
+                          aside={
+                            Object {
+                              "border": false,
+                              "items": <LinkList
+                                heading="Tutorials"
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Containerization A Complete Guide",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "Why should you use microservices and containers",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ]
+                                }
+                              />,
+                            }
+                          }
+                          copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                          cta={
+                            Object {
+                              "card": Object {
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                  "icon": Object {
+                                    "src": Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "render": [Function],
+                                    },
+                                  },
+                                },
+                                "handleClick": [Function],
+                                "heading": "Consectetur adipisicing elit",
+                                "image": Object {
+                                  "alt": "Image alt text",
+                                  "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                                },
+                                "target": null,
+                                "type": "link",
+                              },
+                              "heading": "Lorem ipsum dolor sit amet",
+                              "style": "feature",
+                              "type": "local",
+                            }
+                          }
+                          heading="Curabitur malesuada varius mi eu posuere"
+                        >
+                          <div
+                            className="bx--content-block"
+                            data-autoid="dds--content-block"
+                          >
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <h2
+                                      className="bx--content-block__heading"
+                                      data-autoid="dds--content-block__heading"
+                                    >
+                                      Curabitur malesuada varius mi eu posuere
+                                    </h2>
+                                  </div>
+                                  <div
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  />
+                                </div>
+                              </section>
+                            </Layout>
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <div
+                                      className="bx--content-block__copy"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                        }
+                                      }
+                                    />
+                                    <div
+                                      className="bx--content-block__children"
+                                      data-autoid="dds--content-block__children"
+                                    >
+                                      <ContentGroupSimple
+                                        cta={
+                                          Object {
+                                            "copy": "Lorem ipsum dolor sit ametttt",
+                                            "cta": Object {
+                                              "href": "https://www.example.com",
+                                            },
+                                            "style": "card",
+                                            "type": "local",
+                                          }
+                                        }
+                                        heading="Lorem ipsum dolor sit amet"
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                              "heading": "Lorem ipsum dolor sit amet.",
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                              "heading": "Lorem ipsum dolor sit amet.",
+                                            },
+                                          ]
+                                        }
+                                        key="0"
+                                        mediaData={
+                                          Object {
+                                            "heading": "Lorem ipsum dolor sit amet.",
+                                            "image": Object {
+                                              "alt": "Image alt text",
+                                              "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                              "sources": Array [
+                                                Object {
+                                                  "breakpoint": 320,
+                                                  "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 400,
+                                                  "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 672,
+                                                  "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                },
+                                              ],
+                                            },
+                                          }
+                                        }
+                                        mediaType="image"
+                                      >
+                                        <div
+                                          className="bx--content-group-simple"
+                                          data-autoid="dds--content-group-simple"
+                                        >
+                                          <ContentGroup
+                                            cta={
+                                              Object {
+                                                "copy": "Lorem ipsum dolor sit ametttt",
+                                                "cta": Object {
+                                                  "href": "https://www.example.com",
+                                                },
+                                                "style": "card",
+                                                "type": "local",
+                                              }
+                                            }
+                                            heading="Lorem ipsum dolor sit amet"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                Lorem ipsum dolor sit amet
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-group-simple__media"
+                                                >
+                                                  <ImageWithCaption
+                                                    heading="Lorem ipsum dolor sit amet."
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                        "sources": Array [
+                                                          Object {
+                                                            "breakpoint": 320,
+                                                            "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 400,
+                                                            "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 672,
+                                                            "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                          },
+                                                        ],
+                                                      }
+                                                    }
+                                                  >
+                                                    <div
+                                                      className="bx--image-with-caption"
+                                                      data-autoid="dds--image-with-caption"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        sources={
+                                                          Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <picture
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <source
+                                                            key="0"
+                                                            media="(min-width: 672px )"
+                                                            srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          />
+                                                          <source
+                                                            key="1"
+                                                            media="(min-width: 400px )"
+                                                            srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                          />
+                                                          <source
+                                                            key="2"
+                                                            media="(min-width: 320px )"
+                                                            srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                          />
+                                                          <img
+                                                            alt="Image alt text"
+                                                            aria-describedby=""
+                                                            className="bx--image__img"
+                                                            src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          />
+                                                        </picture>
+                                                      </Image>
+                                                      <p
+                                                        className="bx--image__caption"
+                                                        data-autoid="dds--image__caption"
+                                                      >
+                                                        Lorem ipsum dolor sit amet.
+                                                      </p>
+                                                    </div>
+                                                  </ImageWithCaption>
+                                                </div>
+                                                <ContentItem
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                  heading="Lorem ipsum dolor sit amet."
+                                                  key="0"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <h4
+                                                      className="bx--content-item__heading"
+                                                      data-autoid="dds--content-item__heading"
+                                                    >
+                                                      Lorem ipsum dolor sit amet.
+                                                    </h4>
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                                <ContentItem
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                  heading="Lorem ipsum dolor sit amet."
+                                                  key="1"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <h4
+                                                      className="bx--content-item__heading"
+                                                      data-autoid="dds--content-item__heading"
+                                                    >
+                                                      Lorem ipsum dolor sit amet.
+                                                    </h4>
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                              <div
+                                                className="bx--content-group__cta-row"
+                                                data-autoid="dds--content-group__cta}"
+                                              >
+                                                <CTA
+                                                  copy="Lorem ipsum dolor sit ametttt"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://www.example.com",
+                                                    }
+                                                  }
+                                                  customClassName="bx--content-group__cta"
+                                                  style="card"
+                                                  type="local"
+                                                >
+                                                  <div
+                                                    className="bx--content-group__cta"
+                                                  >
+                                                    <CardCTA
+                                                      copy="Lorem ipsum dolor sit ametttt"
+                                                      cta={
+                                                        Object {
+                                                          "href": "https://www.example.com",
+                                                        }
+                                                      }
+                                                      external={[Function]}
+                                                      iconSelector={[Function]}
+                                                      jump={[Function]}
+                                                      launchLightBox={[Function]}
+                                                      mediaData={Object {}}
+                                                      openLightBox={[Function]}
+                                                      renderLightBox={false}
+                                                      setLightBox={[Function]}
+                                                      setMediaData={[Function]}
+                                                      style="card"
+                                                      type="local"
+                                                      videoTitle={
+                                                        Array [
+                                                          Object {
+                                                            "key": 0,
+                                                            "title": "",
+                                                          },
+                                                        ]
+                                                      }
+                                                    >
+                                                      <Card
+                                                        copy="Lorem ipsum dolor sit ametttt"
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        customClassName="bx--card__CTA"
+                                                        handleClick={[Function]}
+                                                        role="region"
+                                                        target={null}
+                                                        type="link"
+                                                      >
+                                                        <ClickableTile
+                                                          className="bx--card bx--card--link bx--card__CTA"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                          role="region"
+                                                          target={null}
+                                                        >
+                                                          <a
+                                                            className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="region"
+                                                            target={null}
+                                                          >
+                                                            <Image
+                                                              classname="bx--card__img"
+                                                            />
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      style={
+                                                                        Object {
+                                                                          "willChange": "transform",
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </CardCTA>
+                                                  </div>
+                                                </CTA>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </div>
+                                      </ContentGroupSimple>
+                                      <ContentGroupSimple
+                                        cta={
+                                          Object {
+                                            "copy": "Lorem ipsum dolor sit ametttt",
+                                            "cta": Object {
+                                              "href": "https://www.example.com",
+                                            },
+                                            "style": "card",
+                                            "type": "local",
+                                          }
+                                        }
+                                        heading="Lorem ipsum dolor sit amet"
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                              "heading": "Lorem ipsum dolor sit amet.",
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                              "heading": "Lorem ipsum dolor sit amet.",
+                                            },
+                                          ]
+                                        }
+                                        key="1"
+                                        mediaData={
+                                          Object {
+                                            "heading": "Lorem ipsum dolor sit amet.",
+                                            "image": Object {
+                                              "alt": "Image alt text",
+                                              "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                              "sources": Array [
+                                                Object {
+                                                  "breakpoint": 320,
+                                                  "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 400,
+                                                  "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 672,
+                                                  "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                },
+                                              ],
+                                            },
+                                          }
+                                        }
+                                        mediaType="image"
+                                      >
+                                        <div
+                                          className="bx--content-group-simple"
+                                          data-autoid="dds--content-group-simple"
+                                        >
+                                          <ContentGroup
+                                            cta={
+                                              Object {
+                                                "copy": "Lorem ipsum dolor sit ametttt",
+                                                "cta": Object {
+                                                  "href": "https://www.example.com",
+                                                },
+                                                "style": "card",
+                                                "type": "local",
+                                              }
+                                            }
+                                            heading="Lorem ipsum dolor sit amet"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                Lorem ipsum dolor sit amet
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-group-simple__media"
+                                                >
+                                                  <ImageWithCaption
+                                                    heading="Lorem ipsum dolor sit amet."
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                        "sources": Array [
+                                                          Object {
+                                                            "breakpoint": 320,
+                                                            "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 400,
+                                                            "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 672,
+                                                            "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                          },
+                                                        ],
+                                                      }
+                                                    }
+                                                  >
+                                                    <div
+                                                      className="bx--image-with-caption"
+                                                      data-autoid="dds--image-with-caption"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        sources={
+                                                          Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <picture
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <source
+                                                            key="0"
+                                                            media="(min-width: 672px )"
+                                                            srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          />
+                                                          <source
+                                                            key="1"
+                                                            media="(min-width: 400px )"
+                                                            srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                          />
+                                                          <source
+                                                            key="2"
+                                                            media="(min-width: 320px )"
+                                                            srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                          />
+                                                          <img
+                                                            alt="Image alt text"
+                                                            aria-describedby=""
+                                                            className="bx--image__img"
+                                                            src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          />
+                                                        </picture>
+                                                      </Image>
+                                                      <p
+                                                        className="bx--image__caption"
+                                                        data-autoid="dds--image__caption"
+                                                      >
+                                                        Lorem ipsum dolor sit amet.
+                                                      </p>
+                                                    </div>
+                                                  </ImageWithCaption>
+                                                </div>
+                                                <ContentItem
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                  heading="Lorem ipsum dolor sit amet."
+                                                  key="0"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <h4
+                                                      className="bx--content-item__heading"
+                                                      data-autoid="dds--content-item__heading"
+                                                    >
+                                                      Lorem ipsum dolor sit amet.
+                                                    </h4>
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                                <ContentItem
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                  heading="Lorem ipsum dolor sit amet."
+                                                  key="1"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <h4
+                                                      className="bx--content-item__heading"
+                                                      data-autoid="dds--content-item__heading"
+                                                    >
+                                                      Lorem ipsum dolor sit amet.
+                                                    </h4>
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                              <div
+                                                className="bx--content-group__cta-row"
+                                                data-autoid="dds--content-group__cta}"
+                                              >
+                                                <CTA
+                                                  copy="Lorem ipsum dolor sit ametttt"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://www.example.com",
+                                                    }
+                                                  }
+                                                  customClassName="bx--content-group__cta"
+                                                  style="card"
+                                                  type="local"
+                                                >
+                                                  <div
+                                                    className="bx--content-group__cta"
+                                                  >
+                                                    <CardCTA
+                                                      copy="Lorem ipsum dolor sit ametttt"
+                                                      cta={
+                                                        Object {
+                                                          "href": "https://www.example.com",
+                                                        }
+                                                      }
+                                                      external={[Function]}
+                                                      iconSelector={[Function]}
+                                                      jump={[Function]}
+                                                      launchLightBox={[Function]}
+                                                      mediaData={Object {}}
+                                                      openLightBox={[Function]}
+                                                      renderLightBox={false}
+                                                      setLightBox={[Function]}
+                                                      setMediaData={[Function]}
+                                                      style="card"
+                                                      type="local"
+                                                      videoTitle={
+                                                        Array [
+                                                          Object {
+                                                            "key": 0,
+                                                            "title": "",
+                                                          },
+                                                        ]
+                                                      }
+                                                    >
+                                                      <Card
+                                                        copy="Lorem ipsum dolor sit ametttt"
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        customClassName="bx--card__CTA"
+                                                        handleClick={[Function]}
+                                                        role="region"
+                                                        target={null}
+                                                        type="link"
+                                                      >
+                                                        <ClickableTile
+                                                          className="bx--card bx--card--link bx--card__CTA"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                          role="region"
+                                                          target={null}
+                                                        >
+                                                          <a
+                                                            className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="region"
+                                                            target={null}
+                                                          >
+                                                            <Image
+                                                              classname="bx--card__img"
+                                                            />
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      style={
+                                                                        Object {
+                                                                          "willChange": "transform",
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </CardCTA>
+                                                  </div>
+                                                </CTA>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </div>
+                                      </ContentGroupSimple>
+                                    </div>
+                                    <CTA
+                                      card={
+                                        Object {
+                                          "cta": Object {
+                                            "href": "https://www.example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          },
+                                          "handleClick": [Function],
+                                          "heading": "Consectetur adipisicing elit",
+                                          "image": Object {
+                                            "alt": "Image alt text",
+                                            "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                                          },
+                                          "target": null,
+                                          "type": "link",
+                                        }
+                                      }
+                                      customClassName="bx--content-block__cta"
+                                      heading="Lorem ipsum dolor sit amet"
+                                      style="feature"
+                                      type="local"
+                                    >
+                                      <div
+                                        className="bx--content-block__cta"
+                                      >
+                                        <FeatureCTA
+                                          card={
+                                            Object {
+                                              "cta": Object {
+                                                "href": "https://www.example.com",
+                                                "icon": Object {
+                                                  "src": Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  },
+                                                },
+                                              },
+                                              "handleClick": [Function],
+                                              "heading": "Consectetur adipisicing elit",
+                                              "image": Object {
+                                                "alt": "Image alt text",
+                                                "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                                              },
+                                              "target": null,
+                                              "type": "link",
+                                            }
+                                          }
+                                          external={[Function]}
+                                          heading="Lorem ipsum dolor sit amet"
+                                          iconSelector={[Function]}
+                                          jump={[Function]}
+                                          launchLightBox={[Function]}
+                                          mediaData={Object {}}
+                                          openLightBox={[Function]}
+                                          renderLightBox={false}
+                                          setLightBox={[Function]}
+                                          setMediaData={[Function]}
+                                          style="feature"
+                                          type="local"
+                                          videoTitle={
+                                            Array [
+                                              Object {
+                                                "key": 0,
+                                                "title": "",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <FeatureCard
+                                            card={
+                                              Object {
+                                                "cta": Object {
+                                                  "href": "https://www.example.com",
+                                                  "icon": Object {
+                                                    "src": Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    },
+                                                  },
+                                                },
+                                                "handleClick": [Function],
+                                                "heading": "Consectetur adipisicing elit",
+                                                "image": Object {
+                                                  "alt": "Image alt text",
+                                                  "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                                                },
+                                                "target": null,
+                                                "type": "link",
+                                              }
+                                            }
+                                            heading="Lorem ipsum dolor sit amet"
+                                          >
+                                            <section
+                                              className="bx--feature-card"
+                                              data-autoid="dds--feature-card"
+                                            >
+                                              <ContentGroup
+                                                heading="Lorem ipsum dolor sit amet"
+                                              >
+                                                <div
+                                                  className="bx--content-group"
+                                                  data-autoid="dds--content-group"
+                                                >
+                                                  <h3
+                                                    className="bx--content-group__title"
+                                                    data-autoid="dds--content-group__title"
+                                                  >
+                                                    Lorem ipsum dolor sit amet
+                                                  </h3>
+                                                  <div
+                                                    className="bx--content-group__col bx--content-group__children"
+                                                    data-autoid="dds--content-group__children"
+                                                  >
+                                                    <Card
+                                                      cta={
+                                                        Object {
+                                                          "href": "https://www.example.com",
+                                                          "icon": Object {
+                                                            "src": Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            },
+                                                          },
+                                                        }
+                                                      }
+                                                      customClassName="bx--feature-card__card"
+                                                      heading="Consectetur adipisicing elit"
+                                                      image={
+                                                        Object {
+                                                          "alt": "Image alt text",
+                                                          "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
+                                                        }
+                                                      }
+                                                      inverse={true}
+                                                      target={null}
+                                                      type="link"
+                                                    >
+                                                      <ClickableTile
+                                                        className="bx--card bx--card--inverse bx--card--link bx--feature-card__card"
+                                                        clicked={false}
+                                                        data-autoid="dds--card"
+                                                        handleClick={[Function]}
+                                                        handleKeyDown={[Function]}
+                                                        href="https://www.example.com"
+                                                        light={false}
+                                                        target={null}
+                                                      >
+                                                        <a
+                                                          className="bx--link bx--tile bx--tile--clickable bx--card bx--card--inverse bx--card--link bx--feature-card__card"
+                                                          data-autoid="dds--card"
+                                                          href="https://www.example.com"
+                                                          onClick={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          target={null}
+                                                        >
+                                                          <Image
+                                                            alt="Image alt text"
+                                                            classname="bx--card__img"
+                                                            defaultSrc="https://dummyimage.com/672x672/ee5396/161616&text=1x1"
+                                                          >
+                                                            <picture
+                                                              className="bx--image"
+                                                              data-autoid="dds--image__longdescription-"
+                                                            >
+                                                              <img
+                                                                alt="Image alt text"
+                                                                aria-describedby=""
+                                                                className="bx--image__img bx--card__img"
+                                                                src="https://dummyimage.com/672x672/ee5396/161616&text=1x1"
+                                                              />
+                                                            </picture>
+                                                          </Image>
+                                                          <div
+                                                            className="bx--card__wrapper"
+                                                          >
+                                                            <h3
+                                                              className="bx--card__heading"
+                                                            >
+                                                              Consectetur adipisicing elit
+                                                            </h3>
+                                                            <div
+                                                              className="bx--card__footer"
+                                                            >
+                                                              <ForwardRef(ArrowRight20)
+                                                                className="bx--card__cta"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                              >
+                                                                <Icon
+                                                                  className="bx--card__cta"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--card__cta"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    style={
+                                                                      Object {
+                                                                        "willChange": "transform",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowRight20)>
+                                                            </div>
+                                                          </div>
+                                                        </a>
+                                                      </ClickableTile>
+                                                    </Card>
+                                                  </div>
+                                                </div>
+                                              </ContentGroup>
+                                            </section>
+                                          </FeatureCard>
+                                        </FeatureCTA>
+                                      </div>
+                                    </CTA>
+                                  </div>
+                                  <aside
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  >
+                                    <LinkList
+                                      heading="Tutorials"
+                                      items={
+                                        Array [
+                                          Object {
+                                            "copy": "Containerization A Complete Guide",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "local",
+                                          },
+                                          Object {
+                                            "copy": "Why should you use microservices and containers",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "external",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <div
+                                        className="bx--link-list"
+                                        data-autoid="dds--link-list"
+                                      >
+                                        <h4
+                                          className="bx--link-list__heading"
+                                        >
+                                          Tutorials
+                                        </h4>
+                                        <ul
+                                          className="bx--link-list__list"
+                                        >
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="0"
+                                          >
+                                            <CTA
+                                              copy="Containerization A Complete Guide"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="local"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Containerization A Complete Guide"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="local"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Containerization A Complete Guide"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target={null}
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target={null}
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target={null}
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Containerization A Complete Guide</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(ArrowRight20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="1"
+                                          >
+                                            <CTA
+                                              copy="Why should you use microservices and containers"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="external"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Why should you use microservices and containers"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="external"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Why should you use microservices and containers"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target="_blank"
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target="_blank"
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target="_blank"
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Why should you use microservices and containers</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(Launch20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                  />
+                                                                  <path
+                                                                    d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(Launch20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                        </ul>
+                                      </div>
+                                    </LinkList>
+                                  </aside>
+                                </div>
+                              </section>
+                            </Layout>
+                          </div>
+                        </ContentBlock>
+                      </div>
+                    </ContentBlockMedia>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
 <Container
   story={[Function]}
@@ -8415,7 +10308,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                     class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
                   >
                     <ContentBlockMixed
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
@@ -8600,7 +10492,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                     class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
                   >
                     <ContentBlockMixed
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
@@ -8750,7 +10641,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                         data-autoid="dds--content-block-mixed"
                       >
                         <ContentBlock
-                          aside={false}
                           copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
@@ -10437,6 +12327,2538 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  class="bx--row"
+                >
+                  <div
+                    class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                  >
+                    <ContentBlockMixed
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                      cta={
+                        Object {
+                          "copy": "Lorem ipsum dolor sit ametttt",
+                          "cta": Object {
+                            "href": "https://www.ibm.com",
+                          },
+                          "heading": "Lorem ipsum dolor sit amet",
+                          "style": "card",
+                          "type": "local",
+                        }
+                      }
+                      heading="Lorem ipsum dolor sit amet"
+                      items={
+                        Array [
+                          Object {
+                            "heading": "Lorem ipsum dolor sit amet.",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                              },
+                            ],
+                            "type": "ContentGroupCards",
+                          },
+                          Object {
+                            "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                "cta": Object {
+                                  "copy": "Lorem ipsum dolor",
+                                  "href": "https://www.ibm.com",
+                                  "type": "local",
+                                },
+                                "heading": "Aliquam condimentum interdum",
+                                "pictogram": Object {
+                                  "aria-label": "Desktop",
+                                  "src": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                },
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                "cta": Object {
+                                  "copy": "Lorem ipsum dolor",
+                                  "href": "https://www.ibm.com",
+                                  "type": "local",
+                                },
+                                "heading": "Aliquam condimentum interdum",
+                                "pictogram": Object {
+                                  "aria-label": "Pattern",
+                                  "src": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                },
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                "cta": Object {
+                                  "copy": "Lorem ipsum dolor",
+                                  "href": "https://www.ibm.com",
+                                  "type": "local",
+                                },
+                                "heading": "Aliquam condimentum interdum",
+                                "pictogram": Object {
+                                  "aria-label": "Touch",
+                                  "src": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                },
+                              },
+                            ],
+                            "type": "ContentGroupPictograms",
+                          },
+                          Object {
+                            "heading": "Lorem ipsum dolor sit amet",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                            ],
+                            "mediaData": Object {
+                              "heading": "Lorem ipsum dolor sit amet.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                            "mediaType": "image",
+                            "type": "ContentGroupSimple",
+                          },
+                        ]
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  class="bx--row"
+                >
+                  <div
+                    class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                  >
+                    <ContentBlockMixed
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                      cta={
+                        Object {
+                          "copy": "Lorem ipsum dolor sit ametttt",
+                          "cta": Object {
+                            "href": "https://www.ibm.com",
+                          },
+                          "heading": "Lorem ipsum dolor sit amet",
+                          "style": "card",
+                          "type": "local",
+                        }
+                      }
+                      heading="Lorem ipsum dolor sit amet"
+                      items={
+                        Array [
+                          Object {
+                            "heading": "Lorem ipsum dolor sit amet.",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                                "cta": Object {
+                                  "href": "https://www.example.com",
+                                },
+                                "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                              },
+                            ],
+                            "type": "ContentGroupCards",
+                          },
+                          Object {
+                            "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                "cta": Object {
+                                  "copy": "Lorem ipsum dolor",
+                                  "href": "https://www.ibm.com",
+                                  "type": "local",
+                                },
+                                "heading": "Aliquam condimentum interdum",
+                                "pictogram": Object {
+                                  "aria-label": "Desktop",
+                                  "src": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                },
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                "cta": Object {
+                                  "copy": "Lorem ipsum dolor",
+                                  "href": "https://www.ibm.com",
+                                  "type": "local",
+                                },
+                                "heading": "Aliquam condimentum interdum",
+                                "pictogram": Object {
+                                  "aria-label": "Pattern",
+                                  "src": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                },
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                "cta": Object {
+                                  "copy": "Lorem ipsum dolor",
+                                  "href": "https://www.ibm.com",
+                                  "type": "local",
+                                },
+                                "heading": "Aliquam condimentum interdum",
+                                "pictogram": Object {
+                                  "aria-label": "Touch",
+                                  "src": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                },
+                              },
+                            ],
+                            "type": "ContentGroupPictograms",
+                          },
+                          Object {
+                            "heading": "Lorem ipsum dolor sit amet",
+                            "items": Array [
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                              Object {
+                                "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                "heading": "Lorem ipsum dolor sit amet.",
+                              },
+                            ],
+                            "mediaData": Object {
+                              "heading": "Lorem ipsum dolor sit amet.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                            "mediaType": "image",
+                            "type": "ContentGroupSimple",
+                          },
+                        ]
+                      }
+                    >
+                      <div
+                        className="bx--content-block-mixed"
+                        data-autoid="dds--content-block-mixed"
+                      >
+                        <ContentBlock
+                          aside={
+                            Object {
+                              "border": false,
+                              "items": <LinkList
+                                heading="Tutorials"
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Containerization A Complete Guide",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "Why should you use microservices and containers",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ]
+                                }
+                              />,
+                            }
+                          }
+                          copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                          cta={
+                            Object {
+                              "copy": "Lorem ipsum dolor sit ametttt",
+                              "cta": Object {
+                                "href": "https://www.ibm.com",
+                              },
+                              "heading": "Lorem ipsum dolor sit amet",
+                              "style": "card",
+                              "type": "local",
+                            }
+                          }
+                          heading="Lorem ipsum dolor sit amet"
+                        >
+                          <div
+                            className="bx--content-block"
+                            data-autoid="dds--content-block"
+                          >
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <h2
+                                      className="bx--content-block__heading"
+                                      data-autoid="dds--content-block__heading"
+                                    >
+                                      Lorem ipsum dolor sit amet
+                                    </h2>
+                                  </div>
+                                  <div
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  />
+                                </div>
+                              </section>
+                            </Layout>
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <div
+                                      className="bx--content-block__copy"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                        }
+                                      }
+                                    />
+                                    <div
+                                      className="bx--content-block__children"
+                                      data-autoid="dds--content-block__children"
+                                    >
+                                      <ContentGroupCards
+                                        heading="Lorem ipsum dolor sit amet."
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                                              "cta": Object {
+                                                "href": "https://www.example.com",
+                                              },
+                                              "heading": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt",
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                                              "cta": Object {
+                                                "href": "https://www.example.com",
+                                              },
+                                              "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet",
+                                              "cta": Object {
+                                                "href": "https://www.example.com",
+                                              },
+                                              "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt",
+                                              "cta": Object {
+                                                "href": "https://www.example.com",
+                                              },
+                                              "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                                            },
+                                          ]
+                                        }
+                                        key="0"
+                                        type="ContentGroupCards"
+                                      >
+                                        <section
+                                          className="bx--content-group-cards"
+                                          data-autoid="dds--content-group-cards"
+                                        >
+                                          <ContentGroup
+                                            heading="Lorem ipsum dolor sit amet."
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                Lorem ipsum dolor sit amet.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  className="bx--content-group-cards-group bx--grid--condensed"
+                                                  data-autoid="dds--content-group-cards-group"
+                                                >
+                                                  <div
+                                                    className="bx--content-group-cards__row"
+                                                  >
+                                                    <div
+                                                      className="bx--content-group-cards-item__col"
+                                                      data-autoid="dds--content-group-cards-item"
+                                                      key="0"
+                                                      role="region"
+                                                    >
+                                                      <Card
+                                                        aria-label="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt"
+                                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        customClassName="bx--content-group-cards-item"
+                                                        heading="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt"
+                                                        type="link"
+                                                      >
+                                                        <ClickableTile
+                                                          aria-label="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt"
+                                                          className="bx--card bx--card--link bx--content-group-cards-item"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                        >
+                                                          <a
+                                                            aria-label="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt"
+                                                            className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--content-group-cards-item"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                          >
+                                                            <Image
+                                                              classname="bx--card__img"
+                                                            />
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <h3
+                                                                className="bx--card__heading"
+                                                              >
+                                                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+                                                              </h3>
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      style={
+                                                                        Object {
+                                                                          "willChange": "transform",
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </div>
+                                                    <div
+                                                      className="bx--content-group-cards-item__col"
+                                                      data-autoid="dds--content-group-cards-item"
+                                                      key="1"
+                                                      role="region"
+                                                    >
+                                                      <Card
+                                                        aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        customClassName="bx--content-group-cards-item"
+                                                        heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        type="link"
+                                                      >
+                                                        <ClickableTile
+                                                          aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                          className="bx--card bx--card--link bx--content-group-cards-item"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                        >
+                                                          <a
+                                                            aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                            className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--content-group-cards-item"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                          >
+                                                            <Image
+                                                              classname="bx--card__img"
+                                                            />
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <h3
+                                                                className="bx--card__heading"
+                                                              >
+                                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                                                              </h3>
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      style={
+                                                                        Object {
+                                                                          "willChange": "transform",
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </div>
+                                                    <div
+                                                      className="bx--content-group-cards-item__col"
+                                                      data-autoid="dds--content-group-cards-item"
+                                                      key="2"
+                                                      role="region"
+                                                    >
+                                                      <Card
+                                                        aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        copy="Lorem ipsum dolor sit amet"
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        customClassName="bx--content-group-cards-item"
+                                                        heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        type="link"
+                                                      >
+                                                        <ClickableTile
+                                                          aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                          className="bx--card bx--card--link bx--content-group-cards-item"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                        >
+                                                          <a
+                                                            aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                            className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--content-group-cards-item"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                          >
+                                                            <Image
+                                                              classname="bx--card__img"
+                                                            />
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <h3
+                                                                className="bx--card__heading"
+                                                              >
+                                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                                                              </h3>
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Lorem ipsum dolor sit amet</p>",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      style={
+                                                                        Object {
+                                                                          "willChange": "transform",
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </div>
+                                                    <div
+                                                      className="bx--content-group-cards-item__col"
+                                                      data-autoid="dds--content-group-cards-item"
+                                                      key="3"
+                                                      role="region"
+                                                    >
+                                                      <Card
+                                                        aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        customClassName="bx--content-group-cards-item"
+                                                        heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                        type="link"
+                                                      >
+                                                        <ClickableTile
+                                                          aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                          className="bx--card bx--card--link bx--content-group-cards-item"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                        >
+                                                          <a
+                                                            aria-label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+                                                            className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--content-group-cards-item"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                          >
+                                                            <Image
+                                                              classname="bx--card__img"
+                                                            />
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <h3
+                                                                className="bx--card__heading"
+                                                              >
+                                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit
+                                                              </h3>
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      style={
+                                                                        Object {
+                                                                          "willChange": "transform",
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </section>
+                                      </ContentGroupCards>
+                                      <ContentGroupPictograms
+                                        heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                              "cta": Object {
+                                                "copy": "Lorem ipsum dolor",
+                                                "href": "https://www.ibm.com",
+                                                "type": "local",
+                                              },
+                                              "heading": "Aliquam condimentum interdum",
+                                              "pictogram": Object {
+                                                "aria-label": "Desktop",
+                                                "src": Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                },
+                                              },
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                              "cta": Object {
+                                                "copy": "Lorem ipsum dolor",
+                                                "href": "https://www.ibm.com",
+                                                "type": "local",
+                                              },
+                                              "heading": "Aliquam condimentum interdum",
+                                              "pictogram": Object {
+                                                "aria-label": "Pattern",
+                                                "src": Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                },
+                                              },
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                              "cta": Object {
+                                                "copy": "Lorem ipsum dolor",
+                                                "href": "https://www.ibm.com",
+                                                "type": "local",
+                                              },
+                                              "heading": "Aliquam condimentum interdum",
+                                              "pictogram": Object {
+                                                "aria-label": "Touch",
+                                                "src": Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                },
+                                              },
+                                            },
+                                          ]
+                                        }
+                                        key="1"
+                                        type="ContentGroupPictograms"
+                                      >
+                                        <div
+                                          className="bx--content-group-pictograms"
+                                          data-autoid="dds--content-group-pictograms"
+                                        >
+                                          <ContentGroup
+                                            heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <PictogramItem
+                                                  className="bx--content-group-pictograms__item"
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                                  cta={
+                                                    Object {
+                                                      "copy": "Lorem ipsum dolor",
+                                                      "href": "https://www.ibm.com",
+                                                      "type": "local",
+                                                    }
+                                                  }
+                                                  data-autoid="bx--content-group-pictograms__item"
+                                                  heading="Aliquam condimentum interdum"
+                                                  key="0"
+                                                  pictogram={
+                                                    Object {
+                                                      "aria-label": "Desktop",
+                                                      "src": Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      },
+                                                    }
+                                                  }
+                                                >
+                                                  <div
+                                                    className="bx--content-group-pictograms__item bx--pictogram-item"
+                                                  >
+                                                    <div
+                                                      className="bx--pictogram-item__row"
+                                                    >
+                                                      <div
+                                                        className="bx--pictogram-item__wrapper"
+                                                      >
+                                                        <ForwardRef(Desktop)
+                                                          aria-label="Desktop"
+                                                          className="bx--pictogram-item__pictogram"
+                                                          data-autoid="dds--pictogram-item__pictogram"
+                                                        >
+                                                          <Icon
+                                                            aria-label="Desktop"
+                                                            className="bx--pictogram-item__pictogram"
+                                                            data-autoid="dds--pictogram-item__pictogram"
+                                                            height={48}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 48 48"
+                                                            width={48}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-label="Desktop"
+                                                              className="bx--pictogram-item__pictogram"
+                                                              data-autoid="dds--pictogram-item__pictogram"
+                                                              focusable="false"
+                                                              height={48}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              role="img"
+                                                              style={
+                                                                Object {
+                                                                  "willChange": "transform",
+                                                                }
+                                                              }
+                                                              viewBox="0 0 48 48"
+                                                              width={48}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
+                                                                fill="none"
+                                                                stroke="#000"
+                                                                strokeLinejoin="round"
+                                                                strokeMiterlimit="10"
+                                                                strokeWidth=".72"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(Desktop)>
+                                                      </div>
+                                                      <div
+                                                        className="bx--pictogram-item__content"
+                                                        data-autoid="dds--pictogram-item__content"
+                                                      >
+                                                        <ContentItem
+                                                          copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                                          cta={
+                                                            Object {
+                                                              "copy": "Lorem ipsum dolor",
+                                                              "href": "https://www.ibm.com",
+                                                              "style": "text",
+                                                              "type": "local",
+                                                            }
+                                                          }
+                                                          heading="Aliquam condimentum interdum"
+                                                        >
+                                                          <div
+                                                            className="bx--content-item"
+                                                            data-autoid="dds--content-item"
+                                                          >
+                                                            <h4
+                                                              className="bx--content-item__heading"
+                                                              data-autoid="dds--content-item__heading"
+                                                            >
+                                                              Aliquam condimentum interdum
+                                                            </h4>
+                                                            <div
+                                                              className="bx--content-item__copy"
+                                                              dangerouslySetInnerHTML={
+                                                                Object {
+                                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                                }
+                                                              }
+                                                              data-autoid="dds--content-item__copy"
+                                                            />
+                                                            <CTA
+                                                              copy="Lorem ipsum dolor"
+                                                              customClassName="bx--content-item__cta"
+                                                              href="https://www.ibm.com"
+                                                              style="text"
+                                                              type="local"
+                                                            >
+                                                              <div
+                                                                className="bx--content-item__cta"
+                                                              >
+                                                                <TextCTA
+                                                                  copy="Lorem ipsum dolor"
+                                                                  external={[Function]}
+                                                                  href="https://www.ibm.com"
+                                                                  iconSelector={[Function]}
+                                                                  jump={[Function]}
+                                                                  launchLightBox={[Function]}
+                                                                  mediaData={Object {}}
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  setLightBox={[Function]}
+                                                                  setMediaData={[Function]}
+                                                                  style="text"
+                                                                  type="local"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://www.ibm.com"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://www.ibm.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://www.ibm.com"
+                                                                          onClick={[Function]}
+                                                                          target={null}
+                                                                        >
+                                                                          Lorem ipsum dolor
+                                                                          <ForwardRef(ArrowRight20)>
+                                                                            <Icon
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                style={
+                                                                                  Object {
+                                                                                    "willChange": "transform",
+                                                                                  }
+                                                                                }
+                                                                                viewBox="0 0 20 20"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(ArrowRight20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </div>
+                                                        </ContentItem>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </PictogramItem>
+                                                <PictogramItem
+                                                  className="bx--content-group-pictograms__item"
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                                  cta={
+                                                    Object {
+                                                      "copy": "Lorem ipsum dolor",
+                                                      "href": "https://www.ibm.com",
+                                                      "type": "local",
+                                                    }
+                                                  }
+                                                  data-autoid="bx--content-group-pictograms__item"
+                                                  heading="Aliquam condimentum interdum"
+                                                  key="1"
+                                                  pictogram={
+                                                    Object {
+                                                      "aria-label": "Pattern",
+                                                      "src": Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      },
+                                                    }
+                                                  }
+                                                >
+                                                  <div
+                                                    className="bx--content-group-pictograms__item bx--pictogram-item"
+                                                  >
+                                                    <div
+                                                      className="bx--pictogram-item__row"
+                                                    >
+                                                      <div
+                                                        className="bx--pictogram-item__wrapper"
+                                                      >
+                                                        <ForwardRef(Pattern)
+                                                          aria-label="Pattern"
+                                                          className="bx--pictogram-item__pictogram"
+                                                          data-autoid="dds--pictogram-item__pictogram"
+                                                        >
+                                                          <Icon
+                                                            aria-label="Pattern"
+                                                            className="bx--pictogram-item__pictogram"
+                                                            data-autoid="dds--pictogram-item__pictogram"
+                                                            height={48}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 48 48"
+                                                            width={48}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-label="Pattern"
+                                                              className="bx--pictogram-item__pictogram"
+                                                              data-autoid="dds--pictogram-item__pictogram"
+                                                              focusable="false"
+                                                              height={48}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              role="img"
+                                                              style={
+                                                                Object {
+                                                                  "willChange": "transform",
+                                                                }
+                                                              }
+                                                              viewBox="0 0 48 48"
+                                                              width={48}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M27,29H11c-1.1,0-2-0.9-2-2V11c0-1.1,0.9-2,2-2h16c1.1,0,2,0.9,2,2v16C29,28.1,28.1,29,27,29z M19,29v8c0,1.1,0.9,2,2,2h16 c1.1,0,2-0.9,2-2V21c0-1.1-0.9-2-2-2h-8 M23,11l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C22.552,12,23,11.552,23,11z M18,17l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C17.552,18,18,17.552,18,17z M29,17l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C28.552,18,29,17.552,29,17z M12,22v-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C11.552,23,12,22.552,12,22z M23,22l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C22.552,23,23,22.552,23,22z M18,28l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C17.552,29,18,28.552,18,28z M29,27L29,27c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h0 C28.105,29,29,28.105,29,27z M9,11L9,11c0,0.552,0.448,1,1,1h1c0.552,0,1-0.448,1-1v-1c0-0.552-0.448-1-1-1h0"
+                                                                fill="none"
+                                                                stroke="#000"
+                                                                strokeLinecap="round"
+                                                                strokeLinejoin="round"
+                                                                strokeMiterlimit="10"
+                                                                strokeWidth=".72"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(Pattern)>
+                                                      </div>
+                                                      <div
+                                                        className="bx--pictogram-item__content"
+                                                        data-autoid="dds--pictogram-item__content"
+                                                      >
+                                                        <ContentItem
+                                                          copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                                          cta={
+                                                            Object {
+                                                              "copy": "Lorem ipsum dolor",
+                                                              "href": "https://www.ibm.com",
+                                                              "style": "text",
+                                                              "type": "local",
+                                                            }
+                                                          }
+                                                          heading="Aliquam condimentum interdum"
+                                                        >
+                                                          <div
+                                                            className="bx--content-item"
+                                                            data-autoid="dds--content-item"
+                                                          >
+                                                            <h4
+                                                              className="bx--content-item__heading"
+                                                              data-autoid="dds--content-item__heading"
+                                                            >
+                                                              Aliquam condimentum interdum
+                                                            </h4>
+                                                            <div
+                                                              className="bx--content-item__copy"
+                                                              dangerouslySetInnerHTML={
+                                                                Object {
+                                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                                }
+                                                              }
+                                                              data-autoid="dds--content-item__copy"
+                                                            />
+                                                            <CTA
+                                                              copy="Lorem ipsum dolor"
+                                                              customClassName="bx--content-item__cta"
+                                                              href="https://www.ibm.com"
+                                                              style="text"
+                                                              type="local"
+                                                            >
+                                                              <div
+                                                                className="bx--content-item__cta"
+                                                              >
+                                                                <TextCTA
+                                                                  copy="Lorem ipsum dolor"
+                                                                  external={[Function]}
+                                                                  href="https://www.ibm.com"
+                                                                  iconSelector={[Function]}
+                                                                  jump={[Function]}
+                                                                  launchLightBox={[Function]}
+                                                                  mediaData={Object {}}
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  setLightBox={[Function]}
+                                                                  setMediaData={[Function]}
+                                                                  style="text"
+                                                                  type="local"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://www.ibm.com"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://www.ibm.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://www.ibm.com"
+                                                                          onClick={[Function]}
+                                                                          target={null}
+                                                                        >
+                                                                          Lorem ipsum dolor
+                                                                          <ForwardRef(ArrowRight20)>
+                                                                            <Icon
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                style={
+                                                                                  Object {
+                                                                                    "willChange": "transform",
+                                                                                  }
+                                                                                }
+                                                                                viewBox="0 0 20 20"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(ArrowRight20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </div>
+                                                        </ContentItem>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </PictogramItem>
+                                                <PictogramItem
+                                                  className="bx--content-group-pictograms__item"
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                                  cta={
+                                                    Object {
+                                                      "copy": "Lorem ipsum dolor",
+                                                      "href": "https://www.ibm.com",
+                                                      "type": "local",
+                                                    }
+                                                  }
+                                                  data-autoid="bx--content-group-pictograms__item"
+                                                  heading="Aliquam condimentum interdum"
+                                                  key="2"
+                                                  pictogram={
+                                                    Object {
+                                                      "aria-label": "Touch",
+                                                      "src": Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      },
+                                                    }
+                                                  }
+                                                >
+                                                  <div
+                                                    className="bx--content-group-pictograms__item bx--pictogram-item"
+                                                  >
+                                                    <div
+                                                      className="bx--pictogram-item__row"
+                                                    >
+                                                      <div
+                                                        className="bx--pictogram-item__wrapper"
+                                                      >
+                                                        <ForwardRef(Touch)
+                                                          aria-label="Touch"
+                                                          className="bx--pictogram-item__pictogram"
+                                                          data-autoid="dds--pictogram-item__pictogram"
+                                                        >
+                                                          <Icon
+                                                            aria-label="Touch"
+                                                            className="bx--pictogram-item__pictogram"
+                                                            data-autoid="dds--pictogram-item__pictogram"
+                                                            height={48}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 48 48"
+                                                            width={48}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-label="Touch"
+                                                              className="bx--pictogram-item__pictogram"
+                                                              data-autoid="dds--pictogram-item__pictogram"
+                                                              focusable="false"
+                                                              height={48}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              role="img"
+                                                              style={
+                                                                Object {
+                                                                  "willChange": "transform",
+                                                                }
+                                                              }
+                                                              viewBox="0 0 48 48"
+                                                              width={48}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M21,15 c0-1.186,0.821-2,2-2h-0.003C24.176,13,25,13.814,25,15v8c0,0,4.663,0,6.913,0C34.162,23,36,24.541,36,26.776c0,0,0,2.758,0,4.01 C36,35.478,34.706,39,27.769,39c-4.829,0-7.104-2.056-10.134-5.48c-0.845-0.955-3.439-3.765-3.439-3.765 C13.365,28.819,12,27.415,12,26.985c0-1.299,3.219-2.011,4.792-0.803C18.008,27.116,21,30.5,21,30.5V15z M26.994,19.46 c1.23-1.09,2-2.69,2-4.46c0-3.31-2.69-6-6-6s-6,2.69-6,6c0,1.77,0.77,3.37,2,4.46"
+                                                                fill="none"
+                                                                stroke="#000"
+                                                                strokeLinejoin="round"
+                                                                strokeMiterlimit="10"
+                                                                strokeWidth=".72"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(Touch)>
+                                                      </div>
+                                                      <div
+                                                        className="bx--pictogram-item__content"
+                                                        data-autoid="dds--pictogram-item__content"
+                                                      >
+                                                        <ContentItem
+                                                          copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                                          cta={
+                                                            Object {
+                                                              "copy": "Lorem ipsum dolor",
+                                                              "href": "https://www.ibm.com",
+                                                              "style": "text",
+                                                              "type": "local",
+                                                            }
+                                                          }
+                                                          heading="Aliquam condimentum interdum"
+                                                        >
+                                                          <div
+                                                            className="bx--content-item"
+                                                            data-autoid="dds--content-item"
+                                                          >
+                                                            <h4
+                                                              className="bx--content-item__heading"
+                                                              data-autoid="dds--content-item__heading"
+                                                            >
+                                                              Aliquam condimentum interdum
+                                                            </h4>
+                                                            <div
+                                                              className="bx--content-item__copy"
+                                                              dangerouslySetInnerHTML={
+                                                                Object {
+                                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                                }
+                                                              }
+                                                              data-autoid="dds--content-item__copy"
+                                                            />
+                                                            <CTA
+                                                              copy="Lorem ipsum dolor"
+                                                              customClassName="bx--content-item__cta"
+                                                              href="https://www.ibm.com"
+                                                              style="text"
+                                                              type="local"
+                                                            >
+                                                              <div
+                                                                className="bx--content-item__cta"
+                                                              >
+                                                                <TextCTA
+                                                                  copy="Lorem ipsum dolor"
+                                                                  external={[Function]}
+                                                                  href="https://www.ibm.com"
+                                                                  iconSelector={[Function]}
+                                                                  jump={[Function]}
+                                                                  launchLightBox={[Function]}
+                                                                  mediaData={Object {}}
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  setLightBox={[Function]}
+                                                                  setMediaData={[Function]}
+                                                                  style="text"
+                                                                  type="local"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://www.ibm.com"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://www.ibm.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://www.ibm.com"
+                                                                          onClick={[Function]}
+                                                                          target={null}
+                                                                        >
+                                                                          Lorem ipsum dolor
+                                                                          <ForwardRef(ArrowRight20)>
+                                                                            <Icon
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                style={
+                                                                                  Object {
+                                                                                    "willChange": "transform",
+                                                                                  }
+                                                                                }
+                                                                                viewBox="0 0 20 20"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(ArrowRight20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </div>
+                                                        </ContentItem>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </PictogramItem>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </div>
+                                      </ContentGroupPictograms>
+                                      <ContentGroupSimple
+                                        heading="Lorem ipsum dolor sit amet"
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                              "heading": "Lorem ipsum dolor sit amet.",
+                                            },
+                                            Object {
+                                              "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                                              "heading": "Lorem ipsum dolor sit amet.",
+                                            },
+                                          ]
+                                        }
+                                        key="2"
+                                        mediaData={
+                                          Object {
+                                            "heading": "Lorem ipsum dolor sit amet.",
+                                            "image": Object {
+                                              "alt": "Image alt text",
+                                              "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                              "sources": Array [
+                                                Object {
+                                                  "breakpoint": 320,
+                                                  "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 400,
+                                                  "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 672,
+                                                  "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                },
+                                              ],
+                                            },
+                                          }
+                                        }
+                                        mediaType="image"
+                                        type="ContentGroupSimple"
+                                      >
+                                        <div
+                                          className="bx--content-group-simple"
+                                          data-autoid="dds--content-group-simple"
+                                        >
+                                          <ContentGroup
+                                            heading="Lorem ipsum dolor sit amet"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                Lorem ipsum dolor sit amet
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-group-simple__media"
+                                                >
+                                                  <ImageWithCaption
+                                                    heading="Lorem ipsum dolor sit amet."
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                        "sources": Array [
+                                                          Object {
+                                                            "breakpoint": 320,
+                                                            "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 400,
+                                                            "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 672,
+                                                            "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                          },
+                                                        ],
+                                                      }
+                                                    }
+                                                  >
+                                                    <div
+                                                      className="bx--image-with-caption"
+                                                      data-autoid="dds--image-with-caption"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        sources={
+                                                          Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <picture
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <source
+                                                            key="0"
+                                                            media="(min-width: 672px )"
+                                                            srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          />
+                                                          <source
+                                                            key="1"
+                                                            media="(min-width: 400px )"
+                                                            srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                          />
+                                                          <source
+                                                            key="2"
+                                                            media="(min-width: 320px )"
+                                                            srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                          />
+                                                          <img
+                                                            alt="Image alt text"
+                                                            aria-describedby=""
+                                                            className="bx--image__img"
+                                                            src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          />
+                                                        </picture>
+                                                      </Image>
+                                                      <p
+                                                        className="bx--image__caption"
+                                                        data-autoid="dds--image__caption"
+                                                      >
+                                                        Lorem ipsum dolor sit amet.
+                                                      </p>
+                                                    </div>
+                                                  </ImageWithCaption>
+                                                </div>
+                                                <ContentItem
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                  heading="Lorem ipsum dolor sit amet."
+                                                  key="0"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <h4
+                                                      className="bx--content-item__heading"
+                                                      data-autoid="dds--content-item__heading"
+                                                    >
+                                                      Lorem ipsum dolor sit amet.
+                                                    </h4>
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                                <ContentItem
+                                                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                  heading="Lorem ipsum dolor sit amet."
+                                                  key="1"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <h4
+                                                      className="bx--content-item__heading"
+                                                      data-autoid="dds--content-item__heading"
+                                                    >
+                                                      Lorem ipsum dolor sit amet.
+                                                    </h4>
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </div>
+                                      </ContentGroupSimple>
+                                    </div>
+                                    <div
+                                      className="bx--content-block__cta-row"
+                                      data-autoid="dds--content-block__cta"
+                                    >
+                                      <CTA
+                                        copy="Lorem ipsum dolor sit ametttt"
+                                        cta={
+                                          Object {
+                                            "href": "https://www.ibm.com",
+                                          }
+                                        }
+                                        customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                        heading="Lorem ipsum dolor sit amet"
+                                        style="card"
+                                        type="local"
+                                      >
+                                        <div
+                                          className="bx--content-block__cta bx--content-block__cta-col"
+                                        >
+                                          <CardCTA
+                                            copy="Lorem ipsum dolor sit ametttt"
+                                            cta={
+                                              Object {
+                                                "href": "https://www.ibm.com",
+                                              }
+                                            }
+                                            external={[Function]}
+                                            heading="Lorem ipsum dolor sit amet"
+                                            iconSelector={[Function]}
+                                            jump={[Function]}
+                                            launchLightBox={[Function]}
+                                            mediaData={Object {}}
+                                            openLightBox={[Function]}
+                                            renderLightBox={false}
+                                            setLightBox={[Function]}
+                                            setMediaData={[Function]}
+                                            style="card"
+                                            type="local"
+                                            videoTitle={
+                                              Array [
+                                                Object {
+                                                  "key": 0,
+                                                  "title": "",
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <Card
+                                              copy="Lorem ipsum dolor sit ametttt"
+                                              cta={
+                                                Object {
+                                                  "href": "https://www.ibm.com",
+                                                  "icon": Object {
+                                                    "src": Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    },
+                                                  },
+                                                }
+                                              }
+                                              customClassName="bx--card__CTA"
+                                              handleClick={[Function]}
+                                              role="region"
+                                              target={null}
+                                              type="link"
+                                            >
+                                              <ClickableTile
+                                                className="bx--card bx--card--link bx--card__CTA"
+                                                clicked={false}
+                                                data-autoid="dds--card"
+                                                handleClick={[Function]}
+                                                handleKeyDown={[Function]}
+                                                href="https://www.ibm.com"
+                                                light={false}
+                                                role="region"
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                  data-autoid="dds--card"
+                                                  href="https://www.ibm.com"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  role="region"
+                                                  target={null}
+                                                >
+                                                  <Image
+                                                    classname="bx--card__img"
+                                                  />
+                                                  <div
+                                                    className="bx--card__wrapper"
+                                                  >
+                                                    <div
+                                                      className="bx--card__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                        }
+                                                      }
+                                                    />
+                                                    <div
+                                                      className="bx--card__footer"
+                                                    >
+                                                      <ForwardRef(ArrowRight20)
+                                                        className="bx--card__cta"
+                                                        src={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          }
+                                                        }
+                                                      >
+                                                        <Icon
+                                                          className="bx--card__cta"
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          src={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            }
+                                                          }
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="bx--card__cta"
+                                                            focusable="false"
+                                                            height={20}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
+                                                            style={
+                                                              Object {
+                                                                "willChange": "transform",
+                                                              }
+                                                            }
+                                                            viewBox="0 0 20 20"
+                                                            width={20}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                            />
+                                                          </svg>
+                                                        </Icon>
+                                                      </ForwardRef(ArrowRight20)>
+                                                    </div>
+                                                  </div>
+                                                </a>
+                                              </ClickableTile>
+                                            </Card>
+                                          </CardCTA>
+                                        </div>
+                                      </CTA>
+                                    </div>
+                                  </div>
+                                  <aside
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  >
+                                    <LinkList
+                                      heading="Tutorials"
+                                      items={
+                                        Array [
+                                          Object {
+                                            "copy": "Containerization A Complete Guide",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "local",
+                                          },
+                                          Object {
+                                            "copy": "Why should you use microservices and containers",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "external",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <div
+                                        className="bx--link-list"
+                                        data-autoid="dds--link-list"
+                                      >
+                                        <h4
+                                          className="bx--link-list__heading"
+                                        >
+                                          Tutorials
+                                        </h4>
+                                        <ul
+                                          className="bx--link-list__list"
+                                        >
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="0"
+                                          >
+                                            <CTA
+                                              copy="Containerization A Complete Guide"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="local"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Containerization A Complete Guide"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="local"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Containerization A Complete Guide"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target={null}
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target={null}
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target={null}
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Containerization A Complete Guide</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(ArrowRight20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="1"
+                                          >
+                                            <CTA
+                                              copy="Why should you use microservices and containers"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="external"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Why should you use microservices and containers"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="external"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Why should you use microservices and containers"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target="_blank"
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target="_blank"
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target="_blank"
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Why should you use microservices and containers</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(Launch20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                  />
+                                                                  <path
+                                                                    d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(Launch20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                        </ul>
+                                      </div>
+                                    </LinkList>
+                                  </aside>
+                                </div>
+                              </section>
+                            </Layout>
+                          </div>
+                        </ContentBlock>
+                      </div>
+                    </ContentBlockMixed>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
 <Container
   story={[Function]}
@@ -10466,7 +14888,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                     className="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4"
                   >
                     <ContentBlockSegmented
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
@@ -10583,7 +15004,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                     className="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4"
                   >
                     <ContentBlockSegmented
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
@@ -10665,7 +15085,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                         data-autoid="dds--content-block-segmented"
                       >
                         <ContentBlock
-                          aside={false}
                           copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
@@ -11151,6 +15570,1201 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                  >
+                    <ContentBlockSegmented
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+                      cta={
+                        Object {
+                          "copy": "Lorem ipsum dolor",
+                          "cta": Object {
+                            "href": "https://www.example.com",
+                          },
+                          "style": "card",
+                          "type": "local",
+                        }
+                      }
+                      heading="Lorem ipsum dolor sit amet."
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "heading": "Lorem ipsum dolor sit amet.",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "heading": "Lorem ipsum dolor sit amet.",
+                            "image": Object {
+                              "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        ]
+                      }
+                      mediaData={
+                        Object {
+                          "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                          "image": Object {
+                            "alt": "Image alt text",
+                            "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                            "sources": Array [
+                              Object {
+                                "breakpoint": 320,
+                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 400,
+                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 672,
+                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                              },
+                            ],
+                          },
+                        }
+                      }
+                      mediaType="image"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                  >
+                    <ContentBlockSegmented
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+                      cta={
+                        Object {
+                          "copy": "Lorem ipsum dolor",
+                          "cta": Object {
+                            "href": "https://www.example.com",
+                          },
+                          "style": "card",
+                          "type": "local",
+                        }
+                      }
+                      heading="Lorem ipsum dolor sit amet."
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "heading": "Lorem ipsum dolor sit amet.",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "heading": "Lorem ipsum dolor sit amet.",
+                            "image": Object {
+                              "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                              "image": Object {
+                                "alt": "Image alt text",
+                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                "sources": Array [
+                                  Object {
+                                    "breakpoint": 320,
+                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 400,
+                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                  },
+                                  Object {
+                                    "breakpoint": 672,
+                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        ]
+                      }
+                      mediaData={
+                        Object {
+                          "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                          "image": Object {
+                            "alt": "Image alt text",
+                            "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                            "sources": Array [
+                              Object {
+                                "breakpoint": 320,
+                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 400,
+                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 672,
+                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                              },
+                            ],
+                          },
+                        }
+                      }
+                      mediaType="image"
+                    >
+                      <div
+                        className="bx--content-block-segmented"
+                        data-autoid="dds--content-block-segmented"
+                      >
+                        <ContentBlock
+                          aside={
+                            Object {
+                              "border": false,
+                              "items": <LinkList
+                                heading="Tutorials"
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Containerization A Complete Guide",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "Why should you use microservices and containers",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ]
+                                }
+                              />,
+                            }
+                          }
+                          copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+                          cta={
+                            Object {
+                              "copy": "Lorem ipsum dolor",
+                              "cta": Object {
+                                "href": "https://www.example.com",
+                              },
+                              "style": "card",
+                              "type": "local",
+                            }
+                          }
+                          heading="Lorem ipsum dolor sit amet."
+                        >
+                          <div
+                            className="bx--content-block"
+                            data-autoid="dds--content-block"
+                          >
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <h2
+                                      className="bx--content-block__heading"
+                                      data-autoid="dds--content-block__heading"
+                                    >
+                                      Lorem ipsum dolor sit amet.
+                                    </h2>
+                                  </div>
+                                  <div
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  />
+                                </div>
+                              </section>
+                            </Layout>
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <div
+                                      className="bx--content-block__copy"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p>",
+                                        }
+                                      }
+                                    />
+                                    <div
+                                      className="bx--content-block__children"
+                                      data-autoid="dds--content-block__children"
+                                    >
+                                      <div
+                                        data-autoid="dds--content-block-segmented__media"
+                                      >
+                                        <ImageWithCaption
+                                          heading="Mauris iaculis eget dolor nec hendrerit."
+                                          image={
+                                            Object {
+                                              "alt": "Image alt text",
+                                              "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                              "sources": Array [
+                                                Object {
+                                                  "breakpoint": 320,
+                                                  "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 400,
+                                                  "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                },
+                                                Object {
+                                                  "breakpoint": 672,
+                                                  "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="bx--image-with-caption"
+                                            data-autoid="dds--image-with-caption"
+                                          >
+                                            <Image
+                                              alt="Image alt text"
+                                              defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                              sources={
+                                                Array [
+                                                  Object {
+                                                    "breakpoint": 320,
+                                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                  },
+                                                  Object {
+                                                    "breakpoint": 400,
+                                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                  },
+                                                  Object {
+                                                    "breakpoint": 672,
+                                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <picture
+                                                className="bx--image"
+                                                data-autoid="dds--image__longdescription-"
+                                              >
+                                                <source
+                                                  key="0"
+                                                  media="(min-width: 672px )"
+                                                  srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                />
+                                                <source
+                                                  key="1"
+                                                  media="(min-width: 400px )"
+                                                  srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                />
+                                                <source
+                                                  key="2"
+                                                  media="(min-width: 320px )"
+                                                  srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                />
+                                                <img
+                                                  alt="Image alt text"
+                                                  aria-describedby=""
+                                                  className="bx--image__img"
+                                                  src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                />
+                                              </picture>
+                                            </Image>
+                                            <p
+                                              className="bx--image__caption"
+                                              data-autoid="dds--image__caption"
+                                            >
+                                              Mauris iaculis eget dolor nec hendrerit.
+                                            </p>
+                                          </div>
+                                        </ImageWithCaption>
+                                      </div>
+                                      <ContentGroup
+                                        heading="Lorem ipsum dolor sit amet."
+                                        key="0"
+                                      >
+                                        <div
+                                          className="bx--content-group"
+                                          data-autoid="dds--content-group"
+                                        >
+                                          <h3
+                                            className="bx--content-group__title"
+                                            data-autoid="dds--content-group__title"
+                                          >
+                                            Lorem ipsum dolor sit amet.
+                                          </h3>
+                                          <div
+                                            className="bx--content-group__col bx--content-group__children"
+                                            data-autoid="dds--content-group__children"
+                                          >
+                                            <div
+                                              data-autoid="dds--content-block-segmented__content-group"
+                                            >
+                                              <ContentItem
+                                                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                key="0"
+                                              >
+                                                <div
+                                                  className="bx--content-item"
+                                                  data-autoid="dds--content-item"
+                                                >
+                                                  <div
+                                                    className="bx--content-item__copy"
+                                                    dangerouslySetInnerHTML={
+                                                      Object {
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                      }
+                                                    }
+                                                    data-autoid="dds--content-item__copy"
+                                                  />
+                                                </div>
+                                              </ContentItem>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </ContentGroup>
+                                      <ContentGroup
+                                        heading="Lorem ipsum dolor sit amet."
+                                        key="1"
+                                      >
+                                        <div
+                                          className="bx--content-group"
+                                          data-autoid="dds--content-group"
+                                        >
+                                          <h3
+                                            className="bx--content-group__title"
+                                            data-autoid="dds--content-group__title"
+                                          >
+                                            Lorem ipsum dolor sit amet.
+                                          </h3>
+                                          <div
+                                            className="bx--content-group__col bx--content-group__children"
+                                            data-autoid="dds--content-group__children"
+                                          >
+                                            <div
+                                              data-autoid="dds--content-block-segmented__content-group"
+                                            >
+                                              <ContentItem
+                                                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien."
+                                                key="1"
+                                              >
+                                                <div
+                                                  className="bx--content-item"
+                                                  data-autoid="dds--content-item"
+                                                >
+                                                  <div
+                                                    className="bx--content-item__copy"
+                                                    dangerouslySetInnerHTML={
+                                                      Object {
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                      }
+                                                    }
+                                                    data-autoid="dds--content-item__copy"
+                                                  />
+                                                </div>
+                                              </ContentItem>
+                                              <div
+                                                data-autoid="dds--content-block-segmented__media"
+                                              >
+                                                <ImageWithCaption
+                                                  heading="Mauris iaculis eget dolor nec hendrerit."
+                                                  image={
+                                                    Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                      "sources": Array [
+                                                        Object {
+                                                          "breakpoint": 320,
+                                                          "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                        },
+                                                        Object {
+                                                          "breakpoint": 400,
+                                                          "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                        },
+                                                        Object {
+                                                          "breakpoint": 672,
+                                                          "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                        },
+                                                      ],
+                                                    }
+                                                  }
+                                                >
+                                                  <div
+                                                    className="bx--image-with-caption"
+                                                    data-autoid="dds--image-with-caption"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                      sources={
+                                                        Array [
+                                                          Object {
+                                                            "breakpoint": 320,
+                                                            "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 400,
+                                                            "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                          },
+                                                          Object {
+                                                            "breakpoint": 672,
+                                                            "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                          },
+                                                        ]
+                                                      }
+                                                    >
+                                                      <picture
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <source
+                                                          key="0"
+                                                          media="(min-width: 672px )"
+                                                          srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        />
+                                                        <source
+                                                          key="1"
+                                                          media="(min-width: 400px )"
+                                                          srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                        />
+                                                        <source
+                                                          key="2"
+                                                          media="(min-width: 320px )"
+                                                          srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                        />
+                                                        <img
+                                                          alt="Image alt text"
+                                                          aria-describedby=""
+                                                          className="bx--image__img"
+                                                          src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        />
+                                                      </picture>
+                                                    </Image>
+                                                    <p
+                                                      className="bx--image__caption"
+                                                      data-autoid="dds--image__caption"
+                                                    >
+                                                      Mauris iaculis eget dolor nec hendrerit.
+                                                    </p>
+                                                  </div>
+                                                </ImageWithCaption>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </ContentGroup>
+                                    </div>
+                                    <div
+                                      className="bx--content-block__cta-row"
+                                      data-autoid="dds--content-block__cta"
+                                    >
+                                      <CTA
+                                        copy="Lorem ipsum dolor"
+                                        cta={
+                                          Object {
+                                            "href": "https://www.example.com",
+                                          }
+                                        }
+                                        customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                        style="card"
+                                        type="local"
+                                      >
+                                        <div
+                                          className="bx--content-block__cta bx--content-block__cta-col"
+                                        >
+                                          <CardCTA
+                                            copy="Lorem ipsum dolor"
+                                            cta={
+                                              Object {
+                                                "href": "https://www.example.com",
+                                              }
+                                            }
+                                            external={[Function]}
+                                            iconSelector={[Function]}
+                                            jump={[Function]}
+                                            launchLightBox={[Function]}
+                                            mediaData={Object {}}
+                                            openLightBox={[Function]}
+                                            renderLightBox={false}
+                                            setLightBox={[Function]}
+                                            setMediaData={[Function]}
+                                            style="card"
+                                            type="local"
+                                            videoTitle={
+                                              Array [
+                                                Object {
+                                                  "key": 0,
+                                                  "title": "",
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <Card
+                                              copy="Lorem ipsum dolor"
+                                              cta={
+                                                Object {
+                                                  "href": "https://www.example.com",
+                                                  "icon": Object {
+                                                    "src": Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    },
+                                                  },
+                                                }
+                                              }
+                                              customClassName="bx--card__CTA"
+                                              handleClick={[Function]}
+                                              role="region"
+                                              target={null}
+                                              type="link"
+                                            >
+                                              <ClickableTile
+                                                className="bx--card bx--card--link bx--card__CTA"
+                                                clicked={false}
+                                                data-autoid="dds--card"
+                                                handleClick={[Function]}
+                                                handleKeyDown={[Function]}
+                                                href="https://www.example.com"
+                                                light={false}
+                                                role="region"
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                  data-autoid="dds--card"
+                                                  href="https://www.example.com"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  role="region"
+                                                  target={null}
+                                                >
+                                                  <Image
+                                                    classname="bx--card__img"
+                                                  />
+                                                  <div
+                                                    className="bx--card__wrapper"
+                                                  >
+                                                    <div
+                                                      className="bx--card__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor</p>",
+                                                        }
+                                                      }
+                                                    />
+                                                    <div
+                                                      className="bx--card__footer"
+                                                    >
+                                                      <ForwardRef(ArrowRight20)
+                                                        className="bx--card__cta"
+                                                        src={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          }
+                                                        }
+                                                      >
+                                                        <Icon
+                                                          className="bx--card__cta"
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          src={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            }
+                                                          }
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="bx--card__cta"
+                                                            focusable="false"
+                                                            height={20}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
+                                                            style={
+                                                              Object {
+                                                                "willChange": "transform",
+                                                              }
+                                                            }
+                                                            viewBox="0 0 20 20"
+                                                            width={20}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                            />
+                                                          </svg>
+                                                        </Icon>
+                                                      </ForwardRef(ArrowRight20)>
+                                                    </div>
+                                                  </div>
+                                                </a>
+                                              </ClickableTile>
+                                            </Card>
+                                          </CardCTA>
+                                        </div>
+                                      </CTA>
+                                    </div>
+                                  </div>
+                                  <aside
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  >
+                                    <LinkList
+                                      heading="Tutorials"
+                                      items={
+                                        Array [
+                                          Object {
+                                            "copy": "Containerization A Complete Guide",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "local",
+                                          },
+                                          Object {
+                                            "copy": "Why should you use microservices and containers",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "external",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <div
+                                        className="bx--link-list"
+                                        data-autoid="dds--link-list"
+                                      >
+                                        <h4
+                                          className="bx--link-list__heading"
+                                        >
+                                          Tutorials
+                                        </h4>
+                                        <ul
+                                          className="bx--link-list__list"
+                                        >
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="0"
+                                          >
+                                            <CTA
+                                              copy="Containerization A Complete Guide"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="local"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Containerization A Complete Guide"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="local"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Containerization A Complete Guide"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target={null}
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target={null}
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target={null}
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Containerization A Complete Guide</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(ArrowRight20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="1"
+                                          >
+                                            <CTA
+                                              copy="Why should you use microservices and containers"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="external"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Why should you use microservices and containers"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="external"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Why should you use microservices and containers"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target="_blank"
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target="_blank"
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target="_blank"
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Why should you use microservices and containers</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(Launch20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                  />
+                                                                  <path
+                                                                    d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(Launch20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                        </ul>
+                                      </div>
+                                    </LinkList>
+                                  </aside>
+                                </div>
+                              </section>
+                            </Layout>
+                          </div>
+                        </ContentBlock>
+                      </div>
+                    </ContentBlockSegmented>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
 <Container
   story={[Function]}
@@ -11180,7 +16794,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                     class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4 content-block-story"
                   >
                     <ContentBlockSimple
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Here are
@@ -11267,7 +16880,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                     class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4 content-block-story"
                   >
                     <ContentBlockSimple
-                      aside={false}
                       copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
       Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
       nulla quis, *consequat* libero. Here are
@@ -11319,7 +16931,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                         data-autoid="dds--content-block-simple"
                       >
                         <ContentBlock
-                          aside={false}
                           cta={
                             Object {
                               "copy": "Lorem ipsum dolor sit ametttt",
@@ -11628,6 +17239,985 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                 </div>
                               </CTA>
                             </div>
+                          </div>
+                        </ContentBlock>
+                      </div>
+                    </ContentBlockSimple>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  class="bx--row"
+                >
+                  <div
+                    class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 content-block-story"
+                  >
+                    <ContentBlockSimple
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Here are
+      some common categories:
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+      "
+                      cta={
+                        Object {
+                          "copy": "Lorem ipsum dolor sit ametttt",
+                          "cta": Object {
+                            "href": "https://www.ibm.com",
+                          },
+                          "heading": "Lorem ipsum dolor sit amet",
+                          "style": "card",
+                          "type": "local",
+                        }
+                      }
+                      heading="Curabitur malesuada varius mi eu posuere"
+                      mediaData={
+                        Object {
+                          "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                          "image": Object {
+                            "alt": "Image alt text",
+                            "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                            "sources": Array [
+                              Object {
+                                "breakpoint": 320,
+                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 400,
+                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 672,
+                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                              },
+                            ],
+                          },
+                        }
+                      }
+                      mediaType="image"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  class="bx--row"
+                >
+                  <div
+                    class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 content-block-story"
+                  >
+                    <ContentBlockSimple
+                      aside={
+                        Object {
+                          "border": false,
+                          "items": <LinkList
+                            heading="Tutorials"
+                            items={
+                              Array [
+                                Object {
+                                  "copy": "Containerization A Complete Guide",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "Why should you use microservices and containers",
+                                  "cta": Object {
+                                    "href": "https://ibm.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ]
+                            }
+                          />,
+                        }
+                      }
+                      copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Here are
+      some common categories:
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+      "
+                      cta={
+                        Object {
+                          "copy": "Lorem ipsum dolor sit ametttt",
+                          "cta": Object {
+                            "href": "https://www.ibm.com",
+                          },
+                          "heading": "Lorem ipsum dolor sit amet",
+                          "style": "card",
+                          "type": "local",
+                        }
+                      }
+                      heading="Curabitur malesuada varius mi eu posuere"
+                      mediaData={
+                        Object {
+                          "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                          "image": Object {
+                            "alt": "Image alt text",
+                            "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                            "sources": Array [
+                              Object {
+                                "breakpoint": 320,
+                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 400,
+                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                              },
+                              Object {
+                                "breakpoint": 672,
+                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                              },
+                            ],
+                          },
+                        }
+                      }
+                      mediaType="image"
+                    >
+                      <div
+                        className="bx--content-block-simple"
+                        data-autoid="dds--content-block-simple"
+                      >
+                        <ContentBlock
+                          aside={
+                            Object {
+                              "border": false,
+                              "items": <LinkList
+                                heading="Tutorials"
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Containerization A Complete Guide",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "Why should you use microservices and containers",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ]
+                                }
+                              />,
+                            }
+                          }
+                          cta={
+                            Object {
+                              "copy": "Lorem ipsum dolor sit ametttt",
+                              "cta": Object {
+                                "href": "https://www.ibm.com",
+                              },
+                              "heading": "Lorem ipsum dolor sit amet",
+                              "style": "card",
+                              "type": "local",
+                            }
+                          }
+                          heading="Curabitur malesuada varius mi eu posuere"
+                        >
+                          <div
+                            className="bx--content-block"
+                            data-autoid="dds--content-block"
+                          >
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <h2
+                                      className="bx--content-block__heading"
+                                      data-autoid="dds--content-block__heading"
+                                    >
+                                      Curabitur malesuada varius mi eu posuere
+                                    </h2>
+                                  </div>
+                                  <div
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  />
+                                </div>
+                              </section>
+                            </Layout>
+                            <Layout
+                              border={false}
+                              marginBottom={null}
+                              marginTop={null}
+                              nested={true}
+                              stickyOffset={null}
+                              type="2-1"
+                            >
+                              <section
+                                className=""
+                                data-autoid="dds--layout"
+                              >
+                                <div
+                                  className="bx--row"
+                                >
+                                  <div
+                                    className="bx--layout-2-3"
+                                    key="0"
+                                  >
+                                    <div
+                                      className="bx--content-block__children"
+                                      data-autoid="dds--content-block__children"
+                                    >
+                                      <div
+                                        className="bx--content-block-simple__content"
+                                      >
+                                        <ContentItem
+                                          copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Here are
+      some common categories:
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+      "
+                                        >
+                                          <div
+                                            className="bx--content-item"
+                                            data-autoid="dds--content-item"
+                                          >
+                                            <div
+                                              className="bx--content-item__copy"
+                                              dangerouslySetInnerHTML={
+                                                Object {
+                                                  "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.  </p>",
+                                                }
+                                              }
+                                              data-autoid="dds--content-item__copy"
+                                            />
+                                          </div>
+                                        </ContentItem>
+                                        <div
+                                          data-autoid="dds--content-block-simple__media"
+                                        >
+                                          <ImageWithCaption
+                                            heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                                            image={
+                                              Object {
+                                                "alt": "Image alt text",
+                                                "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                "sources": Array [
+                                                  Object {
+                                                    "breakpoint": 320,
+                                                    "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                  },
+                                                  Object {
+                                                    "breakpoint": 400,
+                                                    "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                  },
+                                                  Object {
+                                                    "breakpoint": 672,
+                                                    "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                  },
+                                                ],
+                                              }
+                                            }
+                                          >
+                                            <div
+                                              className="bx--image-with-caption"
+                                              data-autoid="dds--image-with-caption"
+                                            >
+                                              <Image
+                                                alt="Image alt text"
+                                                defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                sources={
+                                                  Array [
+                                                    Object {
+                                                      "breakpoint": 320,
+                                                      "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                    },
+                                                    Object {
+                                                      "breakpoint": 400,
+                                                      "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                    },
+                                                    Object {
+                                                      "breakpoint": 672,
+                                                      "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                <picture
+                                                  className="bx--image"
+                                                  data-autoid="dds--image__longdescription-"
+                                                >
+                                                  <source
+                                                    key="0"
+                                                    media="(min-width: 672px )"
+                                                    srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                  />
+                                                  <source
+                                                    key="1"
+                                                    media="(min-width: 400px )"
+                                                    srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                  />
+                                                  <source
+                                                    key="2"
+                                                    media="(min-width: 320px )"
+                                                    srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                  />
+                                                  <img
+                                                    alt="Image alt text"
+                                                    aria-describedby=""
+                                                    className="bx--image__img"
+                                                    src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                  />
+                                                </picture>
+                                              </Image>
+                                              <p
+                                                className="bx--image__caption"
+                                                data-autoid="dds--image__caption"
+                                              >
+                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                                              </p>
+                                            </div>
+                                          </ImageWithCaption>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      className="bx--content-block__cta-row"
+                                      data-autoid="dds--content-block__cta"
+                                    >
+                                      <CTA
+                                        copy="Lorem ipsum dolor sit ametttt"
+                                        cta={
+                                          Object {
+                                            "href": "https://www.ibm.com",
+                                          }
+                                        }
+                                        customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                        heading="Lorem ipsum dolor sit amet"
+                                        style="card"
+                                        type="local"
+                                      >
+                                        <div
+                                          className="bx--content-block__cta bx--content-block__cta-col"
+                                        >
+                                          <CardCTA
+                                            copy="Lorem ipsum dolor sit ametttt"
+                                            cta={
+                                              Object {
+                                                "href": "https://www.ibm.com",
+                                              }
+                                            }
+                                            external={[Function]}
+                                            heading="Lorem ipsum dolor sit amet"
+                                            iconSelector={[Function]}
+                                            jump={[Function]}
+                                            launchLightBox={[Function]}
+                                            mediaData={Object {}}
+                                            openLightBox={[Function]}
+                                            renderLightBox={false}
+                                            setLightBox={[Function]}
+                                            setMediaData={[Function]}
+                                            style="card"
+                                            type="local"
+                                            videoTitle={
+                                              Array [
+                                                Object {
+                                                  "key": 0,
+                                                  "title": "",
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <Card
+                                              copy="Lorem ipsum dolor sit ametttt"
+                                              cta={
+                                                Object {
+                                                  "href": "https://www.ibm.com",
+                                                  "icon": Object {
+                                                    "src": Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    },
+                                                  },
+                                                }
+                                              }
+                                              customClassName="bx--card__CTA"
+                                              handleClick={[Function]}
+                                              role="region"
+                                              target={null}
+                                              type="link"
+                                            >
+                                              <ClickableTile
+                                                className="bx--card bx--card--link bx--card__CTA"
+                                                clicked={false}
+                                                data-autoid="dds--card"
+                                                handleClick={[Function]}
+                                                handleKeyDown={[Function]}
+                                                href="https://www.ibm.com"
+                                                light={false}
+                                                role="region"
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                  data-autoid="dds--card"
+                                                  href="https://www.ibm.com"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  role="region"
+                                                  target={null}
+                                                >
+                                                  <Image
+                                                    classname="bx--card__img"
+                                                  />
+                                                  <div
+                                                    className="bx--card__wrapper"
+                                                  >
+                                                    <div
+                                                      className="bx--card__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                        }
+                                                      }
+                                                    />
+                                                    <div
+                                                      className="bx--card__footer"
+                                                    >
+                                                      <ForwardRef(ArrowRight20)
+                                                        className="bx--card__cta"
+                                                        src={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          }
+                                                        }
+                                                      >
+                                                        <Icon
+                                                          className="bx--card__cta"
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          src={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            }
+                                                          }
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="bx--card__cta"
+                                                            focusable="false"
+                                                            height={20}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
+                                                            style={
+                                                              Object {
+                                                                "willChange": "transform",
+                                                              }
+                                                            }
+                                                            viewBox="0 0 20 20"
+                                                            width={20}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                            />
+                                                          </svg>
+                                                        </Icon>
+                                                      </ForwardRef(ArrowRight20)>
+                                                    </div>
+                                                  </div>
+                                                </a>
+                                              </ClickableTile>
+                                            </Card>
+                                          </CardCTA>
+                                        </div>
+                                      </CTA>
+                                    </div>
+                                  </div>
+                                  <aside
+                                    className="bx--layout-1-3"
+                                    key="1"
+                                  >
+                                    <LinkList
+                                      heading="Tutorials"
+                                      items={
+                                        Array [
+                                          Object {
+                                            "copy": "Containerization A Complete Guide",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "local",
+                                          },
+                                          Object {
+                                            "copy": "Why should you use microservices and containers",
+                                            "cta": Object {
+                                              "href": "https://ibm.com",
+                                            },
+                                            "type": "external",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <div
+                                        className="bx--link-list"
+                                        data-autoid="dds--link-list"
+                                      >
+                                        <h4
+                                          className="bx--link-list__heading"
+                                        >
+                                          Tutorials
+                                        </h4>
+                                        <ul
+                                          className="bx--link-list__list"
+                                        >
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="0"
+                                          >
+                                            <CTA
+                                              copy="Containerization A Complete Guide"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="local"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Containerization A Complete Guide"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="local"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Containerization A Complete Guide"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target={null}
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target={null}
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target={null}
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Containerization A Complete Guide</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(ArrowRight20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                          <li
+                                            className="bx--link-list__list__CTA"
+                                            key="1"
+                                          >
+                                            <CTA
+                                              copy="Why should you use microservices and containers"
+                                              cta={
+                                                Object {
+                                                  "href": "https://ibm.com",
+                                                }
+                                              }
+                                              style="card"
+                                              type="external"
+                                            >
+                                              <div>
+                                                <CardCTA
+                                                  copy="Why should you use microservices and containers"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://ibm.com",
+                                                    }
+                                                  }
+                                                  external={[Function]}
+                                                  iconSelector={[Function]}
+                                                  jump={[Function]}
+                                                  launchLightBox={[Function]}
+                                                  mediaData={Object {}}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  setLightBox={[Function]}
+                                                  setMediaData={[Function]}
+                                                  style="card"
+                                                  type="external"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <Card
+                                                    copy="Why should you use microservices and containers"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://ibm.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA"
+                                                    handleClick={[Function]}
+                                                    role="region"
+                                                    target="_blank"
+                                                    type="link"
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card--link bx--card__CTA"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href="https://ibm.com"
+                                                      light={false}
+                                                      role="region"
+                                                      target="_blank"
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                        data-autoid="dds--card"
+                                                        href="https://ibm.com"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="region"
+                                                        target="_blank"
+                                                      >
+                                                        <Image
+                                                          classname="bx--card__img"
+                                                        />
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Why should you use microservices and containers</p>",
+                                                              }
+                                                            }
+                                                          />
+                                                          <div
+                                                            className="bx--card__footer"
+                                                          >
+                                                            <ForwardRef(Launch20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  style={
+                                                                    Object {
+                                                                      "willChange": "transform",
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                  />
+                                                                  <path
+                                                                    d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(Launch20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </li>
+                                        </ul>
+                                      </div>
+                                    </LinkList>
+                                  </aside>
+                                </div>
+                              </section>
+                            </Layout>
                           </div>
                         </ContentBlock>
                       </div>

--- a/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
@@ -73,10 +73,77 @@ storiesOf('Patterns (Blocks)|ContentBlockMedia', module)
       },
     ];
 
-    // Render right panels elements
-    const showAside = boolean('Render aside elements', false);
+    return (
+      <div className={'bx--grid'}>
+        <div class="bx--row">
+          <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+            <ContentBlockMedia
+              copy={copy}
+              heading={text(
+                'Heading (required)',
+                'Curabitur malesuada varius mi eu posuere'
+              )}
+              items={items}
+              cta={select('Feature Link (optional)', cta, cta.cta)}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  })
+  .add('With aside elements', () => {
+    const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.`;
 
-    const linkListProps = showAside && {
+    const ctaProps = {
+      type: 'local',
+      heading: 'Lorem ipsum dolor sit amet',
+      card: {
+        cta: {
+          href: 'https://www.example.com',
+          icon: {
+            src: ArrowRight20,
+          },
+        },
+        heading: 'Consectetur adipisicing elit',
+        image: {
+          defaultSrc: 'https://dummyimage.com/672x672/ee5396/161616&text=1x1',
+          alt: 'Image alt text',
+        },
+      },
+    };
+
+    const cta = {
+      cta: ctaProps,
+      none: null,
+    };
+
+    const simpleHeading = ContentGroupSimpleKnobs.heading;
+    const simpleMediaData = ContentGroupSimpleKnobs.mediaData.image;
+    const simpleTypes = ContentGroupSimpleKnobs.types;
+    const simpleMediaType = simpleTypes.image;
+    const simpleItems = ContentGroupSimpleKnobs.items;
+    const simpleCta = ContentGroupSimpleKnobs.cta;
+
+    const items = [
+      {
+        mediaType: simpleMediaType,
+        mediaData: simpleMediaData,
+        heading: simpleHeading,
+        items: simpleItems,
+        cta: simpleCta,
+      },
+      {
+        mediaType: simpleMediaType,
+        mediaData: simpleMediaData,
+        heading: simpleHeading,
+        items: simpleItems,
+        cta: simpleCta,
+      },
+    ];
+
+    const linkListProps = {
       heading: text('link list heading:', 'Tutorials'),
       items: object('link list items array', [
         {
@@ -96,7 +163,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMedia', module)
       ]),
     };
 
-    const aside = showAside && {
+    const aside = {
       items: <LinkList {...linkListProps} />,
       border: boolean('border', false),
     };
@@ -104,21 +171,13 @@ storiesOf('Patterns (Blocks)|ContentBlockMedia', module)
     return (
       <div className={'bx--grid'}>
         <div class="bx--row">
-          <div
-            class={
-              showAside
-                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4'
-                : 'bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4'
-            }>
+          <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
             <ContentBlockMedia
               copy={copy}
-              heading={text(
-                'Heading (required)',
-                'Curabitur malesuada varius mi eu posuere'
-              )}
+              heading={'Curabitur malesuada varius mi eu posuere'}
               items={items}
               aside={aside}
-              cta={select('Feature Link (optional)', cta, cta.cta)}
+              cta={cta.cta}
             />
           </div>
         </div>

--- a/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
@@ -169,7 +169,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMedia', module)
     };
 
     return (
-      <div className={'bx--grid'}>
+      <div className="bx--grid">
         <div class="bx--row">
           <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
             <ContentBlockMedia

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
@@ -119,10 +119,119 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
       },
     ];
 
-    // Render right panels elements
-    const showAside = boolean('Render aside elements', false);
+    return (
+      <div className="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+            <ContentBlockMixed
+              heading={heading}
+              copy={copy}
+              cta={ctaProps}
+              items={items}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  })
+  .add('With aside elements', () => {
+    const heading = 'Lorem ipsum dolor sit amet';
 
-    const linkListProps = showAside && {
+    const ctaTypes = {
+      local: 'local',
+      jump: 'jump',
+      external: 'external',
+    };
+
+    const ctaProps = {
+      cta: {
+        href: 'https://www.ibm.com',
+      },
+      style: 'card',
+      type: select('CTA type', ctaTypes, ctaTypes.local),
+      heading: 'Lorem ipsum dolor sit amet',
+      copy: 'Lorem ipsum dolor sit ametttt',
+    };
+
+    const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.`;
+
+    const pictogramHeading =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+
+    const pictogramItems = [
+      {
+        heading: 'Aliquam condimentum interdum',
+        copy:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+        cta: {
+          href: 'https://www.ibm.com',
+          type: 'local',
+          copy: 'Lorem ipsum dolor',
+        },
+        pictogram: {
+          src: Desktop,
+          'aria-label': 'Desktop',
+        },
+      },
+      {
+        heading: 'Aliquam condimentum interdum',
+        copy:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+        cta: {
+          href: 'https://www.ibm.com',
+          type: 'local',
+          copy: 'Lorem ipsum dolor',
+        },
+        pictogram: {
+          src: Pattern,
+          'aria-label': 'Pattern',
+        },
+      },
+      {
+        heading: 'Aliquam condimentum interdum',
+        copy:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+        cta: {
+          href: 'https://www.ibm.com',
+          type: 'local',
+          copy: 'Lorem ipsum dolor',
+        },
+        pictogram: {
+          src: Touch,
+          'aria-label': 'Touch',
+        },
+      },
+    ];
+
+    const simpleHeading = ContentGroupSimpleKnobs.heading;
+    const simpleMediaData = ContentGroupSimpleKnobs.mediaData;
+    const simpleTypes = ContentGroupSimpleKnobs.types;
+    const simpleMediaType = simpleTypes.image;
+    const simpleItems = ContentGroupSimpleKnobs.items;
+
+    const items = [
+      {
+        type: 'ContentGroupCards',
+        heading: ContentGroupCardsKnobs.heading,
+        items: ContentGroupCardsKnobs.items,
+      },
+      {
+        type: 'ContentGroupPictograms',
+        heading: pictogramHeading,
+        items: pictogramItems,
+      },
+      {
+        type: 'ContentGroupSimple',
+        mediaType: simpleMediaType,
+        mediaData: simpleMediaData.image,
+        heading: simpleHeading,
+        items: simpleItems,
+      },
+    ];
+
+    const linkListProps = {
       heading: text('link list heading:', 'Tutorials'),
       items: object('link list items array', [
         {
@@ -142,7 +251,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
       ]),
     };
 
-    const aside = showAside && {
+    const aside = {
       items: <LinkList {...linkListProps} />,
       border: boolean('border', false),
     };
@@ -150,12 +259,7 @@ storiesOf('Patterns (Blocks)|ContentBlockMixed', module)
     return (
       <div className="bx--grid">
         <div class="bx--row">
-          <div
-            class={
-              showAside
-                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4'
-                : 'bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4'
-            }>
+          <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
             <ContentBlockMixed
               heading={heading}
               copy={copy}

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -100,10 +100,102 @@ storiesOf('Patterns (Blocks)|ContentBlockSegmented', module)
       },
     ];
 
-    // Render right panels elements
-    const showAside = boolean('Render aside elements', false);
+    return (
+      <div className={`${prefix}--grid`}>
+        <div className="bx--row">
+          <div className="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4">
+            <ContentBlockSegmented
+              copy={copy}
+              cta={cta}
+              heading={heading}
+              mediaType={mediaType}
+              mediaData={mediaData}
+              items={object('Content items', items)}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  })
+  .add('With aside elements', () => {
+    const heading = 'Lorem ipsum dolor sit amet.';
 
-    const linkListProps = showAside && {
+    const mediaType = select(
+      'mediaType (optional)',
+      ['image', 'video', 'none'],
+      'image'
+    );
+
+    const image = {
+      heading: 'Mauris iaculis eget dolor nec hendrerit.',
+      image: {
+        sources: [
+          {
+            src: 'https://dummyimage.com/320x180/ee5396/161616&text=16:9',
+            breakpoint: 320,
+          },
+          {
+            src: 'https://dummyimage.com/400x225/ee5396/161616&text=16:9',
+            breakpoint: 400,
+          },
+          {
+            src: 'https://dummyimage.com/672x378/ee5396/161616&text=16:9',
+            breakpoint: 672,
+          },
+        ],
+        alt: 'Image alt text',
+        defaultSrc: 'https://dummyimage.com/672x378/ee5396/161616&text=16:9',
+      },
+    };
+
+    const video = {
+      videoId: '0_uka1msg4',
+      showDescription: true,
+    };
+
+    const mediaData = mediaType === 'image' ? image : video;
+
+    const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.`;
+
+    const ctaStyles = {
+      text: 'text',
+      card: 'card',
+    };
+
+    const ctaTypes = {
+      external: 'external',
+      jump: 'jump',
+      local: 'local',
+    };
+
+    const cta = {
+      cta: {
+        href: 'https://www.example.com',
+      },
+      style: select('CTA style', ctaStyles, ctaStyles.card),
+      type: select('CTA type', ctaTypes, ctaTypes.local),
+      copy: 'Lorem ipsum dolor',
+    };
+
+    const items = [
+      {
+        heading: 'Lorem ipsum dolor sit amet.',
+        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.`,
+      },
+      {
+        heading: 'Lorem ipsum dolor sit amet.',
+        image: image,
+        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.`,
+      },
+    ];
+
+    const linkListProps = {
       heading: text('link list heading:', 'Tutorials'),
       items: object('link list items array', [
         {
@@ -123,7 +215,7 @@ storiesOf('Patterns (Blocks)|ContentBlockSegmented', module)
       ]),
     };
 
-    const aside = showAside && {
+    const aside = {
       items: <LinkList {...linkListProps} />,
       border: boolean('border', false),
     };
@@ -131,19 +223,14 @@ storiesOf('Patterns (Blocks)|ContentBlockSegmented', module)
     return (
       <div className={`${prefix}--grid`}>
         <div className="bx--row">
-          <div
-            className={
-              showAside
-                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4'
-                : 'bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4'
-            }>
+          <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4">
             <ContentBlockSegmented
               copy={copy}
               cta={cta}
               heading={heading}
               mediaType={mediaType}
               mediaData={mediaData}
-              items={object('Conent items', items)}
+              items={items}
               aside={aside}
             />
           </div>

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
@@ -86,10 +86,93 @@ storiesOf('Patterns (Blocks)|ContentBlockSimple', module)
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
       `;
 
-    // Render right panels elements
-    const showAside = boolean('Render aside elements', false);
+    return (
+      <div className="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4 content-block-story">
+            <ContentBlockSimple
+              copy={copy}
+              heading={text(
+                'Heading (required)',
+                'Curabitur malesuada varius mi eu posuere'
+              )}
+              mediaType={mediaType}
+              mediaData={mediaData}
+              cta={ctaProps}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  })
+  .add('With aside elements', () => {
+    const ctaStyles = {
+      text: 'text',
+      card: 'card',
+    };
 
-    const linkListProps = showAside && {
+    const ctaTypes = {
+      local: 'local',
+      jump: 'jump',
+      external: 'external',
+    };
+
+    const ctaProps = {
+      cta: {
+        href: 'https://www.ibm.com',
+      },
+      style: select('CTA style', ctaStyles, ctaStyles.card),
+      type: select('CTA type', ctaTypes, ctaTypes.local),
+      heading: 'Lorem ipsum dolor sit amet',
+      copy: 'Lorem ipsum dolor sit ametttt',
+    };
+
+    const mediaType = select(
+      'mediaType (optional)',
+      ['image', 'video', 'none'],
+      'image'
+    );
+
+    const image = {
+      heading: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      image: {
+        sources: [
+          {
+            src: 'https://dummyimage.com/320x180/ee5396/161616&text=16:9',
+            breakpoint: 320,
+          },
+          {
+            src: 'https://dummyimage.com/400x225/ee5396/161616&text=16:9',
+            breakpoint: 400,
+          },
+          {
+            src: 'https://dummyimage.com/672x378/ee5396/161616&text=16:9',
+            breakpoint: 672,
+          },
+        ],
+        alt: 'Image alt text',
+        defaultSrc: 'https://dummyimage.com/672x378/ee5396/161616&text=16:9',
+      },
+    };
+
+    const video = {
+      videoId: '0_uka1msg4',
+      showDescription: true,
+    };
+
+    const mediaData = mediaType === 'image' ? image : video;
+
+    const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Here are
+      some common categories:
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+      `;
+
+    const linkListProps = {
       heading: text('link list heading:', 'Tutorials'),
       items: object('link list items array', [
         {
@@ -109,20 +192,15 @@ storiesOf('Patterns (Blocks)|ContentBlockSimple', module)
       ]),
     };
 
-    const aside = showAside && {
+    const aside = {
       items: <LinkList {...linkListProps} />,
       border: boolean('border', false),
     };
 
     return (
-      <div className={'bx--grid'}>
+      <div className="bx--grid">
         <div class="bx--row">
-          <div
-            class={
-              showAside
-                ? 'bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 content-block-story'
-                : 'bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4 content-block-story'
-            }>
+          <div class="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4 content-block-story">
             <ContentBlockSimple
               copy={copy}
               heading={text(


### PR DESCRIPTION
### Related Ticket(s)

Story book:- Patterns related to contents showing error message on selecting render aside element #2178

### Description

When turning on the aside knob in storybook for content block decorator patterns and opening new tab, it breaks.

Current workaround in this PR is to place the aside elements in a separate story

### Changelog

**Changed**

- put aside elements in separate story for content block decorators

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
