### PR TITLE
fix(image-with-caption): remove border for mobile devices

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -14761,12 +14761,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                             "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
 
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "cta": Object {
+                              "copy": "Lorem Ipsum dolor sit",
+                              "href": "https://example.com",
+                              "type": "local",
+                            },
                             "heading": "Lorem ipsum dolor sit amet.",
                           },
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
 
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "cta": Object {
+                              "copy": "Lorem Ipsum dolor sit",
+                              "href": "https://example.com",
+                              "type": "local",
+                            },
                             "heading": "Lorem ipsum dolor sit amet.",
                             "image": Object {
                               "heading": "Mauris iaculis eget dolor nec hendrerit.",
@@ -14877,12 +14887,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                             "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
 
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "cta": Object {
+                              "copy": "Lorem Ipsum dolor sit",
+                              "href": "https://example.com",
+                              "type": "local",
+                            },
                             "heading": "Lorem ipsum dolor sit amet.",
                           },
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
 
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.",
+                            "cta": Object {
+                              "copy": "Lorem Ipsum dolor sit",
+                              "href": "https://example.com",
+                              "type": "local",
+                            },
                             "heading": "Lorem ipsum dolor sit amet.",
                             "image": Object {
                               "heading": "Mauris iaculis eget dolor nec hendrerit.",
@@ -15067,6 +15087,14 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                 </ImageWithCaption>
                               </div>
                               <ContentGroup
+                                cta={
+                                  Object {
+                                    "copy": "Lorem Ipsum dolor sit",
+                                    "href": "https://example.com",
+                                    "style": "text",
+                                    "type": "local",
+                                  }
+                                }
                                 heading="Lorem ipsum dolor sit amet."
                                 key="0"
                               >
@@ -15110,9 +15138,100 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                       </ContentItem>
                                     </div>
                                   </div>
+                                  <div
+                                    className="bx--content-group__cta-row"
+                                    data-autoid="dds--content-group__cta"
+                                  >
+                                    <CTA
+                                      copy="Lorem Ipsum dolor sit"
+                                      customClassName="bx--content-group__cta"
+                                      href="https://example.com"
+                                      style="text"
+                                      type="local"
+                                    >
+                                      <div
+                                        className="bx--content-group__cta"
+                                      >
+                                        <TextCTA
+                                          copy="Lorem Ipsum dolor sit"
+                                          href="https://example.com"
+                                          openLightBox={[Function]}
+                                          renderLightBox={false}
+                                          style="text"
+                                          type="local"
+                                          videoTitle={
+                                            Array [
+                                              Object {
+                                                "key": 0,
+                                                "title": "",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <LinkWithIcon
+                                            href="https://example.com"
+                                            onClick={[Function]}
+                                            target={null}
+                                          >
+                                            <div
+                                              className="bx--link-with-icon__container"
+                                              data-autoid="dds--link-with-icon"
+                                            >
+                                              <Link
+                                                className="bx--link-with-icon"
+                                                href="https://example.com"
+                                                onClick={[Function]}
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--link-with-icon"
+                                                  href="https://example.com"
+                                                  onClick={[Function]}
+                                                  target={null}
+                                                >
+                                                  Lorem Ipsum dolor sit
+                                                  <ForwardRef(ArrowRight20)>
+                                                    <Icon
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <polygon
+                                                          points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ArrowRight20)>
+                                                </a>
+                                              </Link>
+                                            </div>
+                                          </LinkWithIcon>
+                                        </TextCTA>
+                                      </div>
+                                    </CTA>
+                                  </div>
                                 </div>
                               </ContentGroup>
                               <ContentGroup
+                                cta={
+                                  Object {
+                                    "copy": "Lorem Ipsum dolor sit",
+                                    "href": "https://example.com",
+                                    "style": "text",
+                                    "type": "local",
+                                  }
+                                }
                                 heading="Lorem ipsum dolor sit amet."
                                 key="1"
                               >
@@ -15244,6 +15363,89 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                         </ImageWithCaption>
                                       </div>
                                     </div>
+                                  </div>
+                                  <div
+                                    className="bx--content-group__cta-row"
+                                    data-autoid="dds--content-group__cta"
+                                  >
+                                    <CTA
+                                      copy="Lorem Ipsum dolor sit"
+                                      customClassName="bx--content-group__cta"
+                                      href="https://example.com"
+                                      style="text"
+                                      type="local"
+                                    >
+                                      <div
+                                        className="bx--content-group__cta"
+                                      >
+                                        <TextCTA
+                                          copy="Lorem Ipsum dolor sit"
+                                          href="https://example.com"
+                                          openLightBox={[Function]}
+                                          renderLightBox={false}
+                                          style="text"
+                                          type="local"
+                                          videoTitle={
+                                            Array [
+                                              Object {
+                                                "key": 0,
+                                                "title": "",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <LinkWithIcon
+                                            href="https://example.com"
+                                            onClick={[Function]}
+                                            target={null}
+                                          >
+                                            <div
+                                              className="bx--link-with-icon__container"
+                                              data-autoid="dds--link-with-icon"
+                                            >
+                                              <Link
+                                                className="bx--link-with-icon"
+                                                href="https://example.com"
+                                                onClick={[Function]}
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--link-with-icon"
+                                                  href="https://example.com"
+                                                  onClick={[Function]}
+                                                  target={null}
+                                                >
+                                                  Lorem Ipsum dolor sit
+                                                  <ForwardRef(ArrowRight20)>
+                                                    <Icon
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <polygon
+                                                          points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ArrowRight20)>
+                                                </a>
+                                              </Link>
+                                            </div>
+                                          </LinkWithIcon>
+                                        </TextCTA>
+                                      </div>
+                                    </CTA>
                                   </div>
                                 </div>
                               </ContentGroup>
@@ -15892,6 +16094,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                         </ImageWithCaption>
                                       </div>
                                       <ContentGroup
+                                        cta={false}
                                         heading="Lorem ipsum dolor sit amet."
                                         key="0"
                                       >
@@ -15938,6 +16141,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                         </div>
                                       </ContentGroup>
                                       <ContentGroup
+                                        cta={false}
                                         heading="Lorem ipsum dolor sit amet."
                                         key="1"
                                       >

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/ContentBlockSegmented.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/ContentBlockSegmented.js
@@ -78,7 +78,17 @@ const _renderMedia = (type, data) => {
  */
 const _renderGroup = items =>
   items.map((item, index) => (
-    <ContentGroup heading={item.heading} key={index}>
+    <ContentGroup
+      heading={item.heading}
+      key={index}
+      cta={
+        item.cta && (item.cta.type === 'jump' || item.cta.type === 'local')
+          ? {
+              style: 'text',
+              ...item.cta,
+            }
+          : false
+      }>
       <div
         data-autoid={`${stablePrefix}--content-block-segmented__content-group`}>
         <ContentItem copy={item.copy} key={index} />

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/README.md
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/README.md
@@ -91,11 +91,12 @@ Add the following line in your `.env` file at the root of your project.
 
 ### items
 
-| Name      | Required | Data Type | Description                                                                                                                                                     |
-| --------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `heading` | YES      | String    | Short copy describing content item.                                                                                                                             |
-| `image`   | NO       | Object    | See the [`Image`](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Image) component for full usage details. |
-| `copy`    | YES      | String    | Item content.                                                                                                                                                   |
+| Name      | Required | Data Type | Description                                                                                                                                                                                                             |
+| --------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `heading` | YES      | String    | Short copy describing content item.                                                                                                                                                                                     |
+| `image`   | NO       | Object    | See the [`Image`](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/Image) component for full usage details.                                                         |
+| `cta`     | NO       | Object    | `jump` and `local` types are allowed, for more information, see the [`CTA`](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/src/components/CTA) component for full usage details. |
+| `copy`    | YES      | String    | Item content.                                                                                                                                                                                                           |
 
 ## Stable selectors
 

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -99,6 +99,11 @@ export const Default = () => {
       copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
 
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.`,
+      cta: {
+        type: 'local',
+        copy: 'Lorem Ipsum dolor sit',
+        href: 'https://example.com',
+      },
     },
     {
       heading: 'Lorem ipsum dolor sit amet.',
@@ -106,6 +111,11 @@ export const Default = () => {
       copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
 
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.`,
+      cta: {
+        type: 'local',
+        copy: 'Lorem Ipsum dolor sit',
+        href: 'https://example.com',
+      },
     },
   ];
 

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__tests__/ContentBlockSegmented.test.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__tests__/ContentBlockSegmented.test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ContentBlockSegmented from '../ContentBlockSegmented';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+describe('ContentBlockSegmented', () => {
+  it('renders as expected', () => {
+    const items = [
+      {
+        heading: 'Lorem ipsum dolor sit amet.',
+        copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
+
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.`,
+        cta: {
+          type: 'local',
+          copy: 'Lorem Ipsum dolor sit',
+          href: 'https://example.com',
+        },
+      },
+    ];
+
+    const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.`;
+
+    const image = {
+      heading: 'Mauris iaculis eget dolor nec hendrerit.',
+      image: {
+        sources: [
+          {
+            src: 'https://dummyimage.com/320x180/ee5396/161616&text=16:9',
+            breakpoint: 320,
+          },
+          {
+            src: 'https://dummyimage.com/400x225/ee5396/161616&text=16:9',
+            breakpoint: 400,
+          },
+          {
+            src: 'https://dummyimage.com/672x378/ee5396/161616&text=16:9',
+            breakpoint: 672,
+          },
+        ],
+        alt: 'Image alt text',
+        defaultSrc: 'https://dummyimage.com/672x378/ee5396/161616&text=16:9',
+      },
+    };
+
+    const component = shallow(
+      <ContentBlockSegmented
+        items={items}
+        heading="Lorem ipsum dolor sit amet"
+        copy={copy}
+        mediaType="image"
+        mediaData={image}
+      />
+    );
+
+    expect(component.find('.bx--content-block-segmented')).toHaveLength(1);
+    expect(
+      component.find('[data-autoid="dds--content-block-segmented__media"]')
+    ).toHaveLength(1);
+    expect(
+      component.find(
+        '[data-autoid="dds--content-block-segmented__content-group"]'
+      )
+    ).toHaveLength(1);
+  });
+});

--- a/packages/styles/scss/components/image-with-caption/image-with-caption.scss
+++ b/packages/styles/scss/components/image-with-caption/image-with-caption.scss
@@ -25,6 +25,7 @@
       padding: 0;
       position: relative;
       pointer-events: none;
+      border: none;
     }
 
     &__zoom-button {

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -180,7 +180,9 @@ $search-transition-timing: 95ms;
   }
 
   @include carbon--breakpoint-down(lg) {
-    display: none;
+    .#{$prefix}--masthead__l1 {
+      display: none;
+    }
   }
 }
 

--- a/packages/styles/scss/patterns/blocks/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-segmented/_content-block-segmented.scss
@@ -14,6 +14,14 @@
         margin-top: $carbon--layout-05;
         margin-bottom: $carbon--layout-05;
       }
+
+      @include carbon--breakpoint('xlg') {
+        margin-top: $carbon--layout-06;
+      }
+
+      &__cta {
+        margin-top: -$layout-02;
+      }
     }
   }
 }

--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -8,7 +8,7 @@
  *
  */
 const settings = {
-  version: 'dds.v1.6.0',
+  version: 'dds.v1.7.0',
   stablePrefix: 'dds',
 };
 


### PR DESCRIPTION
### Related Ticket(s)

Component: Image with Caption:- On mobile and tablet image is displayed in oval shape #2444

### Description

Seems like the default browser border styles for buttons is being applied - overwriting that and setting border to none

### Changelog

**New**

- set `border` to `none`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
