### PR TITLE
fix(image-with-caption): set button border style to none to resolve rounding in mobile

### DIFF
--- a/packages/styles/scss/components/image-with-caption/image-with-caption.scss
+++ b/packages/styles/scss/components/image-with-caption/image-with-caption.scss
@@ -25,6 +25,7 @@
       padding: 0;
       position: relative;
       pointer-events: none;
+      border: none;
     }
 
     &__zoom-button {


### PR DESCRIPTION
### Related Ticket(s)

Component: Image with Caption:- On mobile and tablet image is displayed in oval shape #2444

### Description

Seems like the default browser border styles for buttons is being applied - overwriting that and setting border to none

ISSUE:
![image with caption.jpg](https://images.zenhubusercontent.com/5e21a841639f517d456f7e43/0a7fce42-7bb0-4bdc-83cf-c35d5dcddcd1)

AFTER:
<img width="681" alt="Screen Shot 2020-05-19 at 1 04 38 PM" src="https://user-images.githubusercontent.com/54281166/82356447-937ed980-99d1-11ea-89d9-b77f246e678b.png">

<img width="612" alt="Screen Shot 2020-05-19 at 1 04 59 PM" src="https://user-images.githubusercontent.com/54281166/82356451-95489d00-99d1-11ea-970f-d0f8dab3ae7a.png">


### Changelog

**New**

- set `border` to `none`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
