### PR TITLE
chore(docs): update readme code examples

### DIFF
--- a/packages/react/src/components/CTA/README.md
+++ b/packages/react/src/components/CTA/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,7 +21,9 @@ Here's a quick example to get you started.
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
 
-### Text Link
+##### JS
+
+##### Text Link
 
 ```javascript
 import React from 'react';
@@ -41,7 +45,7 @@ function App() {
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
-### Video Link
+##### Video Link
 
 ```javascript
 import React from 'react';
@@ -65,7 +69,7 @@ function App() {
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
-### Feature Card
+##### Feature Card
 
 ```javascript
 import React from 'react';
@@ -97,7 +101,7 @@ function App() {
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
-### Button(s)
+##### Button(s)
 
 ```javascript
 import React from 'react';
@@ -134,7 +138,7 @@ function App() {
 }
 ```
 
-### Card
+##### Card
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/DotcomShell/README.md
+++ b/packages/react/src/components/DotcomShell/README.md
@@ -5,7 +5,9 @@
 
 ## Getting started
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,7 +21,9 @@
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
 
-### Content
+##### JS
+
+##### Content
 
 ```javascript
 import React from 'react';
@@ -34,7 +38,7 @@ const content = (
 export default content;
 ```
 
-### DotcomShell
+##### DotcomShell
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/ExpressiveModal/README.md
+++ b/packages/react/src/components/ExpressiveModal/README.md
@@ -12,7 +12,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -24,6 +26,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ExpressiveModal styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/Footer/README.md
+++ b/packages/react/src/components/Footer/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -18,6 +20,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Footer styles
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/HorizontalRule/README.md
+++ b/packages/react/src/components/HorizontalRule/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the HorizontalRule
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/Image/README.md
+++ b/packages/react/src/components/Image/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Image styles
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/ImageWithCaption/README.md
+++ b/packages/react/src/components/ImageWithCaption/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ImageWithCaption styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/LightboxMediaViewer/README.md
+++ b/packages/react/src/components/LightboxMediaViewer/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,7 +21,9 @@ Here's a quick example to get you started.
 > LightBoxMediaViewer styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
 
-### Image Media
+##### JS
+
+##### Image Media
 
 ```javascript
 import React from 'react';
@@ -41,7 +45,7 @@ function App() {
       ),
       description: text(
         'description (required)',
-        `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Here are some common categories:`
+        `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.Mauris iaculis eget dolor nec hendrerit.`
       ),
       type: 'image',
     }
@@ -52,7 +56,7 @@ function App() {
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```
 
-### Video Media
+##### Video Media
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/LinkWithIcon/README.md
+++ b/packages/react/src/components/LinkWithIcon/README.md
@@ -6,7 +6,9 @@
 
 ## Getting started
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -18,6 +20,8 @@
 > 💡 Only import fonts once per usage. Don't forget to import the LinkWithIcon
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/LocaleModal/README.md
+++ b/packages/react/src/components/LocaleModal/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the LocaleModal
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/Masthead/README.md
+++ b/packages/react/src/components/Masthead/README.md
@@ -8,7 +8,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Masthead
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/components/VideoPlayer/README.md
+++ b/packages/react/src/components/VideoPlayer/README.md
@@ -9,7 +9,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 ```
 
 > 💡 Only import fonts once per usage
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentBlockMedia/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockMedia/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentBlockMedia styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/README.md
@@ -8,7 +8,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -21,6 +23,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentBlockMixed styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentBlockSegmented styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentBlockSimple styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentGroupCards/README.md
+++ b/packages/react/src/patterns/blocks/ContentGroupCards/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentGroupCards styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentGroupPictograms/README.md
+++ b/packages/react/src/patterns/blocks/ContentGroupPictograms/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentGroupPictograms styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/ContentGroupSimple/README.md
+++ b/packages/react/src/patterns/blocks/ContentGroupSimple/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > ContentGroupSimple styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/FeatureCard/README.md
+++ b/packages/react/src/patterns/blocks/FeatureCard/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -18,6 +20,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the FeatureCard
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/blocks/LogoGrid/README.md
+++ b/packages/react/src/patterns/blocks/LogoGrid/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the LogoGrid
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sections/CardSectionImages/README.md
+++ b/packages/react/src/patterns/sections/CardSectionImages/README.md
@@ -7,13 +7,17 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
 ```
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sections/CardSectionSimple/README.md
+++ b/packages/react/src/patterns/sections/CardSectionSimple/README.md
@@ -7,13 +7,17 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
 ```
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sections/LeadSpace/README.md
+++ b/packages/react/src/patterns/sections/LeadSpace/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Leadspace
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sections/SimpleBenefits/README.md
+++ b/packages/react/src/patterns/sections/SimpleBenefits/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the SimpleBenefits
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sections/SimpleOverview/README.md
+++ b/packages/react/src/patterns/sections/SimpleOverview/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the SimpleOverview
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/ButtonGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/ButtonGroup/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -24,6 +26,8 @@ Here's a quick example to get you started.
 
 This is the base example 'ButtonGroup'. Note, the buttons will not resize based
 on text size.
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/Callout/README.md
+++ b/packages/react/src/patterns/sub-patterns/Callout/README.md
@@ -4,7 +4,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -16,6 +18,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Callout styles
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/Card/README.md
+++ b/packages/react/src/patterns/sub-patterns/Card/README.md
@@ -8,7 +8,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Card styles
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/CardGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/CardGroup/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -20,6 +22,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the card-group
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -23,6 +25,8 @@ Here's a quick example to get you started.
 ### Base example
 
 This is the base example of 'ContentBlock'.
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentGroup/README.md
@@ -4,7 +4,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -16,6 +18,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the ContentGroup
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/ContentItem/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentItem/README.md
@@ -4,7 +4,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -16,6 +18,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the ContentItem
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/ContentSection/README.md
+++ b/packages/react/src/patterns/sub-patterns/ContentSection/README.md
@@ -4,7 +4,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -16,6 +18,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the ContentSection
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/Layout/README.md
+++ b/packages/react/src/patterns/sub-patterns/Layout/README.md
@@ -7,7 +7,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -19,6 +21,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Layout styles
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/LinkList/README.md
+++ b/packages/react/src/patterns/sub-patterns/LinkList/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -18,6 +20,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the LinkList
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';

--- a/packages/react/src/patterns/sub-patterns/PictogramItem/README.md
+++ b/packages/react/src/patterns/sub-patterns/PictogramItem/README.md
@@ -4,7 +4,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -16,6 +18,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the PictogramItem
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import { Desktop } from '@carbon/pictograms-react';

--- a/packages/react/src/patterns/sub-patterns/Quote/README.md
+++ b/packages/react/src/patterns/sub-patterns/Quote/README.md
@@ -4,7 +4,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -16,6 +18,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the Quote styles
 > from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import { Desktop } from '@carbon/pictograms-react';

--- a/packages/react/src/patterns/sub-patterns/TableOfContents/README.md
+++ b/packages/react/src/patterns/sub-patterns/TableOfContents/README.md
@@ -6,7 +6,9 @@
 
 Here's a quick example to get you started.
 
-```scss
+##### CSS
+
+```css
 // yourapplication.scss
 @import '@carbon/type/scss/font-face/mono';
 @import '@carbon/type/scss/font-face/sans';
@@ -18,6 +20,8 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the
 > TableOfContents styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+##### JS
 
 ```javascript
 import React from 'react';


### PR DESCRIPTION
### Description

Updates React component and pattern README.

### Changelog

**Changed**

- update README code example markdown to properly show syntax highlighting
- better visual separation of css/js code examples


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
