### PR TITLE
Fix/localemodal

### DIFF
--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -33,6 +33,9 @@
         position: relative;
       }
     }
+    svg.#{$prefix}--card__cta {
+      color: $ui-05;
+    }
   }
 
   .#{$prefix}--locale-modal-container .#{$prefix}--modal-container {


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/1979

### Description

Changed the arrow icons to gray100 instead of blue (locale modal)

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
