### PR TITLE
fix(percy): hiding cookie preferences in percy output

### DIFF
--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -32,3 +32,9 @@
 .bx--visually-hidden {
   display: none;
 }
+
+@media only percy {
+  #truste_cookie_prefs {
+    display: none;
+  }
+}

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -33,8 +33,7 @@
   display: none;
 }
 
-@media only percy {
-  #teconsent {
-    display: none;
-  }
+// hide the cookie button
+#teconsent {
+  display: none;
 }

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -34,7 +34,7 @@
 }
 
 @media only percy {
-  #truste_cookie_prefs {
+  #teconsent {
     display: none;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

#2353 

### Description

This removed the floating cookie preferences button, which is causing some false positives.

### Changelog

**Changed**

- Added class to suppress cookie button in percy