### PR TITLE
Feat/content block card

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5577,6 +5577,803 @@ exports[`Storyshots Overview|Get Started Read Me 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2 content-block-story"
+                  >
+                    <ContentBlockCards
+                      cards={
+                        Array [
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Nunc convallis lobortis",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Fusce gravida eu arcu",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Interdum et malesuada",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Nunc convallis loborti",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Nunc convallis lbortis",
+                          },
+                        ]
+                      }
+                      heading="Aliquam condimentum interdum"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2 content-block-story"
+                  >
+                    <ContentBlockCards
+                      cards={
+                        Array [
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Nunc convallis lobortis",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Fusce gravida eu arcu",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Interdum et malesuada",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Nunc convallis loborti",
+                          },
+                          Object {
+                            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                            "cta": Object {
+                              "href": "https://www.example.com",
+                            },
+                            "heading": "Nunc convallis lbortis",
+                          },
+                        ]
+                      }
+                      heading="Aliquam condimentum interdum"
+                    >
+                      <div
+                        className="bx--content-block-cards"
+                        data-autoid="dds--content-block-cards"
+                      >
+                        <ContentBlock
+                          heading="Aliquam condimentum interdum"
+                        >
+                          <div
+                            className="bx--content-block"
+                            data-autoid="dds--content-block"
+                          >
+                            <div>
+                              <h2
+                                className="bx--content-block__heading"
+                                data-autoid="dds--content-block__heading"
+                              >
+                                Aliquam condimentum interdum
+                              </h2>
+                            </div>
+                            <div
+                              className="bx--content-block__children"
+                              data-autoid="dds--content-block__children"
+                            >
+                              <div
+                                className="bx--content-block-cards__content"
+                              >
+                                <CardGroup
+                                  cards={
+                                    Array [
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "heading": "Nunc convallis lobortis",
+                                      },
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "heading": "Fusce gravida eu arcu",
+                                      },
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "heading": "Interdum et malesuada",
+                                      },
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "heading": "Nunc convallis loborti",
+                                      },
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "heading": "Nunc convallis lbortis",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div
+                                    className="bx--card-group__cards__row bx--row--condensed"
+                                    data-autoid="dds--card-group"
+                                  >
+                                    <div
+                                      aria-label="Nunc convallis lobortis"
+                                      className="bx--card-group__cards__col"
+                                      key="0"
+                                      role="region"
+                                    >
+                                      <Card
+                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                        cta={
+                                          Object {
+                                            "href": "https://www.example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          }
+                                        }
+                                        customClassName="bx--card-group__card"
+                                        heading="Nunc convallis lobortis"
+                                        key="0"
+                                        type="link"
+                                      >
+                                        <ClickableTile
+                                          className="bx--card bx--card--link bx--card-group__card"
+                                          clicked={false}
+                                          data-autoid="dds--card"
+                                          handleClick={[Function]}
+                                          handleKeyDown={[Function]}
+                                          href="https://www.example.com"
+                                          light={false}
+                                        >
+                                          <a
+                                            className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                            data-autoid="dds--card"
+                                            href="https://www.example.com"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                          >
+                                            <div
+                                              className="bx--card__wrapper"
+                                            >
+                                              <h3
+                                                className="bx--card__heading"
+                                              >
+                                                Nunc convallis lobortis
+                                              </h3>
+                                              <div
+                                                className="bx--card__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--card__footer"
+                                              >
+                                                <ForwardRef(ArrowRight20)
+                                                  className="bx--card__cta"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                >
+                                                  <Icon
+                                                    className="bx--card__cta"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 20 20"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="bx--card__cta"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      src={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        }
+                                                      }
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <polygon
+                                                        points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </div>
+                                            </div>
+                                          </a>
+                                        </ClickableTile>
+                                      </Card>
+                                    </div>
+                                    <div
+                                      aria-label="Fusce gravida eu arcu"
+                                      className="bx--card-group__cards__col"
+                                      key="1"
+                                      role="region"
+                                    >
+                                      <Card
+                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                        cta={
+                                          Object {
+                                            "href": "https://www.example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          }
+                                        }
+                                        customClassName="bx--card-group__card"
+                                        heading="Fusce gravida eu arcu"
+                                        key="1"
+                                        type="link"
+                                      >
+                                        <ClickableTile
+                                          className="bx--card bx--card--link bx--card-group__card"
+                                          clicked={false}
+                                          data-autoid="dds--card"
+                                          handleClick={[Function]}
+                                          handleKeyDown={[Function]}
+                                          href="https://www.example.com"
+                                          light={false}
+                                        >
+                                          <a
+                                            className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                            data-autoid="dds--card"
+                                            href="https://www.example.com"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                          >
+                                            <div
+                                              className="bx--card__wrapper"
+                                            >
+                                              <h3
+                                                className="bx--card__heading"
+                                              >
+                                                Fusce gravida eu arcu
+                                              </h3>
+                                              <div
+                                                className="bx--card__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--card__footer"
+                                              >
+                                                <ForwardRef(ArrowRight20)
+                                                  className="bx--card__cta"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                >
+                                                  <Icon
+                                                    className="bx--card__cta"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 20 20"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="bx--card__cta"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      src={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        }
+                                                      }
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <polygon
+                                                        points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </div>
+                                            </div>
+                                          </a>
+                                        </ClickableTile>
+                                      </Card>
+                                    </div>
+                                    <div
+                                      aria-label="Interdum et malesuada"
+                                      className="bx--card-group__cards__col"
+                                      key="2"
+                                      role="region"
+                                    >
+                                      <Card
+                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                        cta={
+                                          Object {
+                                            "href": "https://www.example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          }
+                                        }
+                                        customClassName="bx--card-group__card"
+                                        heading="Interdum et malesuada"
+                                        key="2"
+                                        type="link"
+                                      >
+                                        <ClickableTile
+                                          className="bx--card bx--card--link bx--card-group__card"
+                                          clicked={false}
+                                          data-autoid="dds--card"
+                                          handleClick={[Function]}
+                                          handleKeyDown={[Function]}
+                                          href="https://www.example.com"
+                                          light={false}
+                                        >
+                                          <a
+                                            className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                            data-autoid="dds--card"
+                                            href="https://www.example.com"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                          >
+                                            <div
+                                              className="bx--card__wrapper"
+                                            >
+                                              <h3
+                                                className="bx--card__heading"
+                                              >
+                                                Interdum et malesuada
+                                              </h3>
+                                              <div
+                                                className="bx--card__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--card__footer"
+                                              >
+                                                <ForwardRef(ArrowRight20)
+                                                  className="bx--card__cta"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                >
+                                                  <Icon
+                                                    className="bx--card__cta"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 20 20"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="bx--card__cta"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      src={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        }
+                                                      }
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <polygon
+                                                        points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </div>
+                                            </div>
+                                          </a>
+                                        </ClickableTile>
+                                      </Card>
+                                    </div>
+                                    <div
+                                      aria-label="Nunc convallis loborti"
+                                      className="bx--card-group__cards__col"
+                                      key="3"
+                                      role="region"
+                                    >
+                                      <Card
+                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                        cta={
+                                          Object {
+                                            "href": "https://www.example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          }
+                                        }
+                                        customClassName="bx--card-group__card"
+                                        heading="Nunc convallis loborti"
+                                        key="3"
+                                        type="link"
+                                      >
+                                        <ClickableTile
+                                          className="bx--card bx--card--link bx--card-group__card"
+                                          clicked={false}
+                                          data-autoid="dds--card"
+                                          handleClick={[Function]}
+                                          handleKeyDown={[Function]}
+                                          href="https://www.example.com"
+                                          light={false}
+                                        >
+                                          <a
+                                            className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                            data-autoid="dds--card"
+                                            href="https://www.example.com"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                          >
+                                            <div
+                                              className="bx--card__wrapper"
+                                            >
+                                              <h3
+                                                className="bx--card__heading"
+                                              >
+                                                Nunc convallis loborti
+                                              </h3>
+                                              <div
+                                                className="bx--card__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--card__footer"
+                                              >
+                                                <ForwardRef(ArrowRight20)
+                                                  className="bx--card__cta"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                >
+                                                  <Icon
+                                                    className="bx--card__cta"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 20 20"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="bx--card__cta"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      src={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        }
+                                                      }
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <polygon
+                                                        points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </div>
+                                            </div>
+                                          </a>
+                                        </ClickableTile>
+                                      </Card>
+                                    </div>
+                                    <div
+                                      aria-label="Nunc convallis lbortis"
+                                      className="bx--card-group__cards__col"
+                                      key="4"
+                                      role="region"
+                                    >
+                                      <Card
+                                        copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                                        cta={
+                                          Object {
+                                            "href": "https://www.example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          }
+                                        }
+                                        customClassName="bx--card-group__card"
+                                        heading="Nunc convallis lbortis"
+                                        key="4"
+                                        type="link"
+                                      >
+                                        <ClickableTile
+                                          className="bx--card bx--card--link bx--card-group__card"
+                                          clicked={false}
+                                          data-autoid="dds--card"
+                                          handleClick={[Function]}
+                                          handleKeyDown={[Function]}
+                                          href="https://www.example.com"
+                                          light={false}
+                                        >
+                                          <a
+                                            className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                            data-autoid="dds--card"
+                                            href="https://www.example.com"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                          >
+                                            <div
+                                              className="bx--card__wrapper"
+                                            >
+                                              <h3
+                                                className="bx--card__heading"
+                                              >
+                                                Nunc convallis lbortis
+                                              </h3>
+                                              <div
+                                                className="bx--card__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--card__footer"
+                                              >
+                                                <ForwardRef(ArrowRight20)
+                                                  className="bx--card__cta"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                >
+                                                  <Icon
+                                                    className="bx--card__cta"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 20 20"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="bx--card__cta"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      src={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        }
+                                                      }
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <polygon
+                                                        points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </div>
+                                            </div>
+                                          </a>
+                                        </ClickableTile>
+                                      </Card>
+                                    </div>
+                                  </div>
+                                </CardGroup>
+                              </div>
+                            </div>
+                          </div>
+                        </ContentBlock>
+                      </div>
+                    </ContentBlockCards>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Patterns (Blocks)|ContentBlockMedia Default 1`] = `
 <Container
   story={[Function]}

--- a/packages/react/src/patterns/blocks/ContentBlockCards/ContentBlockCards.js
+++ b/packages/react/src/patterns/blocks/ContentBlockCards/ContentBlockCards.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { CardGroup } from '../../sub-patterns/CardGroup';
+import { ContentBlock } from '../../sub-patterns/ContentBlock';
+import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { settings } from 'carbon-components';
+
+const { stablePrefix } = ddsSettings;
+const { prefix } = settings;
+
+/**
+ * Content Block - Cards pattern
+ *
+ * @param {object} props props object
+ * @param {Array} props.cards array of cards
+ * @returns {*} Content block cards pattern
+ */
+const ContentBlockCards = ({ heading, cards }) => (
+  <div
+    data-autoid={`${stablePrefix}--content-block-cards`}
+    className={`${prefix}--content-block-cards`}>
+    <ContentBlock heading={heading}>
+      <div className={`${prefix}--content-block-cards__content`}>
+        <CardGroup cards={cards} />
+      </div>
+    </ContentBlock>
+  </div>
+);
+
+ContentBlockCards.propTypes = {
+  heading: PropTypes.string.isRequired,
+  cards: PropTypes.array,
+};
+
+export default ContentBlockCards;

--- a/packages/react/src/patterns/blocks/ContentBlockCards/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockCards/README.md
@@ -18,18 +18,68 @@ Here's a quick example to get you started.
 ```javascript
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CardSectionImages } from '@carbon/ibmdotcom-react';
+import { ContentBlockCards } from '@carbon/ibmdotcom-react';
 import 'yourapplication.scss';
 
 function App() {
   return (
-    <CardSectionImages
-      cards={cards}
-      heading="Aliquam condimentum interdum"
-      theme={theme}
-    />
+    <ContentBlockCards heading={'Aliquam condimentum interdum'} cards={data} />
   );
 }
 
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```
+
+Add the following line on your `.env` file at the root of your project,
+[see more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage).
+
+```
+  SASS_PATH=node_modules:src
+```
+
+## Props
+
+| Name      | Required | Data Type | Default Value | Description                                                                                                                                                                          |
+| --------- | -------- | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `heading` | YES      | String    | n/a           | Main title of ContentBlockCards pattern.                                                                                                                                             |
+| `cards`   | YES      | Array     | null          | Array of objects. See [Card props](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/patterns/blocks/ContentBlockCards#card-props---simple). |
+
+### Card props - simple
+
+| Name       | Required | Data Type | Description                            |
+| ---------- | -------- | --------- | -------------------------------------- |
+| `copy`     | YES      | String    | Copy of the card.                      |
+| `heading`  | YES      | String    | Heading of the card.                   |
+| `cta.href` | YES      | String    | URI for internal or external resource. |
+
+### Card props - image
+
+| Name       | Required | Data Type | Description                              |
+| ---------- | -------- | --------- | ---------------------------------------- |
+| `image`    | YES      | Object    | Contains source and alt text properties. |
+| `eyebrow`  | YES      | String    | Eyebrow of the card.                     |
+| `heading`  | YES      | String    | Heading of the card.                     |
+| `cta.href` | YES      | String    | URI for internal or external resource.   |
+
+> See
+> [Card](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/patterns/blocks/Card)
+> sub-pattern for all card options. 👀
+
+## Stable selectors
+
+| Name                       | Description |
+| -------------------------- | ----------- |
+| `dds--content-block-cards` | Pattern     |
+
+## 🙌 Contributing
+
+We're always looking for contributors to help us fix bugs, build new features,
+or help us improve the project documentation. If you're interested, definitely
+check out our
+[Contributing Guide](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/.github/CONTRIBUTING.md)!
+👀
+
+## 📝 License
+
+Licensed under the
+[Apache 2.0 License](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/LICENSE).

--- a/packages/react/src/patterns/blocks/ContentBlockCards/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockCards/README.md
@@ -1,0 +1,35 @@
+# Content Block - Cards
+
+> The Content Block - Simple pattern is a decorator of `ContentBlock`, and
+> includes a single `CardGroup`.
+
+## Getting started
+
+Here's a quick example to get you started.
+
+```scss
+// yourapplication.scss
+@import '@carbon/type/scss/font-face/mono';
+@import '@carbon/type/scss/font-face/sans';
+@include carbon--font-face-mono();
+@include carbon--font-face-sans();
+```
+
+```javascript
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { CardSectionImages } from '@carbon/ibmdotcom-react';
+import 'yourapplication.scss';
+
+function App() {
+  return (
+    <CardSectionImages
+      cards={cards}
+      heading="Aliquam condimentum interdum"
+      theme={theme}
+    />
+  );
+}
+
+ReactDOM.render(<App />, document.querySelector('#app'));
+```

--- a/packages/react/src/patterns/blocks/ContentBlockCards/__stories__/ContentBlockCards.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockCards/__stories__/ContentBlockCards.stories.js
@@ -22,7 +22,7 @@ storiesOf('Patterns (Blocks)|ContentBlockCards', module)
 
   .add('Default', () => {
     const cardTypes = Object.keys(cards);
-    const type = select('Card type', cardTypes, cardTypes[0]);
+    const type = select('Card (type)', cardTypes, cardTypes[0]);
     const data = object(`Data (${type})`, cards[type]);
 
     return (

--- a/packages/react/src/patterns/blocks/ContentBlockCards/__stories__/ContentBlockCards.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockCards/__stories__/ContentBlockCards.stories.js
@@ -5,15 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import './index.scss';
-import { boolean, object, select, withKnobs } from '@storybook/addon-knobs';
-import CardGroup from '../CardGroup';
-import cards from './data/cards.json';
+import { object, select, text, withKnobs } from '@storybook/addon-knobs';
+import cards from '../../../sub-patterns/CardGroup/__stories__/data/cards.json';
+import ContentBlockCards from '../ContentBlockCards';
 import React from 'react';
 import readme from '../README.md';
 import { storiesOf } from '@storybook/react';
 
-storiesOf('Patterns (Sub-Patterns)|CardGroup', module)
+storiesOf('Patterns (Blocks)|ContentBlockCards', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
@@ -21,27 +20,22 @@ storiesOf('Patterns (Sub-Patterns)|CardGroup', module)
     },
   })
 
-  .add('default', () => {
+  .add('Default', () => {
     const cardTypes = Object.keys(cards);
-
     const type = select('Card type', cardTypes, cardTypes[0]);
     const data = object(`Data (${type})`, cards[type]);
 
-    cards[type] = data;
-
-    const toggleCTA = boolean('cta', true);
-    const cta = {
-      heading: 'Top level card link',
-      cta: {
-        href: 'https://www.example.com',
-      },
-    };
-
     return (
-      <div className="bx--grid bx--content-group-story">
+      <div className="bx--grid">
         <div className="bx--row">
-          <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
-            <CardGroup cards={data} cta={toggleCTA && cta} />
+          <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2 content-block-story">
+            <ContentBlockCards
+              heading={text(
+                'Heading (required):',
+                'Aliquam condimentum interdum'
+              )}
+              cards={data}
+            />
           </div>
         </div>
       </div>

--- a/packages/react/src/patterns/blocks/index.js
+++ b/packages/react/src/patterns/blocks/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export * from './ContentBlockCards';
 export * from './ContentBlockMedia';
 export * from './ContentBlockMixed';
 export * from './ContentBlockSegmented';

--- a/packages/react/src/patterns/sections/CardSectionImages/__stories__/CardSectionImages.stories.js
+++ b/packages/react/src/patterns/sections/CardSectionImages/__stories__/CardSectionImages.stories.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { object, select, text, withKnobs } from '@storybook/addon-knobs';
 import cards from '../../../sub-patterns/CardGroup/__stories__/data/cards.json';
 import CardSectionImages from '../CardSectionImages';
@@ -25,7 +32,7 @@ storiesOf('Patterns (Sections)|CardSectionImages', module)
       <CardSectionImages
         heading={text('Heading (required):', 'Aliquam condimentum interdum')}
         theme={select('theme', themes, themes.white)}
-        cards={object('Data', cards.CardSectionImages)}
+        cards={object('Data', cards.Images)}
       />
     );
   });

--- a/packages/react/src/patterns/sections/CardSectionSimple/__stories__/CardSectionSimple.stories.js
+++ b/packages/react/src/patterns/sections/CardSectionSimple/__stories__/CardSectionSimple.stories.js
@@ -45,7 +45,7 @@ storiesOf('Patterns (Sections)|CardSectionSimple', module)
       <CardSectionSimple
         heading={text('Heading (required):', 'Aliquam condimentum interdum')}
         theme={select('theme', themes, themes.white)}
-        cards={object('Data', cards.CardSectionSimple)}
+        cards={object('Data', cards.Simple)}
         cta={toggleCTA && cta}
       />
     );

--- a/packages/react/src/patterns/sub-patterns/CardGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/CardGroup/README.md
@@ -43,10 +43,10 @@ Add the following line on your `.env` file at the root of your project,
 
 ## Props
 
-| Name    | Required | Data Type | Default Value | Description                                                                                                                                                                         |
-| ------- | -------- | --------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cards` | YES      | Array     | null          | Array of objects. See [Cards props](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/patterns/sub-patterns/CardGroup#card-props---simple). |
-| `cta`   | NO       | Object    | null          | Optional CTA card for group. Always displays as last item.                                                                                                                          |
+| Name    | Required | Data Type | Default Value | Description                                                                                                                                                                        |
+| ------- | -------- | --------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cards` | YES      | Array     | null          | Array of objects. See [Card props](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/patterns/sub-patterns/CardGroup#card-props---simple). |
+| `cta`   | NO       | Object    | null          | Optional CTA card for group. Always displays as last item.                                                                                                                         |
 
 ### Card props - simple
 

--- a/packages/react/src/patterns/sub-patterns/CardGroup/__stories__/CardGroup.stories.js
+++ b/packages/react/src/patterns/sub-patterns/CardGroup/__stories__/CardGroup.stories.js
@@ -24,7 +24,7 @@ storiesOf('Patterns (Sub-Patterns)|CardGroup', module)
   .add('default', () => {
     const cardTypes = Object.keys(cards);
 
-    const type = select('Card type', cardTypes, cardTypes[0]);
+    const type = select('Card (type)', cardTypes, cardTypes[0]);
     const data = object(`Data (${type})`, cards[type]);
 
     cards[type] = data;

--- a/packages/react/src/patterns/sub-patterns/CardGroup/__stories__/data/cards.json
+++ b/packages/react/src/patterns/sub-patterns/CardGroup/__stories__/data/cards.json
@@ -1,5 +1,5 @@
 {
-  "CardSectionSimple": [
+  "Simple": [
     {
       "heading": "Nunc convallis lobortis",
       "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
@@ -36,7 +36,7 @@
       }
     }
   ],
-  "CardSectionImages": [
+  "Images": [
     {
       "image": {
         "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",

--- a/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-block/_content-block.scss
@@ -12,7 +12,6 @@
 
 @mixin content-block {
   .#{$prefix}--content-block {
-    // Do the following spacing really belong on the content-block, or more on a section level?
     padding-top: $carbon--layout-03;
     padding-bottom: $carbon--layout-05;
 
@@ -24,7 +23,6 @@
     @include carbon--breakpoint('max') {
       padding-bottom: $carbon--layout-07;
     }
-    //---
 
     &__heading,
     &__copy {


### PR DESCRIPTION
### Related Ticket(s)

#1855 

### Description

This adds the new pattern `ContentBlockCards`.

### Changelog

**New**

- `ContentBlockCards` pattern


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
