### PR TITLE
fix(ipcinfo): properly set the ipcinfo cookie in the locale modal

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1815,7 +1815,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                         <LocaleButton
                           aria=""
                           displayLang=""
-                          selectItem={[Function]}
                         >
                           <div
                             className="bx--locale-btn__container"
@@ -2626,7 +2625,6 @@ exports[`Storyshots Components|Footer Default 1`] = `
                       <LocaleButton
                         aria=""
                         displayLang=""
-                        selectItem={[Function]}
                       >
                         <div
                           className="bx--locale-btn__container"

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -5,10 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import {
-  settings as ddsSettings,
-  ipcinfoCookie,
-} from '@carbon/ibmdotcom-utilities';
-import {
   globalInit,
   LocaleAPI,
   TranslationAPI,
@@ -16,6 +12,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { DDS_LANGUAGE_SELECTOR } from '../../internal/FeatureFlags';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import FooterLogo from './FooterLogo';
 import FooterNav from './FooterNav';
 import LanguageSelector from './LanguageSelector';
@@ -112,23 +109,6 @@ const Footer = ({
 };
 
 /**
- * method to handle when country/region has been selected
- * sets the ipcInfo cookie with selected locale
- *
- * @param {object} item selected country/region
- * @private
- */
-function _selectItem(item) {
-  const stringLocale = item.selectedItem.locale[0][0];
-  const locale = stringLocale.split('-');
-  const localeObj = {
-    cc: locale[1],
-    lc: locale[0],
-  };
-  ipcinfoCookie.set(localeObj);
-}
-
-/**
  * Loads in the locale modal, language selector, or null
  *
  * @param {boolean} disableLocaleButton Flag to disable to locale button
@@ -159,13 +139,7 @@ function _loadLocaleLanguage(
       />
     );
   } else if (!disableLocaleButton) {
-    return (
-      <LocaleButton
-        aria={localeButtonAria}
-        displayLang={displayLang}
-        selectItem={_selectItem}
-      />
-    );
+    return <LocaleButton aria={localeButtonAria} displayLang={displayLang} />;
   } else {
     return null;
   }

--- a/packages/react/src/components/LocaleModal/LocaleModalCountries.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalCountries.js
@@ -5,8 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {
+  settings as ddsSettings,
+  ipcinfoCookie,
+} from '@carbon/ibmdotcom-utilities';
 import React, { useEffect } from 'react';
-import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import { Search } from 'carbon-components-react';
 import { settings } from 'carbon-components';
@@ -107,6 +110,22 @@ const LocaleModalCountries = ({
     };
   });
 
+  /**
+   * method to handle when country/region has been selected
+   * sets the ipcInfo cookie with selected locale
+   *
+   * @param {object} locale selected country/region
+   * @private
+   */
+  function _setCookie(locale) {
+    const localeSplit = locale.split('-');
+    const localeObj = {
+      cc: localeSplit[1],
+      lc: localeSplit[0],
+    };
+    ipcinfoCookie.set(localeObj);
+  }
+
   return (
     <div className={`${prefix}--locale-modal__filter`}>
       <div className={`${prefix}--locale-modal__search`}>
@@ -132,6 +151,7 @@ const LocaleModalCountries = ({
               <a
                 key={index}
                 className={`${prefix}--locale-modal__locales`}
+                onClick={() => _setCookie(country.locale)}
                 href={country.href}
                 data-region={country.region}>
                 <div className={`${prefix}--locale-modal__locales__name`}>


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2250

### Description

This properly sets the ipcinfo cookie within the locale modal.

### Changelog

**Changed**

- fixed the cookie set method trigger for changing language/locale