### PR TITLE
style(locale-modal): underline added to the eyebrow link

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -147,6 +147,7 @@
         &:hover {
           cursor: pointer;
           color: $interactive-01;
+          text-decoration: underline;
         }
 
         svg {


### PR DESCRIPTION
### Related Ticket(s)

[Locale selector: eyebrow link missing underline #2076](https://github.com/carbon-design-system/ibm-dotcom-library/issues/2076)

### Description

Underline added to the eyebrown link at the `LocaleModal` on hover.

#### previous
<img width="481" alt="79248824-56f81500-7e4a-11ea-9c23-a98d10883587" src="https://user-images.githubusercontent.com/42848561/80536984-9c9ffc00-8979-11ea-89b1-bd1a4aeacca1.png">

#### current
![Captura de Tela 2020-04-28 às 17 57 05](https://user-images.githubusercontent.com/42848561/80537036-b5101680-8979-11ea-9991-99d235267de1.png)
 

### Changelog

**Changed**

- underline at the eyebrow link in the `LocaleModal`;

