### PR TITLE
chore(components): fix prop types

### DIFF
--- a/packages/react/src/components/DotcomShell/DotcomShell.js
+++ b/packages/react/src/components/DotcomShell/DotcomShell.js
@@ -50,8 +50,8 @@ DotcomShell.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
-  footerProps: PropTypes.oneOf(PropTypes.shape(Footer.propTypes)),
-  mastheadProps: PropTypes.oneOf(PropTypes.shape(Masthead.propTypes)),
+  footerProps: PropTypes.shape(Footer.propTypes),
+  mastheadProps: PropTypes.shape(Masthead.propTypes),
 };
 
 /**

--- a/packages/react/src/patterns/blocks/CalloutWithMedia/CalloutWithMedia.js
+++ b/packages/react/src/patterns/blocks/CalloutWithMedia/CalloutWithMedia.js
@@ -8,7 +8,6 @@
 import { Callout } from '../../sub-patterns';
 import { ContentBlockSimple } from '../ContentBlockSimple';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
-import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
 
@@ -32,8 +31,6 @@ const CalloutWithMedia = ({ ...ContentBlockSimpleProps }) => {
   );
 };
 
-CalloutWithMedia.propTypes = PropTypes.oneOf(
-  PropTypes.shape(ContentBlockSimple.propTypes)
-);
+CalloutWithMedia.propTypes = ContentBlockSimple.propTypes;
 
 export default CalloutWithMedia;

--- a/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
+++ b/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
@@ -147,7 +147,7 @@ LeadSpace.propTypes = {
   buttons: PropTypes.array,
   copy: PropTypes.string,
   gradient: PropTypes.bool,
-  image: PropTypes.oneOfType(PropTypes.shape(Image.propTypes)),
+  image: PropTypes.shape(Image.propTypes),
   theme: PropTypes.string,
   title: PropTypes.string.isRequired,
   type: PropTypes.oneOf(['small', 'left', 'centered']),

--- a/packages/react/src/patterns/sub-patterns/CardGroup/CardGroup.js
+++ b/packages/react/src/patterns/sub-patterns/CardGroup/CardGroup.js
@@ -123,7 +123,7 @@ const _renderCards = (cards, containerRef, cta) => (
 
 CardGroup.propTypes = {
   cards: PropTypes.arrayOf(PropTypes.shape(Card.propTypes)),
-  cta: PropTypes.oneOfType(PropTypes.shape(Card.propTypes)),
+  cta: PropTypes.shape(Card.propTypes),
 };
 
 export default CardGroup;

--- a/packages/react/src/patterns/sub-patterns/ContentItem/ContentItem.js
+++ b/packages/react/src/patterns/sub-patterns/ContentItem/ContentItem.js
@@ -97,7 +97,7 @@ const _renderMedia = (type, data, inverse) => {
 };
 
 ContentItem.propTypes = {
-  cta: PropTypes.oneOfType(PropTypes.shape(CTA.propTypes)),
+  cta: PropTypes.shape(CTA.propTypes),
   customClassName: PropTypes.string,
   copy: PropTypes.string,
   heading: PropTypes.string,


### PR DESCRIPTION

### Related Ticket(s)

Fixes #2347.

### Description

This change attempts to fix React prop type warnings for prop type definitions for props that are passed along to child components.

### Changelog

**Changed**

- Prop type definitions for:
  - `footerProps`/`mastheadProps` in `<DotcomShell>`
  - Ones in `<CalloutWithMedia>`
  - `image` in `<LeadSpace>`
  - `cta` in `<CardGroup>`
  - `cta` in `<ContentItem>`