### PR TITLE
fix(card-section): adding style imports for cardsection patterns

### DIFF
--- a/packages/react/src/patterns/blocks/index.js
+++ b/packages/react/src/patterns/blocks/index.js
@@ -11,5 +11,6 @@ export * from './ContentBlockSegmented';
 export * from './ContentBlockSimple';
 export * from './ContentGroupCards';
 export * from './ContentGroupPictograms';
+export * from './ContentGroupSimple';
 export * from './FeatureCard';
 export * from './LogoGrid';

--- a/packages/react/src/patterns/sections/CardSectionImages/README.md
+++ b/packages/react/src/patterns/sections/CardSectionImages/README.md
@@ -15,6 +15,8 @@ Here's a quick example to get you started.
 @import '@carbon/type/scss/font-face/sans';
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
+
+@include '@carbon/ibmdotcom-styles/scss/patterns/sections/card-section-images/card-section-images';
 ```
 
 ##### JS

--- a/packages/react/src/patterns/sections/CardSectionSimple/README.md
+++ b/packages/react/src/patterns/sections/CardSectionSimple/README.md
@@ -15,6 +15,8 @@ Here's a quick example to get you started.
 @import '@carbon/type/scss/font-face/sans';
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
+
+@include '@carbon/ibmdotcom-styles/scss/patterns/sections/card-section-images/card-section-simple';
 ```
 
 ##### JS

--- a/packages/react/src/patterns/sub-patterns/index.js
+++ b/packages/react/src/patterns/sub-patterns/index.js
@@ -6,13 +6,15 @@
  */
 
 export * from './ButtonGroup';
+export * from './Callout';
 export * from './Card';
 export * from './CardGroup';
 export * from './ContentBlock';
-export * from './ContentItem';
 export * from './ContentGroup';
+export * from './ContentItem';
 export * from './ContentSection';
 export * from './Layout';
 export * from './LinkList';
 export * from './PictogramItem';
+export * from './Quote';
 export * from './TableOfContents';

--- a/packages/styles/scss/ibm-dotcom-styles.scss
+++ b/packages/styles/scss/ibm-dotcom-styles.scss
@@ -15,12 +15,16 @@
 @import 'components/footer/index';
 @import 'components/horizontalrule/horizontalrule';
 @import 'components/image/image';
+@import 'components/image-with-caption/image-with-caption';
 @import 'components/lightbox-media-viewer/lightbox-media-viewer';
 @import 'components/link-with-icon/link-with-icon';
 @import 'components/locale-modal/locale-modal';
 @import 'components/masthead/index';
+@import 'components/video-player/video-player';
 
 // Patterns - Sections
+@import 'patterns/sections/card-section-images/card-section-images';
+@import 'patterns/sections/card-section-simple/card-section-simple';
 @import 'patterns/sections/leadspace/leadspace';
 @import 'patterns/sections/simplebenefits/simplebenefits';
 @import 'patterns/sections/simpleoverview/simpleoverview';
@@ -38,15 +42,18 @@
 
 // Patterns - Sub-Patterns
 @import 'patterns/sub-patterns/buttongroup/buttongroup';
+@import 'patterns/sub-patterns/callout/callout';
 @import 'patterns/sub-patterns/card/index';
 @import 'patterns/sub-patterns/card-group/card-group';
-@import 'patterns/sub-patterns/callout/callout';
+@import 'patterns/sub-patterns/content-block/content-block';
+@import 'patterns/sub-patterns/content-item/content-item';
 @import 'patterns/sub-patterns/content-group/content-group';
 @import 'patterns/sub-patterns/content-section/content-section';
 @import 'patterns/sub-patterns/layout/layout';
 @import 'patterns/sub-patterns/link-list/index';
-@import 'patterns/sub-patterns/tableofcontents/tableofcontents';
+@import 'patterns/sub-patterns/pictogram-item/pictogram-item';
 @import 'patterns/sub-patterns/quote/quote';
+@import 'patterns/sub-patterns/tableofcontents/tableofcontents';
 
 // Temporary Expressive
 @import 'temp-carbon-expressive/accordion/accordion-expressive';

--- a/packages/styles/scss/patterns/sections/card-section-images/_card-section-images.scss
+++ b/packages/styles/scss/patterns/sections/card-section-images/_card-section-images.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../globals/imports';
+@import '../../sub-patterns/content-section/content-section';
+@import '../../sub-patterns/card-group/card-group';

--- a/packages/styles/scss/patterns/sections/card-section-simple/_card-section-simple.scss
+++ b/packages/styles/scss/patterns/sections/card-section-simple/_card-section-simple.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../../globals/imports';
+@import '../../sub-patterns/content-section/content-section';
+@import '../../sub-patterns/card-group/card-group';


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2322, https://github.com/carbon-design-system/ibm-dotcom-library/issues/2324

### Description

This adds in the discrete style imports for `CardSectionSimple` and `CardSectionImages`

### Changelog

**New**

- style imports for card section