### PR TITLE
fix(css): add videoplayer styles

### DIFF
--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -6,7 +6,8 @@
 //
 
 @import '../../globals/imports';
-@import '.././expressive-modal/expressive-modal';
+@import '../expressive-modal/expressive-modal';
+@import '../video-player/video-player';
 
 @mixin lightbox-media-viewer {
   .#{$prefix}--modal--expressive--fullwidth


### PR DESCRIPTION
### Description

Adds missing styles to `LightboxMediaViewer`

### Changelog

**New**

- `VideoPlayer` styles added to `LightboxMediaViewer`


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
