### PR TITLE
feat(contentblocksimple): added inverse theme to contentblocksimple

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -16070,6 +16070,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                         }
                       }
                       heading="Curabitur malesuada varius mi eu posuere"
+                      inverse={false}
                       mediaData={
                         Object {
                           "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
@@ -16156,6 +16157,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                         }
                       }
                       heading="Curabitur malesuada varius mi eu posuere"
+                      inverse={false}
                       mediaData={
                         Object {
                           "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
@@ -16198,6 +16200,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                             }
                           }
                           heading="Curabitur malesuada varius mi eu posuere"
+                          inverse={false}
                         >
                           <div
                             className="bx--content-block"
@@ -16228,6 +16231,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
 
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
       "
+                                  inverse={false}
                                 >
                                   <div
                                     className="bx--content-item"
@@ -16269,6 +16273,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                         ],
                                       }
                                     }
+                                    inverse={false}
                                   >
                                     <div
                                       className="bx--image-with-caption"

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/ContentBlockSimple.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/ContentBlockSimple.js
@@ -36,14 +36,15 @@ const ContentBlockSimple = ({
   mediaData,
   cta,
   aside,
+  inverse,
 }) => (
   <div
     data-autoid={`${stablePrefix}--content-block-simple`}
     className={`${prefix}--content-block-simple`}>
-    <ContentBlock heading={heading} cta={cta} aside={aside}>
+    <ContentBlock inverse={inverse} heading={heading} cta={cta} aside={aside}>
       <div className={`${prefix}--content-block-simple__content`}>
-        <ContentItem copy={copy} />
-        {_renderMedia(mediaType, mediaData)}
+        <ContentItem inverse={inverse} copy={copy} />
+        {_renderMedia(mediaType, mediaData, inverse)}
       </div>
     </ContentBlock>
   </div>
@@ -54,15 +55,16 @@ const ContentBlockSimple = ({
  *
  * @param {string} type cta type ( external | jump | local)
  * @param {object} data cta type ( external | jump | local)
+ * @param {boolean} inverse inverse theme
  * @private
  * @returns {*} media component
  */
-const _renderMedia = (type, data) => {
+const _renderMedia = (type, data, inverse) => {
   if (data) {
     return (
       <div data-autoid={`${stablePrefix}--content-block-simple__media`}>
-        {type === 'image' && <ImageWithCaption {...data} />}
-        {type === 'video' && <VideoPlayer {...data} />}
+        {type === 'image' && <ImageWithCaption inverse={inverse} {...data} />}
+        {type === 'video' && <VideoPlayer inverse={inverse} {...data} />}
       </div>
     );
   }
@@ -75,6 +77,7 @@ ContentBlockSimple.propTypes = {
   mediaData: PropTypes.object,
   cta: PropTypes.object,
   aside: PropTypes.object,
+  inverse: PropTypes.bool,
 };
 
 export default ContentBlockSimple;

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/README.md
@@ -57,6 +57,7 @@ function App() {
 
   return (
     <ContentBlockSimple
+      inverse={false}
       heading={heading}
       copy={copy}
       mediaType={mediaType}
@@ -89,6 +90,7 @@ Add the following line on your `.env` file at the root of your project,
 | `mediaData` | NO       | Object    | n/a           | Media Data for either image or video. See the [`ImageWithCaption`](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/ImageWithCaption) or [`VideoPlayer`](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/VideoPlayer) component for full usage details. |
 | `cta`       | NO       | Object    | n/a           | CTA used at the end of content body. `Text` and `Card` styles supported.                                                                                                                                                                                                                                                                                         |
 | `aside`     | NO       | Object    | n/a           | Elements to be rendered on right panel of the content block. See `ContentBlock` README for more info.                                                                                                                                                                                                                                                            |
+| `inverse`   | NO       | Boolean   | `false`       | Changes theme to inverse/default                                                                                                                                                                                                                                                                                                                                 |
 
 ## Stable selectors
 

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
@@ -7,10 +7,14 @@ import {
   boolean,
 } from '@storybook/addon-knobs';
 import ContentBlockSimple from '../ContentBlockSimple';
+import cx from 'classnames';
 import { LinkList } from '../../../sub-patterns/LinkList';
 import React from 'react';
 import readme from '../README.md';
+import { settings } from 'carbon-components';
 import { storiesOf } from '@storybook/react';
+
+const { prefix } = settings;
 
 storiesOf('Patterns (Blocks)|ContentBlockSimple', module)
   .addDecorator(withKnobs)
@@ -86,11 +90,17 @@ storiesOf('Patterns (Blocks)|ContentBlockSimple', module)
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
       `;
 
+    const inverse = boolean('inverse', false);
+
     return (
-      <div className="bx--grid">
+      <div
+        className={cx('bx--grid', {
+          [`${prefix}--content-block-simple--inverse`]: inverse,
+        })}>
         <div className="bx--row">
           <div className="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4 content-block-story">
             <ContentBlockSimple
+              inverse={inverse}
               copy={copy}
               heading={text(
                 'Heading (required)',

--- a/packages/styles/scss/patterns/blocks/content-block-simple/_content-block-simple.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-simple/_content-block-simple.scss
@@ -5,6 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 @mixin content-block-simple {
+  .#{$prefix}--content-block-simple--inverse {
+    background-color: $inverse-02;
+  }
   .#{$prefix}--content-block {
     // empty for now
   }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2212

Adds the inverse theme for Content Block Simple

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
