### PR TITLE
fix(masthead): fix build error

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -180,7 +180,9 @@ $search-transition-timing: 95ms;
   }
 
   @include carbon--breakpoint-down(lg) {
-    display: none;
+    .#{$prefix}--masthead__l1 {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Refs #2198.

### Description

This change attempts to fix the build error that is observed by incorporating the full set of masthead styles. The issue is observed by creating code with `@import '@carbon/ibmdotcom-styles/scss/components/masthead/index'` (Replacing code importing `masthead.scss` in `styles.scss` in https://github.com/carbon-design-system/ibm-dotcom-library/compare/master...asudoh:codesandbox), which yields to a Sass build error.

### Changelog

**Changed**

- Add back a missing selector surrounding `display: none`, in `_masthead-l1.scss`.