### PR TITLE
fix(expressive-theme): removing __docgenInfo references

### DIFF
--- a/packages/styles/src/carbon-stories/ComboBox/ComboBox-story.js
+++ b/packages/styles/src/carbon-stories/ComboBox/ComboBox-story.js
@@ -86,12 +86,6 @@ const ControlledComboBoxApp = props => {
     </>
   );
 };
-// ControlledComboBoxApp.__docgenInfo = {
-//   ...ComboBox.__docgenInfo,
-//   props: {
-//     ...ComboBox.__docgenInfo.props,
-//   },
-// };
 
 storiesOf('ComboBox', module)
   .addDecorator(withKnobs)

--- a/packages/styles/src/carbon-stories/InlineLoading/InlineLoading-story.js
+++ b/packages/styles/src/carbon-stories/InlineLoading/InlineLoading-story.js
@@ -79,12 +79,6 @@ storiesOf('InlineLoading', module)
       }
 
       MockSubmission.displayName = 'InlineLoading';
-      MockSubmission.__docgenInfo = {
-        ...InlineLoading.__docgenInfo,
-        props: {
-          ...InlineLoading.__docgenInfo.props,
-        },
-      };
 
       return (
         <MockSubmission>


### PR DESCRIPTION
### Related Ticket(s)

[Inline Loading UX example page is giving an error message #1309](https://github.com/carbon-design-system/ibm-dotcom-library/issues/1309)

### Description

Removed all the references to the `__docgeninfo` property since we're not using it. This prevents the `InlineLoading` component from continuing to break.

#### previous
<img width="939" alt="73789789-6cc3cc80-476d-11ea-819b-c6763b4243d7" src="https://user-images.githubusercontent.com/42848561/80522351-d74a6a00-8962-11ea-85eb-29cd47a614f5.png">

#### current
<img width="1268" alt="Captura de Tela 2020-04-28 às 15 13 26" src="https://user-images.githubusercontent.com/42848561/80522420-f0531b00-8962-11ea-83d5-a6d7bf2d5b21.png">


### Changelog

**Removed**

- all the references to the `__docgeninfo` property