### PR TITLE
fix(masthead): update masthead nav chevron size

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -8,7 +8,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ChevronDownGlyph } from '@carbon/icons-react';
+import { ChevronDown20 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
@@ -19,7 +19,7 @@ import { AriaLabelPropType } from '../../../prop-types/AriaPropTypes';
 const { prefix } = settings;
 
 const defaultRenderMenuContent = () => (
-  <ChevronDownGlyph className={`${prefix}--header__menu-arrow`} />
+  <ChevronDown20 className={`${prefix}--header__menu-arrow`} />
 );
 
 /**

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -153,7 +153,7 @@ $search-transition-timing: 95ms;
 
       svg {
         position: relative;
-        top: -6px;
+        top: -2px;
         fill: $text-01;
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

#2069 

### Description

Fixes chevron size in masthead navigation.

### Changelog


**Changed**

- update masthead chevron to use `ChevronDown20` from `@carbon/icons-react`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
