### PR TITLE
fix(locale): remove scroll on vertical media query

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -20,8 +20,6 @@
 
     @media (max-height: rem(450px)) {
       .#{$prefix}--locale-modal__filtering {
-        overflow-y: scroll;
-
         .#{$prefix}--locale-modal__filter {
           overflow-y: initial;
 


### PR DESCRIPTION
### Related Ticket(s)

#2279 

### Description

Removes country list container scrollbar when vertical media query active.

### Changelog

**Removed**

- vertical scrollbar in `LocaleCountry` list when vertical media query active

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react" -->
<!-- *** "package: vanilla" -->
<!-- *** "package: services" -->
<!-- *** "package: utilities" -->
<!-- *** "package: styles" -->
