### PR TITLE
fix(percy): hiding cookie preferences in footer in percy output

### DIFF
--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -37,3 +37,9 @@
 #teconsent {
   display: none;
 }
+
+@media only percy {
+  [data-autoid='dds--privacy-cp'] {
+    visibility: hidden;
+  }
+}

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -35,7 +35,7 @@
 
 // hide the cookie button
 #teconsent {
-  display: none;
+  visibility: hidden;
 }
 
 @media only percy {


### PR DESCRIPTION
### Related Ticket(s)

#2353 

### Description

Still noticing the cookie link appearing. This also will suppress the cookie link in the footer as it seems to switch between "Cookie Preferences" and "Cookie Preferences and Do Not Share My Info".

### Changelog

**Changed**

- Hiding cookie link in Percy