### PR TITLE
Fix/missing fcblocklarge scss

### DIFF
--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -8,7 +8,7 @@
  *
  */
 const settings = {
-  version: 'dds.v1.6.0',
+  version: 'dds.v1.7.0',
   stablePrefix: 'dds',
 };
 


### PR DESCRIPTION
#1965 # Description

Missing scss file for Feature Card Block Large in ibm-dotcom-styles.scss

### Changelog

**Changed**

- line added to ibm-dotcom-styles.scss

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
