### PR TITLE
chore(content-block): specifying CTA prop in the pattern

### DIFF
--- a/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/ContentBlock.js
@@ -149,7 +149,7 @@ ContentBlock.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  cta: PropTypes.object,
+  cta: PropTypes.shape(CTA.propTypes),
   customClassName: PropTypes.string,
   aside: PropTypes.shape({
     items: PropTypes.element,


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Change the Content block based on the Solution page designs and updated functions specs #1847

### Description

Turning the `ContentBlock` proptypes declaration for the `CTA` component more specific.  

### Changelog

**Changed**

- `ContentBlock` proptype from `cta: PropTypes.object` to `cta: PropTypes.shape(CTA.propType)`;