### PR TITLE
style(locale-modal): applying correct type size

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -92,6 +92,7 @@
         width: 50%;
         color: $text-03;
         padding: $carbon--spacing-04 $carbon--spacing-05;
+        @include type-style('body-short-02');
 
         &:first-of-type {
           color: $text-01;


### PR DESCRIPTION
### Related Ticket(s)

Locale selector: locale list is using the wrong type size #1978

### Description

Applyied the correct type size to the locale-selector. 

### Changelog

**Changed**

- Now the text at the locale list follows the `$body-short-02` `scss` token. 