### PR TITLE
fix(dotcomshell): passing additional footer props through dotcomshell

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -210,12 +210,31 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
           Object {
             "content": <React.Fragment>
               <DotcomShell
-                disableLocaleButton={false}
-                footerType="default"
-                hasProfile={true}
-                hasSearch={true}
-                navigation="default"
-                platform={null}
+                footerProps={
+                  Object {
+                    "disableLocaleButton": false,
+                    "languageCallback": [Function],
+                    "languageInitialItem": Object {
+                      "id": "en",
+                      "text": "English",
+                    },
+                    "languageItems": null,
+                    "languageOnly": false,
+                    "navigation": false,
+                    "type": "",
+                  }
+                }
+                mastheadProps={
+                  Object {
+                    "eyebrowLink": null,
+                    "eyebrowText": null,
+                    "hasProfile": true,
+                    "hasSearch": true,
+                    "navigation": "default",
+                    "platform": null,
+                    "title": null,
+                  }
+                }
               >
                 <div
                   className="bx--grid"
@@ -604,18 +623,43 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
           >
             <div>
               <DotcomShell
-                disableLocaleButton={false}
-                footerType="default"
-                hasProfile={true}
-                hasSearch={true}
-                navigation="default"
-                platform={null}
+                footerProps={
+                  Object {
+                    "disableLocaleButton": false,
+                    "languageCallback": [Function],
+                    "languageInitialItem": Object {
+                      "id": "en",
+                      "text": "English",
+                    },
+                    "languageItems": null,
+                    "languageOnly": false,
+                    "navigation": false,
+                    "type": "",
+                  }
+                }
+                mastheadProps={
+                  Object {
+                    "eyebrowLink": null,
+                    "eyebrowText": null,
+                    "hasProfile": true,
+                    "hasSearch": true,
+                    "navigation": "default",
+                    "platform": null,
+                    "title": null,
+                  }
+                }
               >
                 <Masthead
+                  eyebrowLink={null}
+                  eyebrowText={null}
                   hasProfile={true}
                   hasSearch={true}
+                  mastheadProps={null}
                   navigation="default"
+                  placeHolderText="Search all of IBM"
                   platform={null}
+                  searchOpenOnload={false}
+                  title={null}
                 >
                   <HeaderContainer
                     isSideNavExpanded={false}
@@ -748,6 +792,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                 className="bx--header__search "
                               >
                                 <MastheadTopNav
+                                  mastheadProps={null}
                                   navigation={Array []}
                                   platform={null}
                                 >
@@ -990,8 +1035,8 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                               </HeaderGlobalBar>
                               <MastheadLeftNav
                                 isSideNavExpanded={false}
+                                mastheadProps={null}
                                 navigation={Array []}
-                                platform={null}
                               >
                                 <ForwardRef(SideNav)
                                   addFocusListeners={true}
@@ -1711,12 +1756,19 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                 </div>
                 <Footer
                   disableLocaleButton={false}
-                  footerNav={null}
-                  footerType="full"
-                  langCode={null}
+                  footerProps={null}
+                  languageCallback={[Function]}
+                  languageInitialItem={
+                    Object {
+                      "id": "en",
+                      "text": "English",
+                    }
+                  }
+                  languageItems={null}
+                  languageOnly={false}
                   mastheadProps={null}
-                  navigation={null}
-                  type="default"
+                  navigation={false}
+                  type=""
                 >
                   <footer
                     className="bx--footer"
@@ -2512,9 +2564,7 @@ exports[`Storyshots Components|Footer Default 1`] = `
             "content": <React.Fragment>
               <Footer
                 disableLocaleButton={false}
-                footerNav={null}
-                footerType="full"
-                langCode={null}
+                footerProps={null}
                 languageCallback={[Function]}
                 languageInitialItem={
                   Object {
@@ -2557,9 +2607,7 @@ exports[`Storyshots Components|Footer Default 1`] = `
             <div>
               <Footer
                 disableLocaleButton={false}
-                footerNav={null}
-                footerType="full"
-                langCode={null}
+                footerProps={null}
                 languageCallback={[Function]}
                 languageInitialItem={
                   Object {
@@ -4154,11 +4202,16 @@ exports[`Storyshots Components|Masthead Default 1`] = `
           Object {
             "content": <React.Fragment>
               <Masthead
+                eyebrowLink={null}
+                eyebrowText={null}
                 hasProfile={true}
                 hasSearch={true}
+                mastheadProps={null}
                 navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
+                searchOpenOnload={false}
+                title={null}
               />
             </React.Fragment>,
             "type": "STORY",
@@ -4188,11 +4241,16 @@ exports[`Storyshots Components|Masthead Default 1`] = `
           >
             <div>
               <Masthead
+                eyebrowLink={null}
+                eyebrowText={null}
                 hasProfile={true}
                 hasSearch={true}
+                mastheadProps={null}
                 navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
+                searchOpenOnload={false}
+                title={null}
               >
                 <HeaderContainer
                   isSideNavExpanded={false}
@@ -4325,8 +4383,8 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                               className="bx--header__search "
                             >
                               <MastheadTopNav
+                                mastheadProps={null}
                                 navigation={Array []}
-                                placeHolderText="Search all of IBM"
                                 platform={null}
                               >
                                 <div
@@ -4568,9 +4626,8 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                             </HeaderGlobalBar>
                             <MastheadLeftNav
                               isSideNavExpanded={false}
+                              mastheadProps={null}
                               navigation={Array []}
-                              placeHolderText="Search all of IBM"
-                              platform={null}
                             >
                               <ForwardRef(SideNav)
                                 addFocusListeners={true}
@@ -4654,12 +4711,16 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
           Object {
             "content": <React.Fragment>
               <Masthead
+                eyebrowLink={null}
+                eyebrowText={null}
                 hasProfile={true}
                 hasSearch={true}
+                mastheadProps={null}
                 navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
                 searchOpenOnload={true}
+                title={null}
               />
             </React.Fragment>,
             "type": "STORY",
@@ -4689,12 +4750,16 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
           >
             <div>
               <Masthead
+                eyebrowLink={null}
+                eyebrowText={null}
                 hasProfile={true}
                 hasSearch={true}
+                mastheadProps={null}
                 navigation="default"
                 placeHolderText="Search all of IBM"
                 platform={null}
                 searchOpenOnload={true}
+                title={null}
               >
                 <HeaderContainer
                   isSideNavExpanded={false}
@@ -4827,10 +4892,9 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                               className="bx--header__search "
                             >
                               <MastheadTopNav
+                                mastheadProps={null}
                                 navigation={Array []}
-                                placeHolderText="Search all of IBM"
                                 platform={null}
-                                searchOpenOnload={true}
                               >
                                 <div
                                   className="bx--header__nav-container"
@@ -5241,10 +5305,8 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                             </HeaderGlobalBar>
                             <MastheadLeftNav
                               isSideNavExpanded={false}
+                              mastheadProps={null}
                               navigation={Array []}
-                              placeHolderText="Search all of IBM"
-                              platform={null}
-                              searchOpenOnload={true}
                             >
                               <ForwardRef(SideNav)
                                 addFocusListeners={true}

--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -20,26 +20,14 @@ const { prefix } = settings;
  *
  * @param {object} props react proptypes
  * @param {object} props.children Children of the Dotcom Shell
- * @param {object} props.footerNav Footer navigation object
- * @param {string} props.footerType Sets the footer type
- * @param {object} props.langCode Language code object
- * @param {object} props.navigation Masthead navigation object
- * @param {boolean} props.disableLocaleButton Disables the locale button
+ * @param {object} props.footerProps Properties passed into the Footer
  * @param {object} props.mastheadProps Properties passed into the Masthead
  * @returns {*} JSX component for the Dotcom Shell
  */
-const DotcomShell = ({
-  children,
-  footerNav,
-  footerType,
-  langCode,
-  navigation,
-  disableLocaleButton,
-  ...mastheadProps
-}) => {
+const DotcomShell = ({ children, footerProps, mastheadProps }) => {
   return (
     <>
-      <Masthead navigation={navigation} {...mastheadProps} />
+      <Masthead {...mastheadProps} />
       <div
         data-autoid={`${stablePrefix}--dotcom-shell`}
         className={`${prefix}--dotcom-shell`}>
@@ -49,12 +37,7 @@ const DotcomShell = ({
           {children}
         </div>
       </div>
-      <Footer
-        navigation={footerNav}
-        langCode={langCode}
-        type={footerType}
-        disableLocaleButton={disableLocaleButton}
-      />
+      <Footer {...footerProps} />
     </>
   );
 };
@@ -67,26 +50,17 @@ DotcomShell.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
-  navigation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  footerNav: PropTypes.object,
-  footerType: PropTypes.string,
-  langCode: PropTypes.object,
-  mastheadProps: PropTypes.object,
-  disableLocaleButton: PropTypes.bool,
+  footerProps: PropTypes.oneOf(PropTypes.shape(Footer.propTypes)),
+  mastheadProps: PropTypes.oneOf(PropTypes.shape(Masthead.propTypes)),
 };
 
 /**
- * @property {object} defaultProps default Footer props
- * @type {{navigation: null, mastheadProps: null, langCode: null,
- * footerNav: null, footerType: string, disableLocaleButton: boolean}}
+ * @property {object} defaultProps default DotcomShell props
+ * @type {{footerProps: null, mastheadProps: null}}
  */
 Footer.defaultProps = {
-  navigation: null,
-  footerNav: null,
-  footerType: 'full',
-  langCode: null,
+  footerProps: null,
   mastheadProps: null,
-  disableLocaleButton: false,
 };
 
 export default DotcomShell;

--- a/packages/react/src/components/DotcomShell/README.md
+++ b/packages/react/src/components/DotcomShell/README.md
@@ -43,8 +43,27 @@ import 'yourapplication.scss';
 import content from 'content';
 
 function App() {
+  return <DotcomShell>{content}</DotcomShell>;
+}
+```
+
+Example with custom `Masthead` and `Footer` props:
+
+```javascript
+import React from 'react';
+import { DotcomShell } from '@carbon/ibmdotcom-react';
+import 'yourapplication.scss';
+import content from 'content';
+
+function App() {
   return (
-    <DotcomShell navigation={navigation} footerType="short">
+    <DotcomShell
+      footerProps={{
+        footerType: 'short',
+      }}
+      mastheadProps={{
+        platform: 'My Platform Name',
+      }}>
       {content}
     </DotcomShell>
   );
@@ -63,11 +82,11 @@ Add the following line on your `.env` file at the root of your project,
 
 ## Data and content
 
-| Name          | Description     |
-| ------------- | --------------- |
-| `children`    | User content    |
-| `footer`      | Footer type     |
-| `navigtation` | Navigation data |
+| Name         | Description     |
+| ------------ | --------------- |
+| `children`   | User content    |
+| `footer`     | Footer type     |
+| `navigation` | Navigation data |
 
 > 💡 See the
 > [Masthead](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Masthead)
@@ -77,13 +96,11 @@ Add the following line on your `.env` file at the root of your project,
 
 ## Props
 
-| Name            | Required | Data Type        | Default Value | Description                                                                   |
-| --------------- | -------- | ---------------- | ------------- | ----------------------------------------------------------------------------- |
-| `children`      | YES      | Array OR Node    | n/a           | Component(s) to render within the UI shell                                    |
-| `footerNav`     | NO       | Object           | null          | Navigation data for the Footer                                                |
-| `footerType`    | NO       | String           | null          | Type of Footer (short OR tall). See `Footer` README.md for more details.      |
-| `mastheadProps` | NO       | Object           | null          | Additional Props for the Masthead. See `Masthead` README.md for more details. |
-| `navigation`    | NO       | String OR Object | null          | Navigation data for the Masthead                                              |
+| Name            | Required | Data Type     | Default Value | Description                                                        |
+| --------------- | -------- | ------------- | ------------- | ------------------------------------------------------------------ |
+| `children`      | YES      | Array OR Node | n/a           | Component(s) to render within the UI shell                         |
+| `footerProps`   | NO       | Object        | null          | Props for the Masthead. See `Footer` README.md for more details.   |
+| `mastheadProps` | NO       | Object        | null          | Props for the Masthead. See `Masthead` README.md for more details. |
 
 ## Stable selectors
 

--- a/packages/react/src/components/DotcomShell/README.md
+++ b/packages/react/src/components/DotcomShell/README.md
@@ -80,20 +80,6 @@ Add the following line on your `.env` file at the root of your project,
 > 💡 And don't forget to import the DotcomShell styles from
 > [@carbon/ibmdotcom-styles](/packages/styles).
 
-## Data and content
-
-| Name         | Description     |
-| ------------ | --------------- |
-| `children`   | User content    |
-| `footer`     | Footer type     |
-| `navigation` | Navigation data |
-
-> 💡 See the
-> [Masthead](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Masthead)
-> and
-> [Footer](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Footer)
-> component documentation for their specific usage.
-
 ## Props
 
 | Name            | Required | Data Type     | Default Value | Description                                                        |
@@ -101,6 +87,12 @@ Add the following line on your `.env` file at the root of your project,
 | `children`      | YES      | Array OR Node | n/a           | Component(s) to render within the UI shell                         |
 | `footerProps`   | NO       | Object        | null          | Props for the Masthead. See `Footer` README.md for more details.   |
 | `mastheadProps` | NO       | Object        | null          | Props for the Masthead. See `Masthead` README.md for more details. |
+
+> 💡 See the
+> [Masthead](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Masthead)
+> and
+> [Footer](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Footer)
+> component documentation for their specific usage.
 
 ## Stable selectors
 

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -1,17 +1,24 @@
 import './index.scss';
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
+import {
+  boolean,
+  object,
+  select,
+  text,
+  withKnobs,
+} from '@storybook/addon-knobs';
+import {
+  DDS_MASTHEAD_L1,
+  DDS_LANGUAGE_SELECTOR,
+} from '../../../internal/FeatureFlags';
 import content from './data/content';
-import { DDS_MASTHEAD_L1 } from '../../../internal/FeatureFlags';
 import DotcomShell from '../DotcomShell';
+import footerMenu from '../../Footer/__data__/footer-menu.json';
+import footerThin from '../../Footer/__data__/footer-thin.json';
+import languageItems from '../../Footer/__data__/language-items.json';
 import mastheadKnobs from '../../Masthead/__stories__/data/Masthead.stories.knobs.js';
 import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
-
-const footer = {
-  default: 'default',
-  short: 'short',
-};
 
 storiesOf('Components|Dotcom Shell', module)
   .addDecorator(withKnobs)
@@ -21,28 +28,105 @@ storiesOf('Components|Dotcom Shell', module)
     },
   })
   .add('Default', () => {
-    const mastheadL1Props = DDS_MASTHEAD_L1 && {
-      title: text('Title', 'Stock Charts'),
-      eyebrowText: text('Eyebrow text', 'Eyebrow'),
-      eyebrowLink: text('Eyebrow link', '#'),
+    let navigation = select(
+      'Masthead: navigation data (navigation)',
+      mastheadKnobs.navigation,
+      mastheadKnobs.navigation.default
+    );
+
+    let platform = select(
+      'Masthead: platform name (platform)',
+      mastheadKnobs.platform,
+      mastheadKnobs.platform.none
+    );
+
+    let hasProfile = boolean(
+      'Masthead: show the profile functionality (hasProfile)',
+      true
+    );
+
+    let hasSearch = boolean(
+      'Masthead: show the search functionality (hasSearch)',
+      true
+    );
+
+    let title = DDS_MASTHEAD_L1
+      ? text('Masthead: L1 Title (title)', 'Stock Charts')
+      : null;
+
+    let eyebrowText = DDS_MASTHEAD_L1
+      ? text('Masthead: L1 Eyebrow text (eyebrowText)', 'Eyebrow')
+      : null;
+
+    let eyebrowLink = DDS_MASTHEAD_L1
+      ? text('Masthead: Eyebrow link (eyebrowLink)', '#')
+      : null;
+
+    const footerTypeOptions = {
+      tall: '',
+      short: 'short',
     };
+
+    let type = select(
+      'Footer: sets the type of footer (type)',
+      footerTypeOptions,
+      footerTypeOptions.tall
+    );
+
+    let isCustom = boolean(
+      'Footer: show custom navigation (not a prop)',
+      false
+    );
+
+    let footerNav = isCustom
+      ? object('Footer: custom navigation data (navigation)', {
+          footerMenu,
+          footerThin,
+        })
+      : null;
+
+    let disableLocaleButton = boolean(
+      'Footer: hide the locale button (disableLocaleButton)',
+      false
+    );
+
+    let languageOnly =
+      DDS_LANGUAGE_SELECTOR &&
+      boolean('Footer: switch to the language selector (languageOnly)', false);
+
+    let items = languageOnly
+      ? object('Footer: language dropdown items (languageItems)', languageItems)
+      : null;
+
+    /**
+     * Language callback demo function
+     *
+     * @param {string} selectedItem Selected item
+     */
+    const languageCallback = selectedItem => {
+      console.log('Selected Item:', selectedItem);
+    };
+
     return (
       <DotcomShell
-        navigation={select(
-          'Navigation',
-          mastheadKnobs.navigation,
-          mastheadKnobs.navigation.default
-        )}
-        platform={select(
-          'Platform name',
-          mastheadKnobs.platform,
-          mastheadKnobs.platform.none
-        )}
-        footerType={select('Footer', footer, footer.default)}
-        hasProfile={boolean('Has profile', true)}
-        hasSearch={boolean('Has search', true)}
-        disableLocaleButton={boolean('hide the locale button', false)}
-        {...mastheadL1Props}>
+        mastheadProps={{
+          navigation,
+          platform,
+          hasProfile,
+          hasSearch,
+          title,
+          eyebrowText,
+          eyebrowLink,
+        }}
+        footerProps={{
+          navigation: isCustom && footerNav,
+          type,
+          disableLocaleButton,
+          languageOnly,
+          languageItems: items,
+          languageInitialItem: { id: 'en', text: 'English' },
+          languageCallback,
+        }}>
         {content}
       </DotcomShell>
     );

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -29,37 +29,40 @@ storiesOf('Components|Dotcom Shell', module)
   })
   .add('Default', () => {
     let navigation = select(
-      'Masthead: navigation data (navigation)',
+      'Masthead (mastheadProps): navigation data (navigation)',
       mastheadKnobs.navigation,
       mastheadKnobs.navigation.default
     );
 
     let platform = select(
-      'Masthead: platform name (platform)',
+      'Masthead (mastheadProps): platform name (platform)',
       mastheadKnobs.platform,
       mastheadKnobs.platform.none
     );
 
     let hasProfile = boolean(
-      'Masthead: show the profile functionality (hasProfile)',
+      'Masthead (mastheadProps): show the profile functionality (hasProfile)',
       true
     );
 
     let hasSearch = boolean(
-      'Masthead: show the search functionality (hasSearch)',
+      'Masthead (mastheadProps): show the search functionality (hasSearch)',
       true
     );
 
     let title = DDS_MASTHEAD_L1
-      ? text('Masthead: L1 Title (title)', 'Stock Charts')
+      ? text('Masthead (mastheadProps): L1 Title (title)', 'Stock Charts')
       : null;
 
     let eyebrowText = DDS_MASTHEAD_L1
-      ? text('Masthead: L1 Eyebrow text (eyebrowText)', 'Eyebrow')
+      ? text(
+          'Masthead (mastheadProps): L1 Eyebrow text (eyebrowText)',
+          'Eyebrow'
+        )
       : null;
 
     let eyebrowLink = DDS_MASTHEAD_L1
-      ? text('Masthead: Eyebrow link (eyebrowLink)', '#')
+      ? text('Masthead (mastheadProps): Eyebrow link (eyebrowLink)', '#')
       : null;
 
     const footerTypeOptions = {
@@ -68,34 +71,40 @@ storiesOf('Components|Dotcom Shell', module)
     };
 
     let type = select(
-      'Footer: sets the type of footer (type)',
+      'Footer (footerProps): sets the type of footer (type)',
       footerTypeOptions,
       footerTypeOptions.tall
     );
 
     let isCustom = boolean(
-      'Footer: show custom navigation (not a prop)',
+      'Footer (footerProps): show custom navigation (not a prop)',
       false
     );
 
     let footerNav = isCustom
-      ? object('Footer: custom navigation data (navigation)', {
+      ? object('Footer (footerProps): custom navigation data (navigation)', {
           footerMenu,
           footerThin,
         })
       : null;
 
     let disableLocaleButton = boolean(
-      'Footer: hide the locale button (disableLocaleButton)',
+      'Footer (footerProps): hide the locale button (disableLocaleButton)',
       false
     );
 
     let languageOnly =
       DDS_LANGUAGE_SELECTOR &&
-      boolean('Footer: switch to the language selector (languageOnly)', false);
+      boolean(
+        'Footer (footerProps): switch to the language selector (languageOnly)',
+        false
+      );
 
     let items = languageOnly
-      ? object('Footer: language dropdown items (languageItems)', languageItems)
+      ? object(
+          'Footer (footerProps): language dropdown items (languageItems)',
+          languageItems
+        )
       : null;
 
     /**
@@ -104,7 +113,7 @@ storiesOf('Components|Dotcom Shell', module)
      * @param {string} selectedItem Selected item
      */
     const languageCallback = selectedItem => {
-      console.log('Selected Item:', selectedItem);
+      console.log('footer (language selector) selected item:', selectedItem);
     };
 
     return (

--- a/packages/react/src/components/Footer/LanguageSelector.js
+++ b/packages/react/src/components/Footer/LanguageSelector.js
@@ -36,7 +36,7 @@ const LanguageSelector = ({ items, initialSelectedItem, callback }) => {
    */
   function _setSelectedItem(selectedItem) {
     setSelectedItem(selectedItem);
-    callback(setSelectedItem);
+    callback(selectedItem);
   }
 
   return (

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -56,7 +56,7 @@ storiesOf('Components|Footer', module)
      * @param {string} selectedItem Selected item
      */
     const languageCallback = selectedItem => {
-      console.log('Selected Item:', selectedItem);
+      console.log('footer (language selector) selected item:', selectedItem);
     };
 
     return (

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -30,7 +30,7 @@ storiesOf('Components|Footer', module)
 
     let isCustom = boolean('show custom navigation (not a prop)', false);
 
-    const navigation =
+    let navigation =
       isCustom &&
       object('custom navigation data (navigation)', {
         footerMenu,

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -42,9 +42,26 @@ const { prefix } = settings;
  * @param {object} props.navigation Object containing navigation elements
  * @param {boolean} props.hasProfile Determines whether to render Profile component
  * @param {boolean} props.hasSearch Determines whether to render Search Bar
+ * @param {boolean} props.searchOpenOnload Determines if the search field is open on page load
+ * @param {string} props.placeHolderText Placeholder value for search input
+ * @param {object} props.platform Platform name that appears on L0.
+ * @param {string} props.title Title for the masthead L1
+ * @param {string} props.eyebrowText Text for the eyebrow link in masthead L1
+ * @param {string} props.eyebrowLink URL for the eyebrow link in masthead L1
  * @returns {*} Masthead component
  */
-const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
+const Masthead = ({
+  navigation,
+  hasProfile,
+  hasSearch,
+  searchOpenOnload,
+  placeHolderText,
+  platform,
+  title,
+  eyebrowText,
+  eyebrowLink,
+  ...mastheadProps
+}) => {
   /**
    * Returns IBM.com authenticated status
    *
@@ -114,7 +131,7 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
   });
 
   const hasPlatform = cx({
-    [`${prefix}--masthead__platform`]: mastheadProps.platform,
+    [`${prefix}--masthead__platform`]: platform,
   });
 
   useEffect(() => {
@@ -179,13 +196,14 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
                 {navigation && (
                   <MastheadTopNav
                     {...mastheadProps}
+                    platform={platform}
                     navigation={mastheadData}
                   />
                 )}
                 {hasSearch && (
                   <MastheadSearch
-                    searchOpenOnload={mastheadProps.searchOpenOnload}
-                    placeHolderText={mastheadProps.placeHolderText}
+                    searchOpenOnload={searchOpenOnload}
+                    placeHolderText={placeHolderText}
                   />
                 )}
               </div>
@@ -227,9 +245,9 @@ const Masthead = ({ navigation, hasProfile, hasSearch, ...mastheadProps }) => {
             <div ref={mastheadL1Ref}>
               <MastheadL1
                 isShort={isMastheadSticky}
-                title={mastheadProps.title}
-                eyebrowText={mastheadProps.eyebrowText}
-                eyebrowLink={mastheadProps.eyebrowLink}
+                title={title}
+                eyebrowText={eyebrowText}
+                eyebrowLink={eyebrowLink}
               />
             </div>
           )}
@@ -249,6 +267,12 @@ Masthead.propTypes = {
   navigation: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   hasProfile: PropTypes.bool,
   hasSearch: PropTypes.bool,
+  searchOpenOnload: PropTypes.bool,
+  platform: PropTypes.object,
+  placeHolderText: PropTypes.string,
+  title: PropTypes.string,
+  eyebrowText: PropTypes.string,
+  eyebrowLink: PropTypes.string,
   mastheadProps: PropTypes.object,
 };
 
@@ -259,6 +283,13 @@ Masthead.propTypes = {
 Masthead.defaultProps = {
   hasProfile: true,
   hasSearch: true,
+  searchOpenOnload: false,
+  platform: null,
+  placeHolderText: 'Search all of IBM',
+  title: null,
+  eyebrowText: null,
+  eyebrowLink: null,
+  mastheadProps: null,
 };
 
 export default Masthead;

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -59,16 +59,17 @@ DDS_MASTHEAD_L1=true
 
 ## Props
 
-| Name              | Required | Data Type        | Default Value       | Description                                                         |
-| ----------------- | -------- | ---------------- | ------------------- | ------------------------------------------------------------------- |
-| `navigation`      | NO       | String OR Object | null                | Navigation data object/string for Masthead. See `navigation` below. |
-| `hasProfile`      | NO       | Boolean          | true                | Determines whether to render IBM Profile Menu component.            |
-| `hasSearch`       | NO       | Boolean          | true                | Determines whether to render SearchBar component.                   |
-| `placeHolderText` | NO       | String           | `Search all of IBM` | Placeholder value for search input.                                 |
-| `platform`        | NO       | Object           | null                | Platform name that appears on L0. See `platform` below.             |
-| `title`           | NO       | String           | null                | Title for the masthead L1.                                          |
-| `eyebrowText`     | NO       | String           | null                | Text for the eyebrow link in masthead L1.                           |
-| `eyebrowLink`     | NO       | String           | null                | URL for the eyebrow link in masthead L1.                            |
+| Name               | Required | Data Type        | Default Value       | Description                                                         |
+| ------------------ | -------- | ---------------- | ------------------- | ------------------------------------------------------------------- |
+| `navigation`       | NO       | String OR Object | null                | Navigation data object/string for Masthead. See `navigation` below. |
+| `hasProfile`       | NO       | Boolean          | true                | Determines whether to render IBM Profile Menu component.            |
+| `hasSearch`        | NO       | Boolean          | true                | Determines whether to render SearchBar component.                   |
+| `placeHolderText`  | NO       | String           | `Search all of IBM` | Placeholder value for search input.                                 |
+| `platform`         | NO       | Object           | null                | Platform name that appears on L0. See `platform` below.             |
+| `searchOpenOnload` | NO       | Boolean          | false               | Determines if the search field is open on page load.                |
+| `title`            | NO       | String           | null                | Title for the masthead L1 (experimental).                           |
+| `eyebrowText`      | NO       | String           | null                | Text for the eyebrow link in masthead L1 (experimental).            |
+| `eyebrowLink`      | NO       | String           | null                | URL for the eyebrow link in masthead L1 (experimental).             |
 
 ## navigation
 

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -17,57 +17,64 @@ storiesOf('Components|Masthead', module)
   .add('Default', () => {
     const standardProps = {
       navigation: select(
-        'Navigation',
+        'navigation data (navigation)',
         mastheadKnobs.navigation,
         mastheadKnobs.navigation.default
       ),
       platform: select(
-        'Platform name',
+        'platform name (platform)',
         mastheadKnobs.platform,
         mastheadKnobs.platform.none
       ),
-      hasProfile: boolean('Has profile', true),
-      hasSearch: boolean('Has search', true),
+      hasProfile: boolean('show the profile functionality (hasProfile)', true),
+      hasSearch: boolean('show the search functionality (hasSearch)', true),
+      placeHolderText: text(
+        'search placeholder (placeHolderText)',
+        'Search all of IBM'
+      ),
     };
     const mastheadL1Props = DDS_MASTHEAD_L1 && {
-      title: text('Title', 'Stock Charts'),
-      eyebrowText: text('Eyebrow text', 'Eyebrow'),
-      eyebrowLink: text('Eyebrow link', '#'),
+      title: text('L1 title (title) (experimental)', 'Stock Charts'),
+      eyebrowText: text(
+        'L1 eyebrow text (eyebrowText) (experimental)',
+        'Eyebrow'
+      ),
+      eyebrowLink: text('L1 eyebrow link (eyebrowLink) (experimental)', '#'),
     };
-    return (
-      <Masthead
-        {...standardProps}
-        {...mastheadL1Props}
-        placeHolderText={text('Search placeholder', 'Search all of IBM')}
-      />
-    );
+    return <Masthead {...standardProps} {...mastheadL1Props} />;
   })
   .add('Search open by default', () => {
     const standardProps = {
       navigation: select(
-        'Navigation',
+        'navigation data (navigation)',
         mastheadKnobs.navigation,
         mastheadKnobs.navigation.default
       ),
       platform: select(
-        'Platform name',
+        'platform name (platform)',
         mastheadKnobs.platform,
         mastheadKnobs.platform.none
       ),
-      hasProfile: boolean('Has profile', true),
-      hasSearch: boolean('Has search', true),
+      hasProfile: boolean('show the profile functionality (hasProfile)', true),
+      hasSearch: boolean('show the search functionality (hasSearch)', true),
+      placeHolderText: text(
+        'search placeholder (placeHolderText)',
+        'Search all of IBM'
+      ),
     };
     const mastheadL1Props = DDS_MASTHEAD_L1 && {
-      title: text('Title', 'Stock Charts'),
-      eyebrowText: text('Eyebrow text', 'Eyebrow'),
-      eyebrowLink: text('Eyebrow link', '#'),
+      title: text('L1 title (title) (experimental)', 'Stock Charts'),
+      eyebrowText: text(
+        'L1 eyebrow text (eyebrowText) (experimental)',
+        'Eyebrow'
+      ),
+      eyebrowLink: text('L1 eyebrow link (eyebrowLink) (experimental)', '#'),
     };
     return (
       <Masthead
         {...standardProps}
         {...mastheadL1Props}
         searchOpenOnload={true}
-        placeHolderText={text('Search placeholder', 'Search all of IBM')}
       />
     );
   });


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2254

### Description

Made a number of fixes to the prop handling, storybook prop descriptions, and also generally how the footer props are passed through the `DotcomShell`. This is a breaking change for DotcomShell users, so will need to note this in release notes for `1.7.0`.

### Changelog

**Changed**

- Passing props for footer through the `DotcomShell`
- Various storybook descriptions
- README updates