### PR TITLE
feat(linklist): add linklist variations

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -15211,7 +15211,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                                   onClick={[Function]}
                                                   target={null}
                                                 >
-                                                  Lorem Ipsum dolor sit
+                                                  <span>
+                                                    Lorem Ipsum dolor sit
+                                                  </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
                                                       height={20}
@@ -15437,7 +15439,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                                   onClick={[Function]}
                                                   target={null}
                                                 >
-                                                  Lorem Ipsum dolor sit
+                                                  <span>
+                                                    Lorem Ipsum dolor sit
+                                                  </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
                                                       height={20}

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -135,7 +135,9 @@ exports[`Storyshots Components|CTA Default 1`] = `
                                   onClick={[Function]}
                                   target={null}
                                 >
-                                  Lorem ipsum dolor sit amet
+                                  <span>
+                                    Lorem ipsum dolor sit amet
+                                  </span>
                                   <ForwardRef(ArrowRight20)>
                                     <Icon
                                       height={20}
@@ -8512,6 +8514,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] 
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -8699,6 +8702,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] 
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -8851,6 +8855,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] 
                                     },
                                   ]
                                 }
+                                style="card"
                               />,
                             }
                           }
@@ -9994,6 +9999,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] 
                                           },
                                         ]
                                       }
+                                      style="card"
                                     >
                                       <div
                                         className="bx--link-list"
@@ -10005,10 +10011,10 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] 
                                           Tutorials
                                         </h4>
                                         <ul
-                                          className="bx--link-list__list"
+                                          className="bx--link-list__list bx--link-list__list--card"
                                         >
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--local"
                                             key="0"
                                           >
                                             <CTA
@@ -10151,7 +10157,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMedia With aside elements 1`] 
                                             </CTA>
                                           </li>
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--external"
                                             key="1"
                                           >
                                             <CTA
@@ -11489,7 +11495,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                                                   onClick={[Function]}
                                                                   target={null}
                                                                 >
-                                                                  Lorem ipsum dolor
+                                                                  <span>
+                                                                    Lorem ipsum dolor
+                                                                  </span>
                                                                   <ForwardRef(ArrowRight20)>
                                                                     <Icon
                                                                       height={20}
@@ -11680,7 +11688,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                                                   onClick={[Function]}
                                                                   target={null}
                                                                 >
-                                                                  Lorem ipsum dolor
+                                                                  <span>
+                                                                    Lorem ipsum dolor
+                                                                  </span>
                                                                   <ForwardRef(ArrowRight20)>
                                                                     <Icon
                                                                       height={20}
@@ -11870,7 +11880,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                                                   onClick={[Function]}
                                                                   target={null}
                                                                 >
-                                                                  Lorem ipsum dolor
+                                                                  <span>
+                                                                    Lorem ipsum dolor
+                                                                  </span>
                                                                   <ForwardRef(ArrowRight20)>
                                                                     <Icon
                                                                       height={20}
@@ -12342,6 +12354,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -12552,6 +12565,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -12727,6 +12741,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                     },
                                   ]
                                 }
+                                style="card"
                               />,
                             }
                           }
@@ -13577,7 +13592,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                                                           onClick={[Function]}
                                                                           target={null}
                                                                         >
-                                                                          Lorem ipsum dolor
+                                                                          <span>
+                                                                            Lorem ipsum dolor
+                                                                          </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
                                                                               height={20}
@@ -13768,7 +13785,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                                                           onClick={[Function]}
                                                                           target={null}
                                                                         >
-                                                                          Lorem ipsum dolor
+                                                                          <span>
+                                                                            Lorem ipsum dolor
+                                                                          </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
                                                                               height={20}
@@ -13958,7 +13977,9 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                                                           onClick={[Function]}
                                                                           target={null}
                                                                         >
-                                                                          Lorem ipsum dolor
+                                                                          <span>
+                                                                            Lorem ipsum dolor
+                                                                          </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
                                                                               height={20}
@@ -14382,6 +14403,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                           },
                                         ]
                                       }
+                                      style="card"
                                     >
                                       <div
                                         className="bx--link-list"
@@ -14393,10 +14415,10 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                           Tutorials
                                         </h4>
                                         <ul
-                                          className="bx--link-list__list"
+                                          className="bx--link-list__list bx--link-list__list--card"
                                         >
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--local"
                                             key="0"
                                           >
                                             <CTA
@@ -14539,7 +14561,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                             </CTA>
                                           </li>
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--external"
                                             key="1"
                                           >
                                             <CTA
@@ -15467,6 +15489,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -15609,6 +15632,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -15716,6 +15740,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                     },
                                   ]
                                 }
+                                style="card"
                               />,
                             }
                           }
@@ -16244,6 +16269,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           },
                                         ]
                                       }
+                                      style="card"
                                     >
                                       <div
                                         className="bx--link-list"
@@ -16255,10 +16281,10 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           Tutorials
                                         </h4>
                                         <ul
-                                          className="bx--link-list__list"
+                                          className="bx--link-list__list bx--link-list__list--card"
                                         >
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--local"
                                             key="0"
                                           >
                                             <CTA
@@ -16401,7 +16427,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                             </CTA>
                                           </li>
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--external"
                                             key="1"
                                           >
                                             <CTA
@@ -17114,6 +17140,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -17226,6 +17253,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -17303,6 +17331,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                     },
                                   ]
                                 }
+                                style="card"
                               />,
                             }
                           }
@@ -17672,6 +17701,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                           },
                                         ]
                                       }
+                                      style="card"
                                     >
                                       <div
                                         className="bx--link-list"
@@ -17683,10 +17713,10 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                           Tutorials
                                         </h4>
                                         <ul
-                                          className="bx--link-list__list"
+                                          className="bx--link-list__list bx--link-list__list--card"
                                         >
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--local"
                                             key="0"
                                           >
                                             <CTA
@@ -17829,7 +17859,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                             </CTA>
                                           </li>
                                           <li
-                                            className="bx--link-list__list__CTA"
+                                            className="bx--link-list__list__CTA bx--link-list__list--external"
                                             key="1"
                                           >
                                             <CTA
@@ -18685,47 +18715,63 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                         Array [
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin.",
-                            "cta": Array [
-                              Object {
-                                "copy": "Link text",
-                                "href": "https://example.com",
-                                "type": "local",
-                              },
-                              Object {
-                                "copy": "External link text",
-                                "href": "https://example.com",
-                                "type": "external",
-                              },
-                            ],
+                            "cta": Object {
+                              "items": Array [
+                                Object {
+                                  "copy": "Link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "External link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ],
+                            },
                             "eyebrow": "Lorem ipsum",
                             "heading": "Aliquam condimentum",
                           },
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-                            "cta": Array [
-                              Object {
-                                "copy": "Link text",
-                                "href": "https://example.com",
-                                "type": "local",
-                              },
-                              Object {
-                                "copy": "External link text",
-                                "href": "https://example.com",
-                                "type": "external",
-                              },
-                            ],
+                            "cta": Object {
+                              "items": Array [
+                                Object {
+                                  "copy": "Link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "External link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ],
+                            },
                             "eyebrow": "Lorem ipsum",
                             "heading": "Aliquam condimentum",
                           },
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-                            "cta": Array [
-                              Object {
-                                "copy": "Link text",
-                                "href": "https://example.com",
-                                "type": "local",
-                              },
-                            ],
+                            "cta": Object {
+                              "items": Array [
+                                Object {
+                                  "copy": "Link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "local",
+                                },
+                              ],
+                            },
                             "eyebrow": "Lorem ipsum",
                             "heading": "Aliquam condimentum",
                           },
@@ -18777,47 +18823,63 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                         Array [
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin.",
-                            "cta": Array [
-                              Object {
-                                "copy": "Link text",
-                                "href": "https://example.com",
-                                "type": "local",
-                              },
-                              Object {
-                                "copy": "External link text",
-                                "href": "https://example.com",
-                                "type": "external",
-                              },
-                            ],
+                            "cta": Object {
+                              "items": Array [
+                                Object {
+                                  "copy": "Link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "External link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ],
+                            },
                             "eyebrow": "Lorem ipsum",
                             "heading": "Aliquam condimentum",
                           },
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-                            "cta": Array [
-                              Object {
-                                "copy": "Link text",
-                                "href": "https://example.com",
-                                "type": "local",
-                              },
-                              Object {
-                                "copy": "External link text",
-                                "href": "https://example.com",
-                                "type": "external",
-                              },
-                            ],
+                            "cta": Object {
+                              "items": Array [
+                                Object {
+                                  "copy": "Link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "local",
+                                },
+                                Object {
+                                  "copy": "External link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "external",
+                                },
+                              ],
+                            },
                             "eyebrow": "Lorem ipsum",
                             "heading": "Aliquam condimentum",
                           },
                           Object {
                             "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-                            "cta": Array [
-                              Object {
-                                "copy": "Link text",
-                                "href": "https://example.com",
-                                "type": "local",
-                              },
-                            ],
+                            "cta": Object {
+                              "items": Array [
+                                Object {
+                                  "copy": "Link text",
+                                  "cta": Object {
+                                    "href": "https://example.com",
+                                  },
+                                  "type": "local",
+                                },
+                              ],
+                            },
                             "eyebrow": "Lorem ipsum",
                             "heading": "Aliquam condimentum",
                           },
@@ -18848,18 +18910,24 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                             <ContentItemHorizontal
                               copy="Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin."
                               cta={
-                                Array [
-                                  Object {
-                                    "copy": "Link text",
-                                    "href": "https://example.com",
-                                    "type": "local",
-                                  },
-                                  Object {
-                                    "copy": "External link text",
-                                    "href": "https://example.com",
-                                    "type": "external",
-                                  },
-                                ]
+                                Object {
+                                  "items": Array [
+                                    Object {
+                                      "copy": "Link text",
+                                      "cta": Object {
+                                        "href": "https://example.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "External link text",
+                                      "cta": Object {
+                                        "href": "https://example.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ],
+                                }
                               }
                               eyebrow="Lorem ipsum"
                               heading="Aliquam condimentum"
@@ -18904,167 +18972,220 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                       className="bx--content-item-horizontal__item--cta"
                                       data-autoid="dds--content-item-horizontal__item--cta"
                                     >
-                                      <CTA
-                                        copy="Link text"
-                                        customClassName="bx--card__cta"
-                                        href="https://example.com"
-                                        key="0"
-                                        style="text"
-                                        type="local"
+                                      <LinkList
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Link text",
+                                              "cta": Object {
+                                                "href": "https://example.com",
+                                              },
+                                              "type": "local",
+                                            },
+                                            Object {
+                                              "copy": "External link text",
+                                              "cta": Object {
+                                                "href": "https://example.com",
+                                              },
+                                              "type": "external",
+                                            },
+                                          ]
+                                        }
+                                        style="horizontal"
                                       >
                                         <div
-                                          className="bx--card__cta"
+                                          className="bx--link-list"
+                                          data-autoid="dds--link-list"
                                         >
-                                          <TextCTA
-                                            copy="Link text"
-                                            href="https://example.com"
-                                            openLightBox={[Function]}
-                                            renderLightBox={false}
-                                            style="text"
-                                            type="local"
-                                            videoTitle={
-                                              Array [
-                                                Object {
-                                                  "key": 0,
-                                                  "title": "",
-                                                },
-                                              ]
-                                            }
+                                          <ul
+                                            className="bx--link-list__list bx--link-list__list--horizontal"
                                           >
-                                            <LinkWithIcon
-                                              href="https://example.com"
-                                              onClick={[Function]}
-                                              target={null}
+                                            <li
+                                              className="bx--link-list__list__CTA bx--link-list__list--local"
+                                              key="0"
                                             >
-                                              <div
-                                                className="bx--link-with-icon__container"
-                                                data-autoid="dds--link-with-icon"
+                                              <CTA
+                                                copy="Link text"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://example.com",
+                                                  }
+                                                }
+                                                style="text"
+                                                type="local"
                                               >
-                                                <Link
-                                                  className="bx--link-with-icon"
-                                                  href="https://example.com"
-                                                  onClick={[Function]}
-                                                  target={null}
-                                                >
-                                                  <a
-                                                    className="bx--link bx--link-with-icon"
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target={null}
+                                                <div>
+                                                  <TextCTA
+                                                    copy="Link text"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://example.com",
+                                                      }
+                                                    }
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
                                                   >
-                                                    Link text
-                                                    <ForwardRef(ArrowRight20)>
-                                                      <Icon
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        viewBox="0 0 20 20"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          focusable="false"
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 20 20"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target={null}
                                                         >
-                                                          <polygon
-                                                            points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
-                                                          />
-                                                        </svg>
-                                                      </Icon>
-                                                    </ForwardRef(ArrowRight20)>
-                                                  </a>
-                                                </Link>
-                                              </div>
-                                            </LinkWithIcon>
-                                          </TextCTA>
-                                        </div>
-                                      </CTA>
-                                      <CTA
-                                        copy="External link text"
-                                        customClassName="bx--card__cta"
-                                        href="https://example.com"
-                                        key="1"
-                                        style="text"
-                                        type="external"
-                                      >
-                                        <div
-                                          className="bx--card__cta"
-                                        >
-                                          <TextCTA
-                                            copy="External link text"
-                                            href="https://example.com"
-                                            openLightBox={[Function]}
-                                            renderLightBox={false}
-                                            style="text"
-                                            type="external"
-                                            videoTitle={
-                                              Array [
-                                                Object {
-                                                  "key": 0,
-                                                  "title": "",
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            <LinkWithIcon
-                                              href="https://example.com"
-                                              onClick={[Function]}
-                                              target="_blank"
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <span>
+                                                              Link text
+                                                            </span>
+                                                            <ForwardRef(ArrowRight20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <polygon
+                                                                    points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
+                                                </div>
+                                              </CTA>
+                                            </li>
+                                            <li
+                                              className="bx--link-list__list__CTA bx--link-list__list--external"
+                                              key="1"
                                             >
-                                              <div
-                                                className="bx--link-with-icon__container"
-                                                data-autoid="dds--link-with-icon"
+                                              <CTA
+                                                copy="External link text"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://example.com",
+                                                  }
+                                                }
+                                                style="text"
+                                                type="external"
                                               >
-                                                <Link
-                                                  className="bx--link-with-icon"
-                                                  href="https://example.com"
-                                                  onClick={[Function]}
-                                                  target="_blank"
-                                                >
-                                                  <a
-                                                    className="bx--link bx--link-with-icon"
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target="_blank"
+                                                <div>
+                                                  <TextCTA
+                                                    copy="External link text"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://example.com",
+                                                      }
+                                                    }
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="external"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
                                                   >
-                                                    External link text
-                                                    <ForwardRef(Launch20)>
-                                                      <Icon
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        viewBox="0 0 32 32"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target="_blank"
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          focusable="false"
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 32 32"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target="_blank"
                                                         >
-                                                          <path
-                                                            d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                          />
-                                                          <polygon
-                                                            points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
-                                                          />
-                                                        </svg>
-                                                      </Icon>
-                                                    </ForwardRef(Launch20)>
-                                                  </a>
-                                                </Link>
-                                              </div>
-                                            </LinkWithIcon>
-                                          </TextCTA>
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target="_blank"
+                                                          >
+                                                            <span>
+                                                              External link text
+                                                            </span>
+                                                            <ForwardRef(Launch20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                  />
+                                                                  <polygon
+                                                                    points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(Launch20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
+                                                </div>
+                                              </CTA>
+                                            </li>
+                                          </ul>
                                         </div>
-                                      </CTA>
+                                      </LinkList>
                                     </div>
                                   </div>
                                 </div>
@@ -19073,18 +19194,24 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                             <ContentItemHorizontal
                               copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
                               cta={
-                                Array [
-                                  Object {
-                                    "copy": "Link text",
-                                    "href": "https://example.com",
-                                    "type": "local",
-                                  },
-                                  Object {
-                                    "copy": "External link text",
-                                    "href": "https://example.com",
-                                    "type": "external",
-                                  },
-                                ]
+                                Object {
+                                  "items": Array [
+                                    Object {
+                                      "copy": "Link text",
+                                      "cta": Object {
+                                        "href": "https://example.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "External link text",
+                                      "cta": Object {
+                                        "href": "https://example.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ],
+                                }
                               }
                               eyebrow="Lorem ipsum"
                               heading="Aliquam condimentum"
@@ -19129,167 +19256,220 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                       className="bx--content-item-horizontal__item--cta"
                                       data-autoid="dds--content-item-horizontal__item--cta"
                                     >
-                                      <CTA
-                                        copy="Link text"
-                                        customClassName="bx--card__cta"
-                                        href="https://example.com"
-                                        key="0"
-                                        style="text"
-                                        type="local"
+                                      <LinkList
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Link text",
+                                              "cta": Object {
+                                                "href": "https://example.com",
+                                              },
+                                              "type": "local",
+                                            },
+                                            Object {
+                                              "copy": "External link text",
+                                              "cta": Object {
+                                                "href": "https://example.com",
+                                              },
+                                              "type": "external",
+                                            },
+                                          ]
+                                        }
+                                        style="horizontal"
                                       >
                                         <div
-                                          className="bx--card__cta"
+                                          className="bx--link-list"
+                                          data-autoid="dds--link-list"
                                         >
-                                          <TextCTA
-                                            copy="Link text"
-                                            href="https://example.com"
-                                            openLightBox={[Function]}
-                                            renderLightBox={false}
-                                            style="text"
-                                            type="local"
-                                            videoTitle={
-                                              Array [
-                                                Object {
-                                                  "key": 0,
-                                                  "title": "",
-                                                },
-                                              ]
-                                            }
+                                          <ul
+                                            className="bx--link-list__list bx--link-list__list--horizontal"
                                           >
-                                            <LinkWithIcon
-                                              href="https://example.com"
-                                              onClick={[Function]}
-                                              target={null}
+                                            <li
+                                              className="bx--link-list__list__CTA bx--link-list__list--local"
+                                              key="0"
                                             >
-                                              <div
-                                                className="bx--link-with-icon__container"
-                                                data-autoid="dds--link-with-icon"
+                                              <CTA
+                                                copy="Link text"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://example.com",
+                                                  }
+                                                }
+                                                style="text"
+                                                type="local"
                                               >
-                                                <Link
-                                                  className="bx--link-with-icon"
-                                                  href="https://example.com"
-                                                  onClick={[Function]}
-                                                  target={null}
-                                                >
-                                                  <a
-                                                    className="bx--link bx--link-with-icon"
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target={null}
+                                                <div>
+                                                  <TextCTA
+                                                    copy="Link text"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://example.com",
+                                                      }
+                                                    }
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
                                                   >
-                                                    Link text
-                                                    <ForwardRef(ArrowRight20)>
-                                                      <Icon
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        viewBox="0 0 20 20"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          focusable="false"
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 20 20"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target={null}
                                                         >
-                                                          <polygon
-                                                            points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
-                                                          />
-                                                        </svg>
-                                                      </Icon>
-                                                    </ForwardRef(ArrowRight20)>
-                                                  </a>
-                                                </Link>
-                                              </div>
-                                            </LinkWithIcon>
-                                          </TextCTA>
-                                        </div>
-                                      </CTA>
-                                      <CTA
-                                        copy="External link text"
-                                        customClassName="bx--card__cta"
-                                        href="https://example.com"
-                                        key="1"
-                                        style="text"
-                                        type="external"
-                                      >
-                                        <div
-                                          className="bx--card__cta"
-                                        >
-                                          <TextCTA
-                                            copy="External link text"
-                                            href="https://example.com"
-                                            openLightBox={[Function]}
-                                            renderLightBox={false}
-                                            style="text"
-                                            type="external"
-                                            videoTitle={
-                                              Array [
-                                                Object {
-                                                  "key": 0,
-                                                  "title": "",
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            <LinkWithIcon
-                                              href="https://example.com"
-                                              onClick={[Function]}
-                                              target="_blank"
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <span>
+                                                              Link text
+                                                            </span>
+                                                            <ForwardRef(ArrowRight20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <polygon
+                                                                    points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
+                                                </div>
+                                              </CTA>
+                                            </li>
+                                            <li
+                                              className="bx--link-list__list__CTA bx--link-list__list--external"
+                                              key="1"
                                             >
-                                              <div
-                                                className="bx--link-with-icon__container"
-                                                data-autoid="dds--link-with-icon"
+                                              <CTA
+                                                copy="External link text"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://example.com",
+                                                  }
+                                                }
+                                                style="text"
+                                                type="external"
                                               >
-                                                <Link
-                                                  className="bx--link-with-icon"
-                                                  href="https://example.com"
-                                                  onClick={[Function]}
-                                                  target="_blank"
-                                                >
-                                                  <a
-                                                    className="bx--link bx--link-with-icon"
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target="_blank"
+                                                <div>
+                                                  <TextCTA
+                                                    copy="External link text"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://example.com",
+                                                      }
+                                                    }
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="external"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
                                                   >
-                                                    External link text
-                                                    <ForwardRef(Launch20)>
-                                                      <Icon
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        viewBox="0 0 32 32"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target="_blank"
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          focusable="false"
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 32 32"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target="_blank"
                                                         >
-                                                          <path
-                                                            d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                          />
-                                                          <polygon
-                                                            points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
-                                                          />
-                                                        </svg>
-                                                      </Icon>
-                                                    </ForwardRef(Launch20)>
-                                                  </a>
-                                                </Link>
-                                              </div>
-                                            </LinkWithIcon>
-                                          </TextCTA>
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target="_blank"
+                                                          >
+                                                            <span>
+                                                              External link text
+                                                            </span>
+                                                            <ForwardRef(Launch20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                  />
+                                                                  <polygon
+                                                                    points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(Launch20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
+                                                </div>
+                                              </CTA>
+                                            </li>
+                                          </ul>
                                         </div>
-                                      </CTA>
+                                      </LinkList>
                                     </div>
                                   </div>
                                 </div>
@@ -19298,13 +19478,17 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                             <ContentItemHorizontal
                               copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
                               cta={
-                                Array [
-                                  Object {
-                                    "copy": "Link text",
-                                    "href": "https://example.com",
-                                    "type": "local",
-                                  },
-                                ]
+                                Object {
+                                  "items": Array [
+                                    Object {
+                                      "copy": "Link text",
+                                      "cta": Object {
+                                        "href": "https://example.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                  ],
+                                }
                               }
                               eyebrow="Lorem ipsum"
                               heading="Aliquam condimentum"
@@ -19349,85 +19533,120 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                       className="bx--content-item-horizontal__item--cta"
                                       data-autoid="dds--content-item-horizontal__item--cta"
                                     >
-                                      <CTA
-                                        copy="Link text"
-                                        customClassName="bx--card__cta"
-                                        href="https://example.com"
-                                        key="0"
-                                        style="text"
-                                        type="local"
+                                      <LinkList
+                                        items={
+                                          Array [
+                                            Object {
+                                              "copy": "Link text",
+                                              "cta": Object {
+                                                "href": "https://example.com",
+                                              },
+                                              "type": "local",
+                                            },
+                                          ]
+                                        }
+                                        style="horizontal"
                                       >
                                         <div
-                                          className="bx--card__cta"
+                                          className="bx--link-list"
+                                          data-autoid="dds--link-list"
                                         >
-                                          <TextCTA
-                                            copy="Link text"
-                                            href="https://example.com"
-                                            openLightBox={[Function]}
-                                            renderLightBox={false}
-                                            style="text"
-                                            type="local"
-                                            videoTitle={
-                                              Array [
-                                                Object {
-                                                  "key": 0,
-                                                  "title": "",
-                                                },
-                                              ]
-                                            }
+                                          <ul
+                                            className="bx--link-list__list bx--link-list__list--horizontal"
                                           >
-                                            <LinkWithIcon
-                                              href="https://example.com"
-                                              onClick={[Function]}
-                                              target={null}
+                                            <li
+                                              className="bx--link-list__list__CTA bx--link-list__list--local"
+                                              key="0"
                                             >
-                                              <div
-                                                className="bx--link-with-icon__container"
-                                                data-autoid="dds--link-with-icon"
+                                              <CTA
+                                                copy="Link text"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://example.com",
+                                                  }
+                                                }
+                                                style="text"
+                                                type="local"
                                               >
-                                                <Link
-                                                  className="bx--link-with-icon"
-                                                  href="https://example.com"
-                                                  onClick={[Function]}
-                                                  target={null}
-                                                >
-                                                  <a
-                                                    className="bx--link bx--link-with-icon"
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target={null}
+                                                <div>
+                                                  <TextCTA
+                                                    copy="Link text"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://example.com",
+                                                      }
+                                                    }
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
                                                   >
-                                                    Link text
-                                                    <ForwardRef(ArrowRight20)>
-                                                      <Icon
-                                                        height={20}
-                                                        preserveAspectRatio="xMidYMid meet"
-                                                        viewBox="0 0 20 20"
-                                                        width={20}
-                                                        xmlns="http://www.w3.org/2000/svg"
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          focusable="false"
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 20 20"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target={null}
                                                         >
-                                                          <polygon
-                                                            points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
-                                                          />
-                                                        </svg>
-                                                      </Icon>
-                                                    </ForwardRef(ArrowRight20)>
-                                                  </a>
-                                                </Link>
-                                              </div>
-                                            </LinkWithIcon>
-                                          </TextCTA>
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <span>
+                                                              Link text
+                                                            </span>
+                                                            <ForwardRef(ArrowRight20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <polygon
+                                                                    points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
+                                                </div>
+                                              </CTA>
+                                            </li>
+                                          </ul>
                                         </div>
-                                      </CTA>
+                                      </LinkList>
                                     </div>
                                   </div>
                                 </div>
@@ -21457,7 +21676,9 @@ exports[`Storyshots Patterns (Sections)|CTASection Default 1`] = `
                                         onClick={[Function]}
                                         target={null}
                                       >
-                                        Find a partner
+                                        <span>
+                                          Find a partner
+                                        </span>
                                         <ForwardRef(ArrowRight20)>
                                           <Icon
                                             height={20}
@@ -21568,7 +21789,9 @@ exports[`Storyshots Patterns (Sections)|CTASection Default 1`] = `
                                         onClick={[Function]}
                                         target={null}
                                       >
-                                        Browse tutorials
+                                        <span>
+                                          Browse tutorials
+                                        </span>
                                         <ForwardRef(ArrowRight20)>
                                           <Icon
                                             height={20}
@@ -26760,10 +26983,10 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                       Tutorials
                                     </h4>
                                     <ul
-                                      className="bx--link-list__list"
+                                      className="bx--link-list__list bx--link-list__list--undefined"
                                     >
                                       <li
-                                        className="bx--link-list__list__CTA"
+                                        className="bx--link-list__list__CTA bx--link-list__list--local"
                                         key="0"
                                       >
                                         <CTA
@@ -26773,11 +26996,11 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               "href": "https://ibm.com",
                                             }
                                           }
-                                          style="card"
+                                          style="text"
                                           type="local"
                                         >
                                           <div>
-                                            <CardCTA
+                                            <TextCTA
                                               copy="Containerization A Complete Guide"
                                               cta={
                                                 Object {
@@ -26786,7 +27009,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               }
                                               openLightBox={[Function]}
                                               renderLightBox={false}
-                                              style="card"
+                                              style="text"
                                               type="local"
                                               videoTitle={
                                                 Array [
@@ -26797,116 +27020,63 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                                 ]
                                               }
                                             >
-                                              <Card
-                                                copy="Containerization A Complete Guide"
-                                                cta={
-                                                  Object {
-                                                    "href": "https://ibm.com",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
-                                                      },
-                                                    },
-                                                  }
-                                                }
-                                                customClassName="bx--card__CTA"
-                                                handleClick={[Function]}
-                                                role="region"
+                                              <LinkWithIcon
+                                                href="https://ibm.com"
+                                                onClick={[Function]}
                                                 target={null}
-                                                type="link"
                                               >
-                                                <ClickableTile
-                                                  className="bx--card bx--card--link bx--card__CTA"
-                                                  clicked={false}
-                                                  data-autoid="dds--card"
-                                                  handleClick={[Function]}
-                                                  handleKeyDown={[Function]}
-                                                  href="https://ibm.com"
-                                                  light={false}
-                                                  onClick={[Function]}
-                                                  role="region"
-                                                  target={null}
+                                                <div
+                                                  className="bx--link-with-icon__container"
+                                                  data-autoid="dds--link-with-icon"
                                                 >
-                                                  <a
-                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
-                                                    data-autoid="dds--card"
+                                                  <Link
+                                                    className="bx--link-with-icon"
                                                     href="https://ibm.com"
                                                     onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    role="region"
                                                     target={null}
                                                   >
-                                                    <div
-                                                      className="bx--card__wrapper"
+                                                    <a
+                                                      className="bx--link bx--link-with-icon"
+                                                      href="https://ibm.com"
+                                                      onClick={[Function]}
+                                                      target={null}
                                                     >
-                                                      <div
-                                                        className="bx--card__copy"
-                                                        dangerouslySetInnerHTML={
-                                                          Object {
-                                                            "__html": "<p>Containerization A Complete Guide</p>",
-                                                          }
-                                                        }
-                                                      />
-                                                      <div
-                                                        className="bx--card__footer"
-                                                      >
-                                                        <ForwardRef(ArrowRight20)
-                                                          className="bx--card__cta"
-                                                          src={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "render": [Function],
-                                                            }
-                                                          }
+                                                      <span>
+                                                        Containerization A Complete Guide
+                                                      </span>
+                                                      <ForwardRef(ArrowRight20)>
+                                                        <Icon
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
                                                         >
-                                                          <Icon
-                                                            className="bx--card__cta"
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            focusable="false"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
-                                                            src={
-                                                              Object {
-                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                "render": [Function],
-                                                              }
-                                                            }
                                                             viewBox="0 0 20 20"
                                                             width={20}
                                                             xmlns="http://www.w3.org/2000/svg"
                                                           >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="bx--card__cta"
-                                                              focusable="false"
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              src={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "render": [Function],
-                                                                }
-                                                              }
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <polygon
-                                                                points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
-                                                              />
-                                                            </svg>
-                                                          </Icon>
-                                                        </ForwardRef(ArrowRight20)>
-                                                      </div>
-                                                    </div>
-                                                  </a>
-                                                </ClickableTile>
-                                              </Card>
-                                            </CardCTA>
+                                                            <polygon
+                                                              points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                            />
+                                                          </svg>
+                                                        </Icon>
+                                                      </ForwardRef(ArrowRight20)>
+                                                    </a>
+                                                  </Link>
+                                                </div>
+                                              </LinkWithIcon>
+                                            </TextCTA>
                                           </div>
                                         </CTA>
                                       </li>
                                       <li
-                                        className="bx--link-list__list__CTA"
+                                        className="bx--link-list__list__CTA bx--link-list__list--external"
                                         key="1"
                                       >
                                         <CTA
@@ -26916,11 +27086,11 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               "href": "https://ibm.com",
                                             }
                                           }
-                                          style="card"
+                                          style="text"
                                           type="external"
                                         >
                                           <div>
-                                            <CardCTA
+                                            <TextCTA
                                               copy="Why should you use microservices and containers"
                                               cta={
                                                 Object {
@@ -26929,7 +27099,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               }
                                               openLightBox={[Function]}
                                               renderLightBox={false}
-                                              style="card"
+                                              style="text"
                                               type="external"
                                               videoTitle={
                                                 Array [
@@ -26940,114 +27110,61 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                                 ]
                                               }
                                             >
-                                              <Card
-                                                copy="Why should you use microservices and containers"
-                                                cta={
-                                                  Object {
-                                                    "href": "https://ibm.com",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
-                                                      },
-                                                    },
-                                                  }
-                                                }
-                                                customClassName="bx--card__CTA"
-                                                handleClick={[Function]}
-                                                role="region"
+                                              <LinkWithIcon
+                                                href="https://ibm.com"
+                                                onClick={[Function]}
                                                 target="_blank"
-                                                type="link"
                                               >
-                                                <ClickableTile
-                                                  className="bx--card bx--card--link bx--card__CTA"
-                                                  clicked={false}
-                                                  data-autoid="dds--card"
-                                                  handleClick={[Function]}
-                                                  handleKeyDown={[Function]}
-                                                  href="https://ibm.com"
-                                                  light={false}
-                                                  onClick={[Function]}
-                                                  role="region"
-                                                  target="_blank"
+                                                <div
+                                                  className="bx--link-with-icon__container"
+                                                  data-autoid="dds--link-with-icon"
                                                 >
-                                                  <a
-                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
-                                                    data-autoid="dds--card"
+                                                  <Link
+                                                    className="bx--link-with-icon"
                                                     href="https://ibm.com"
                                                     onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    role="region"
                                                     target="_blank"
                                                   >
-                                                    <div
-                                                      className="bx--card__wrapper"
+                                                    <a
+                                                      className="bx--link bx--link-with-icon"
+                                                      href="https://ibm.com"
+                                                      onClick={[Function]}
+                                                      target="_blank"
                                                     >
-                                                      <div
-                                                        className="bx--card__copy"
-                                                        dangerouslySetInnerHTML={
-                                                          Object {
-                                                            "__html": "<p>Why should you use microservices and containers</p>",
-                                                          }
-                                                        }
-                                                      />
-                                                      <div
-                                                        className="bx--card__footer"
-                                                      >
-                                                        <ForwardRef(Launch20)
-                                                          className="bx--card__cta"
-                                                          src={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "render": [Function],
-                                                            }
-                                                          }
+                                                      <span>
+                                                        Why should you use microservices and containers
+                                                      </span>
+                                                      <ForwardRef(Launch20)>
+                                                        <Icon
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          viewBox="0 0 32 32"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
                                                         >
-                                                          <Icon
-                                                            className="bx--card__cta"
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            focusable="false"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
-                                                            src={
-                                                              Object {
-                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                "render": [Function],
-                                                              }
-                                                            }
                                                             viewBox="0 0 32 32"
                                                             width={20}
                                                             xmlns="http://www.w3.org/2000/svg"
                                                           >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="bx--card__cta"
-                                                              focusable="false"
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              src={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "render": [Function],
-                                                                }
-                                                              }
-                                                              viewBox="0 0 32 32"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <path
-                                                                d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                              />
-                                                              <polygon
-                                                                points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
-                                                              />
-                                                            </svg>
-                                                          </Icon>
-                                                        </ForwardRef(Launch20)>
-                                                      </div>
-                                                    </div>
-                                                  </a>
-                                                </ClickableTile>
-                                              </Card>
-                                            </CardCTA>
+                                                            <path
+                                                              d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                            />
+                                                            <polygon
+                                                              points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                            />
+                                                          </svg>
+                                                        </Icon>
+                                                      </ForwardRef(Launch20)>
+                                                    </a>
+                                                  </Link>
+                                                </div>
+                                              </LinkWithIcon>
+                                            </TextCTA>
                                           </div>
                                         </CTA>
                                       </li>
@@ -27641,7 +27758,9 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentItem Default 1`] = `
                                       onClick={[Function]}
                                       target={null}
                                     >
-                                      Lorem ipsum dolor sit amet
+                                      <span>
+                                        Lorem ipsum dolor sit amet
+                                      </span>
                                       <ForwardRef(ArrowRight20)>
                                         <Icon
                                           height={20}
@@ -27722,18 +27841,24 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentItemHorizontal Default 1`] = 
                     <ContentItemHorizontal
                       copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
                       cta={
-                        Array [
-                          Object {
-                            "copy": "Link text",
-                            "href": "https://example.com",
-                            "type": "local",
-                          },
-                          Object {
-                            "copy": "External link text",
-                            "href": "https://example.com",
-                            "type": "external",
-                          },
-                        ]
+                        Object {
+                          "items": Array [
+                            Object {
+                              "copy": "Learn more",
+                              "cta": Object {
+                                "href": "https://ibm.com",
+                              },
+                              "type": "local",
+                            },
+                            Object {
+                              "copy": "Microservices and containers",
+                              "cta": Object {
+                                "href": "https://ibm.com",
+                              },
+                              "type": "external",
+                            },
+                          ],
+                        }
                       }
                       eyebrow="Lorem ipsum"
                       heading="Aliquam condimentum"
@@ -27780,18 +27905,24 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentItemHorizontal Default 1`] = 
                     <ContentItemHorizontal
                       copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
                       cta={
-                        Array [
-                          Object {
-                            "copy": "Link text",
-                            "href": "https://example.com",
-                            "type": "local",
-                          },
-                          Object {
-                            "copy": "External link text",
-                            "href": "https://example.com",
-                            "type": "external",
-                          },
-                        ]
+                        Object {
+                          "items": Array [
+                            Object {
+                              "copy": "Learn more",
+                              "cta": Object {
+                                "href": "https://ibm.com",
+                              },
+                              "type": "local",
+                            },
+                            Object {
+                              "copy": "Microservices and containers",
+                              "cta": Object {
+                                "href": "https://ibm.com",
+                              },
+                              "type": "external",
+                            },
+                          ],
+                        }
                       }
                       eyebrow="Lorem ipsum"
                       heading="Aliquam condimentum"
@@ -27835,167 +27966,220 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentItemHorizontal Default 1`] = 
                               className="bx--content-item-horizontal__item--cta"
                               data-autoid="dds--content-item-horizontal__item--cta"
                             >
-                              <CTA
-                                copy="Link text"
-                                customClassName="bx--card__cta"
-                                href="https://example.com"
-                                key="0"
-                                style="text"
-                                type="local"
+                              <LinkList
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Learn more",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "local",
+                                    },
+                                    Object {
+                                      "copy": "Microservices and containers",
+                                      "cta": Object {
+                                        "href": "https://ibm.com",
+                                      },
+                                      "type": "external",
+                                    },
+                                  ]
+                                }
+                                style="horizontal"
                               >
                                 <div
-                                  className="bx--card__cta"
+                                  className="bx--link-list"
+                                  data-autoid="dds--link-list"
                                 >
-                                  <TextCTA
-                                    copy="Link text"
-                                    href="https://example.com"
-                                    openLightBox={[Function]}
-                                    renderLightBox={false}
-                                    style="text"
-                                    type="local"
-                                    videoTitle={
-                                      Array [
-                                        Object {
-                                          "key": 0,
-                                          "title": "",
-                                        },
-                                      ]
-                                    }
+                                  <ul
+                                    className="bx--link-list__list bx--link-list__list--horizontal"
                                   >
-                                    <LinkWithIcon
-                                      href="https://example.com"
-                                      onClick={[Function]}
-                                      target={null}
+                                    <li
+                                      className="bx--link-list__list__CTA bx--link-list__list--local"
+                                      key="0"
                                     >
-                                      <div
-                                        className="bx--link-with-icon__container"
-                                        data-autoid="dds--link-with-icon"
+                                      <CTA
+                                        copy="Learn more"
+                                        cta={
+                                          Object {
+                                            "href": "https://ibm.com",
+                                          }
+                                        }
+                                        style="text"
+                                        type="local"
                                       >
-                                        <Link
-                                          className="bx--link-with-icon"
-                                          href="https://example.com"
-                                          onClick={[Function]}
-                                          target={null}
-                                        >
-                                          <a
-                                            className="bx--link bx--link-with-icon"
-                                            href="https://example.com"
-                                            onClick={[Function]}
-                                            target={null}
+                                        <div>
+                                          <TextCTA
+                                            copy="Learn more"
+                                            cta={
+                                              Object {
+                                                "href": "https://ibm.com",
+                                              }
+                                            }
+                                            openLightBox={[Function]}
+                                            renderLightBox={false}
+                                            style="text"
+                                            type="local"
+                                            videoTitle={
+                                              Array [
+                                                Object {
+                                                  "key": 0,
+                                                  "title": "",
+                                                },
+                                              ]
+                                            }
                                           >
-                                            Link text
-                                            <ForwardRef(ArrowRight20)>
-                                              <Icon
-                                                height={20}
-                                                preserveAspectRatio="xMidYMid meet"
-                                                viewBox="0 0 20 20"
-                                                width={20}
-                                                xmlns="http://www.w3.org/2000/svg"
+                                            <LinkWithIcon
+                                              href="https://ibm.com"
+                                              onClick={[Function]}
+                                              target={null}
+                                            >
+                                              <div
+                                                className="bx--link-with-icon__container"
+                                                data-autoid="dds--link-with-icon"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  focusable="false"
-                                                  height={20}
-                                                  preserveAspectRatio="xMidYMid meet"
-                                                  viewBox="0 0 20 20"
-                                                  width={20}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <Link
+                                                  className="bx--link-with-icon"
+                                                  href="https://ibm.com"
+                                                  onClick={[Function]}
+                                                  target={null}
                                                 >
-                                                  <polygon
-                                                    points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
-                                                  />
-                                                </svg>
-                                              </Icon>
-                                            </ForwardRef(ArrowRight20)>
-                                          </a>
-                                        </Link>
-                                      </div>
-                                    </LinkWithIcon>
-                                  </TextCTA>
-                                </div>
-                              </CTA>
-                              <CTA
-                                copy="External link text"
-                                customClassName="bx--card__cta"
-                                href="https://example.com"
-                                key="1"
-                                style="text"
-                                type="external"
-                              >
-                                <div
-                                  className="bx--card__cta"
-                                >
-                                  <TextCTA
-                                    copy="External link text"
-                                    href="https://example.com"
-                                    openLightBox={[Function]}
-                                    renderLightBox={false}
-                                    style="text"
-                                    type="external"
-                                    videoTitle={
-                                      Array [
-                                        Object {
-                                          "key": 0,
-                                          "title": "",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                    <LinkWithIcon
-                                      href="https://example.com"
-                                      onClick={[Function]}
-                                      target="_blank"
+                                                  <a
+                                                    className="bx--link bx--link-with-icon"
+                                                    href="https://ibm.com"
+                                                    onClick={[Function]}
+                                                    target={null}
+                                                  >
+                                                    <span>
+                                                      Learn more
+                                                    </span>
+                                                    <ForwardRef(ArrowRight20)>
+                                                      <Icon
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          focusable="false"
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <polygon
+                                                            points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                          />
+                                                        </svg>
+                                                      </Icon>
+                                                    </ForwardRef(ArrowRight20)>
+                                                  </a>
+                                                </Link>
+                                              </div>
+                                            </LinkWithIcon>
+                                          </TextCTA>
+                                        </div>
+                                      </CTA>
+                                    </li>
+                                    <li
+                                      className="bx--link-list__list__CTA bx--link-list__list--external"
+                                      key="1"
                                     >
-                                      <div
-                                        className="bx--link-with-icon__container"
-                                        data-autoid="dds--link-with-icon"
+                                      <CTA
+                                        copy="Microservices and containers"
+                                        cta={
+                                          Object {
+                                            "href": "https://ibm.com",
+                                          }
+                                        }
+                                        style="text"
+                                        type="external"
                                       >
-                                        <Link
-                                          className="bx--link-with-icon"
-                                          href="https://example.com"
-                                          onClick={[Function]}
-                                          target="_blank"
-                                        >
-                                          <a
-                                            className="bx--link bx--link-with-icon"
-                                            href="https://example.com"
-                                            onClick={[Function]}
-                                            target="_blank"
+                                        <div>
+                                          <TextCTA
+                                            copy="Microservices and containers"
+                                            cta={
+                                              Object {
+                                                "href": "https://ibm.com",
+                                              }
+                                            }
+                                            openLightBox={[Function]}
+                                            renderLightBox={false}
+                                            style="text"
+                                            type="external"
+                                            videoTitle={
+                                              Array [
+                                                Object {
+                                                  "key": 0,
+                                                  "title": "",
+                                                },
+                                              ]
+                                            }
                                           >
-                                            External link text
-                                            <ForwardRef(Launch20)>
-                                              <Icon
-                                                height={20}
-                                                preserveAspectRatio="xMidYMid meet"
-                                                viewBox="0 0 32 32"
-                                                width={20}
-                                                xmlns="http://www.w3.org/2000/svg"
+                                            <LinkWithIcon
+                                              href="https://ibm.com"
+                                              onClick={[Function]}
+                                              target="_blank"
+                                            >
+                                              <div
+                                                className="bx--link-with-icon__container"
+                                                data-autoid="dds--link-with-icon"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  focusable="false"
-                                                  height={20}
-                                                  preserveAspectRatio="xMidYMid meet"
-                                                  viewBox="0 0 32 32"
-                                                  width={20}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <Link
+                                                  className="bx--link-with-icon"
+                                                  href="https://ibm.com"
+                                                  onClick={[Function]}
+                                                  target="_blank"
                                                 >
-                                                  <path
-                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                  />
-                                                  <polygon
-                                                    points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
-                                                  />
-                                                </svg>
-                                              </Icon>
-                                            </ForwardRef(Launch20)>
-                                          </a>
-                                        </Link>
-                                      </div>
-                                    </LinkWithIcon>
-                                  </TextCTA>
+                                                  <a
+                                                    className="bx--link bx--link-with-icon"
+                                                    href="https://ibm.com"
+                                                    onClick={[Function]}
+                                                    target="_blank"
+                                                  >
+                                                    <span>
+                                                      Microservices and containers
+                                                    </span>
+                                                    <ForwardRef(Launch20)>
+                                                      <Icon
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 32 32"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          focusable="false"
+                                                          height={20}
+                                                          preserveAspectRatio="xMidYMid meet"
+                                                          viewBox="0 0 32 32"
+                                                          width={20}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                          />
+                                                          <polygon
+                                                            points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                          />
+                                                        </svg>
+                                                      </Icon>
+                                                    </ForwardRef(Launch20)>
+                                                  </a>
+                                                </Link>
+                                              </div>
+                                            </LinkWithIcon>
+                                          </TextCTA>
+                                        </div>
+                                      </CTA>
+                                    </li>
+                                  </ul>
                                 </div>
-                              </CTA>
+                              </LinkList>
                             </div>
                           </div>
                         </div>
@@ -28963,18 +29147,25 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                       items={
                         Array [
                           Object {
-                            "copy": "Containerization A Complete Guide",
+                            "copy": "Learn more",
                             "cta": Object {
                               "href": "https://ibm.com",
                             },
                             "type": "local",
                           },
                           Object {
-                            "copy": "Why should you use microservices and containers",
+                            "copy": "Containerization A Complete Guide",
                             "cta": Object {
                               "href": "https://ibm.com",
                             },
-                            "type": "local",
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
                           },
                           Object {
                             "media": Object {
@@ -28985,6 +29176,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                           },
                         ]
                       }
+                      style="card"
                     />
                   </div>
                 </div>
@@ -29030,18 +29222,25 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                       items={
                         Array [
                           Object {
-                            "copy": "Containerization A Complete Guide",
+                            "copy": "Learn more",
                             "cta": Object {
                               "href": "https://ibm.com",
                             },
                             "type": "local",
                           },
                           Object {
-                            "copy": "Why should you use microservices and containers",
+                            "copy": "Containerization A Complete Guide",
                             "cta": Object {
                               "href": "https://ibm.com",
                             },
-                            "type": "local",
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
                           },
                           Object {
                             "media": Object {
@@ -29052,6 +29251,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                           },
                         ]
                       }
+                      style="card"
                     >
                       <div
                         className="bx--link-list"
@@ -29063,11 +29263,154 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                           Tutorials
                         </h4>
                         <ul
-                          className="bx--link-list__list"
+                          className="bx--link-list__list bx--link-list__list--card"
                         >
                           <li
-                            className="bx--link-list__list__CTA"
+                            className="bx--link-list__list__CTA bx--link-list__list--local"
                             key="0"
+                          >
+                            <CTA
+                              copy="Learn more"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="card"
+                              type="local"
+                            >
+                              <div>
+                                <CardCTA
+                                  copy="Learn more"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="card"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Card
+                                    copy="Learn more"
+                                    cta={
+                                      Object {
+                                        "href": "https://ibm.com",
+                                        "icon": Object {
+                                          "src": Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "render": [Function],
+                                          },
+                                        },
+                                      }
+                                    }
+                                    customClassName="bx--card__CTA"
+                                    handleClick={[Function]}
+                                    role="region"
+                                    target={null}
+                                    type="link"
+                                  >
+                                    <ClickableTile
+                                      className="bx--card bx--card--link bx--card__CTA"
+                                      clicked={false}
+                                      data-autoid="dds--card"
+                                      handleClick={[Function]}
+                                      handleKeyDown={[Function]}
+                                      href="https://ibm.com"
+                                      light={false}
+                                      onClick={[Function]}
+                                      role="region"
+                                      target={null}
+                                    >
+                                      <a
+                                        className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                        data-autoid="dds--card"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="region"
+                                        target={null}
+                                      >
+                                        <div
+                                          className="bx--card__wrapper"
+                                        >
+                                          <div
+                                            className="bx--card__copy"
+                                            dangerouslySetInnerHTML={
+                                              Object {
+                                                "__html": "<p>Learn more</p>",
+                                              }
+                                            }
+                                          />
+                                          <div
+                                            className="bx--card__footer"
+                                          >
+                                            <ForwardRef(ArrowRight20)
+                                              className="bx--card__cta"
+                                              src={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                }
+                                              }
+                                            >
+                                              <Icon
+                                                className="bx--card__cta"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                src={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  }
+                                                }
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="bx--card__cta"
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                  viewBox="0 0 20 20"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <polygon
+                                                    points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(ArrowRight20)>
+                                          </div>
+                                        </div>
+                                      </a>
+                                    </ClickableTile>
+                                  </Card>
+                                </CardCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--download"
+                            key="1"
                           >
                             <CTA
                               copy="Containerization A Complete Guide"
@@ -29077,7 +29420,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                 }
                               }
                               style="card"
-                              type="local"
+                              type="download"
                             >
                               <div>
                                 <CardCTA
@@ -29090,7 +29433,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                   openLightBox={[Function]}
                                   renderLightBox={false}
                                   style="card"
-                                  type="local"
+                                  type="download"
                                   videoTitle={
                                     Array [
                                       Object {
@@ -29154,7 +29497,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                           <div
                                             className="bx--card__footer"
                                           >
-                                            <ForwardRef(ArrowRight20)
+                                            <ForwardRef(Download20)
                                               className="bx--card__cta"
                                               src={
                                                 Object {
@@ -29173,7 +29516,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                                     "render": [Function],
                                                   }
                                                 }
-                                                viewBox="0 0 20 20"
+                                                viewBox="0 0 32 32"
                                                 width={20}
                                                 xmlns="http://www.w3.org/2000/svg"
                                               >
@@ -29189,16 +29532,19 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                                       "render": [Function],
                                                     }
                                                   }
-                                                  viewBox="0 0 20 20"
+                                                  viewBox="0 0 32 32"
                                                   width={20}
                                                   xmlns="http://www.w3.org/2000/svg"
                                                 >
                                                   <polygon
-                                                    points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                    points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                                                  />
+                                                  <path
+                                                    d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
                                                   />
                                                 </svg>
                                               </Icon>
-                                            </ForwardRef(ArrowRight20)>
+                                            </ForwardRef(Download20)>
                                           </div>
                                         </div>
                                       </a>
@@ -29209,11 +29555,2317 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                             </CTA>
                           </li>
                           <li
-                            className="bx--link-list__list__CTA"
+                            className="bx--link-list__list__CTA bx--link-list__list--external"
+                            key="2"
+                          >
+                            <CTA
+                              copy="Microservices and containers"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="card"
+                              type="external"
+                            >
+                              <div>
+                                <CardCTA
+                                  copy="Microservices and containers"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="card"
+                                  type="external"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Card
+                                    copy="Microservices and containers"
+                                    cta={
+                                      Object {
+                                        "href": "https://ibm.com",
+                                        "icon": Object {
+                                          "src": Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "render": [Function],
+                                          },
+                                        },
+                                      }
+                                    }
+                                    customClassName="bx--card__CTA"
+                                    handleClick={[Function]}
+                                    role="region"
+                                    target="_blank"
+                                    type="link"
+                                  >
+                                    <ClickableTile
+                                      className="bx--card bx--card--link bx--card__CTA"
+                                      clicked={false}
+                                      data-autoid="dds--card"
+                                      handleClick={[Function]}
+                                      handleKeyDown={[Function]}
+                                      href="https://ibm.com"
+                                      light={false}
+                                      onClick={[Function]}
+                                      role="region"
+                                      target="_blank"
+                                    >
+                                      <a
+                                        className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                        data-autoid="dds--card"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="region"
+                                        target="_blank"
+                                      >
+                                        <div
+                                          className="bx--card__wrapper"
+                                        >
+                                          <div
+                                            className="bx--card__copy"
+                                            dangerouslySetInnerHTML={
+                                              Object {
+                                                "__html": "<p>Microservices and containers</p>",
+                                              }
+                                            }
+                                          />
+                                          <div
+                                            className="bx--card__footer"
+                                          >
+                                            <ForwardRef(Launch20)
+                                              className="bx--card__cta"
+                                              src={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                }
+                                              }
+                                            >
+                                              <Icon
+                                                className="bx--card__cta"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                src={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  }
+                                                }
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="bx--card__cta"
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                  />
+                                                  <polygon
+                                                    points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(Launch20)>
+                                          </div>
+                                        </div>
+                                      </a>
+                                    </ClickableTile>
+                                  </Card>
+                                </CardCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--video"
+                            key="3"
+                          >
+                            <CTA
+                              media={
+                                Object {
+                                  "src": "0_uka1msg4",
+                                  "type": "video",
+                                }
+                              }
+                              style="card"
+                              type="video"
+                            >
+                              <div>
+                                <CardCTA
+                                  media={
+                                    Object {
+                                      "src": "0_uka1msg4",
+                                      "type": "video",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="card"
+                                  type="video"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div>
+                                    <Card
+                                      copy=""
+                                      cta={
+                                        Object {
+                                          "href": "#",
+                                          "icon": Object {
+                                            "src": Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "render": [Function],
+                                            },
+                                          },
+                                        }
+                                      }
+                                      customClassName="bx--card__CTA"
+                                      handleClick={[Function]}
+                                      type="link"
+                                    >
+                                      <ClickableTile
+                                        className="bx--card bx--card--link bx--card__CTA"
+                                        clicked={false}
+                                        data-autoid="dds--card"
+                                        handleClick={[Function]}
+                                        handleKeyDown={[Function]}
+                                        href="#"
+                                        light={false}
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                          data-autoid="dds--card"
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          target={null}
+                                        >
+                                          <div
+                                            className="bx--card__wrapper"
+                                          >
+                                            <div
+                                              className="bx--card__footer"
+                                            >
+                                              <ForwardRef(PlayOutline20)
+                                                className="bx--card__cta"
+                                                src={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  }
+                                                }
+                                              >
+                                                <Icon
+                                                  className="bx--card__cta"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="bx--card__cta"
+                                                    focusable="false"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 32 32"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
+                                                    />
+                                                    <path
+                                                      d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
+                                                    />
+                                                  </svg>
+                                                </Icon>
+                                              </ForwardRef(PlayOutline20)>
+                                            </div>
+                                          </div>
+                                        </a>
+                                      </ClickableTile>
+                                    </Card>
+                                  </div>
+                                </CardCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                        </ul>
+                      </div>
+                    </LinkList>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Patterns (Sub-Patterns)|LinkList End Of Section 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="vertical-end"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="vertical-end"
+                    >
+                      <div
+                        className="bx--link-list"
+                        data-autoid="dds--link-list"
+                      >
+                        <h4
+                          className="bx--link-list__heading"
+                        >
+                          Tutorials
+                        </h4>
+                        <ul
+                          className="bx--link-list__list bx--link-list__list--vertical-end"
+                        >
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                            key="0"
+                          >
+                            <CTA
+                              copy="Learn more"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="local"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Learn more"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Learn more
+                                          </span>
+                                          <ForwardRef(ArrowRight20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 20 20"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(ArrowRight20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--download"
                             key="1"
                           >
                             <CTA
-                              copy="Why should you use microservices and containers"
+                              copy="Containerization A Complete Guide"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="download"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Containerization A Complete Guide"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="download"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Containerization A Complete Guide
+                                          </span>
+                                          <ForwardRef(Download20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                                                />
+                                                <path
+                                                  d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Download20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--external"
+                            key="2"
+                          >
+                            <CTA
+                              copy="Microservices and containers"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="external"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Microservices and containers"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="external"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target="_blank"
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target="_blank"
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target="_blank"
+                                        >
+                                          <span>
+                                            Microservices and containers
+                                          </span>
+                                          <ForwardRef(Launch20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                />
+                                                <polygon
+                                                  points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Launch20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--video"
+                            key="3"
+                          >
+                            <CTA
+                              media={
+                                Object {
+                                  "src": "0_uka1msg4",
+                                  "type": "video",
+                                }
+                              }
+                              style="text"
+                              type="video"
+                            >
+                              <div>
+                                <TextCTA
+                                  media={
+                                    Object {
+                                      "src": "0_uka1msg4",
+                                      "type": "video",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="video"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div>
+                                    <LinkWithIcon
+                                      href="#"
+                                      onClick={[Function]}
+                                    >
+                                      <div
+                                        className="bx--link-with-icon__container"
+                                        data-autoid="dds--link-with-icon"
+                                      >
+                                        <Link
+                                          className="bx--link-with-icon"
+                                          href="#"
+                                          onClick={[Function]}
+                                        >
+                                          <a
+                                            className="bx--link bx--link-with-icon"
+                                            href="#"
+                                            onClick={[Function]}
+                                          >
+                                            <span />
+                                            <ForwardRef(PlayOutline20)>
+                                              <Icon
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
+                                                  />
+                                                  <path
+                                                    d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(PlayOutline20)>
+                                          </a>
+                                        </Link>
+                                      </div>
+                                    </LinkWithIcon>
+                                  </div>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                        </ul>
+                      </div>
+                    </LinkList>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Patterns (Sub-Patterns)|LinkList Horizontal 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-10 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                        ]
+                      }
+                      style="horizontal"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-10 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                        ]
+                      }
+                      style="horizontal"
+                    >
+                      <div
+                        className="bx--link-list"
+                        data-autoid="dds--link-list"
+                      >
+                        <h4
+                          className="bx--link-list__heading"
+                        >
+                          Tutorials
+                        </h4>
+                        <ul
+                          className="bx--link-list__list bx--link-list__list--horizontal"
+                        >
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                            key="0"
+                          >
+                            <CTA
+                              copy="Learn more"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="local"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Learn more"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Learn more
+                                          </span>
+                                          <ForwardRef(ArrowRight20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 20 20"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(ArrowRight20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--download"
+                            key="1"
+                          >
+                            <CTA
+                              copy="Containerization A Complete Guide"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="download"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Containerization A Complete Guide"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="download"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Containerization A Complete Guide
+                                          </span>
+                                          <ForwardRef(Download20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                                                />
+                                                <path
+                                                  d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Download20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                        </ul>
+                      </div>
+                    </LinkList>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Patterns (Sub-Patterns)|LinkList Vertical 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="vertical"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="vertical"
+                    >
+                      <div
+                        className="bx--link-list"
+                        data-autoid="dds--link-list"
+                      >
+                        <h4
+                          className="bx--link-list__heading"
+                        >
+                          Tutorials
+                        </h4>
+                        <ul
+                          className="bx--link-list__list bx--link-list__list--vertical"
+                        >
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                            key="0"
+                          >
+                            <CTA
+                              copy="Learn more"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="local"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Learn more"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Learn more
+                                          </span>
+                                          <ForwardRef(ArrowRight20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 20 20"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(ArrowRight20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--download"
+                            key="1"
+                          >
+                            <CTA
+                              copy="Containerization A Complete Guide"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="download"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Containerization A Complete Guide"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="download"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Containerization A Complete Guide
+                                          </span>
+                                          <ForwardRef(Download20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                                                />
+                                                <path
+                                                  d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Download20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--external"
+                            key="2"
+                          >
+                            <CTA
+                              copy="Microservices and containers"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="external"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Microservices and containers"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="external"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target="_blank"
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target="_blank"
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target="_blank"
+                                        >
+                                          <span>
+                                            Microservices and containers
+                                          </span>
+                                          <ForwardRef(Launch20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                />
+                                                <polygon
+                                                  points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Launch20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--video"
+                            key="3"
+                          >
+                            <CTA
+                              media={
+                                Object {
+                                  "src": "0_uka1msg4",
+                                  "type": "video",
+                                }
+                              }
+                              style="text"
+                              type="video"
+                            >
+                              <div>
+                                <TextCTA
+                                  media={
+                                    Object {
+                                      "src": "0_uka1msg4",
+                                      "type": "video",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="video"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div>
+                                    <LinkWithIcon
+                                      href="#"
+                                      onClick={[Function]}
+                                    >
+                                      <div
+                                        className="bx--link-with-icon__container"
+                                        data-autoid="dds--link-with-icon"
+                                      >
+                                        <Link
+                                          className="bx--link-with-icon"
+                                          href="#"
+                                          onClick={[Function]}
+                                        >
+                                          <a
+                                            className="bx--link bx--link-with-icon"
+                                            href="#"
+                                            onClick={[Function]}
+                                          >
+                                            <span />
+                                            <ForwardRef(PlayOutline20)>
+                                              <Icon
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
+                                                  />
+                                                  <path
+                                                    d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(PlayOutline20)>
+                                          </a>
+                                        </Link>
+                                      </div>
+                                    </LinkWithIcon>
+                                  </div>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                        </ul>
+                      </div>
+                    </LinkList>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Patterns (Sub-Patterns)|LinkList Vertical With Cards 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="vertical"
+                    />
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="card"
+                    />
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                className="bx--grid"
+              >
+                <div
+                  className="bx--row"
+                >
+                  <div
+                    className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4"
+                  >
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="vertical"
+                    >
+                      <div
+                        className="bx--link-list"
+                        data-autoid="dds--link-list"
+                      >
+                        <h4
+                          className="bx--link-list__heading"
+                        >
+                          Tutorials
+                        </h4>
+                        <ul
+                          className="bx--link-list__list bx--link-list__list--vertical"
+                        >
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                            key="0"
+                          >
+                            <CTA
+                              copy="Learn more"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="local"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Learn more"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Learn more
+                                          </span>
+                                          <ForwardRef(ArrowRight20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 20 20"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(ArrowRight20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--download"
+                            key="1"
+                          >
+                            <CTA
+                              copy="Containerization A Complete Guide"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="download"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Containerization A Complete Guide"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="download"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Containerization A Complete Guide
+                                          </span>
+                                          <ForwardRef(Download20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <polygon
+                                                  points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                                                />
+                                                <path
+                                                  d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Download20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--external"
+                            key="2"
+                          >
+                            <CTA
+                              copy="Microservices and containers"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="text"
+                              type="external"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Microservices and containers"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="external"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://ibm.com"
+                                    onClick={[Function]}
+                                    target="_blank"
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        target="_blank"
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://ibm.com"
+                                          onClick={[Function]}
+                                          target="_blank"
+                                        >
+                                          <span>
+                                            Microservices and containers
+                                          </span>
+                                          <ForwardRef(Launch20)>
+                                            <Icon
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                />
+                                                <polygon
+                                                  points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Launch20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--video"
+                            key="3"
+                          >
+                            <CTA
+                              media={
+                                Object {
+                                  "src": "0_uka1msg4",
+                                  "type": "video",
+                                }
+                              }
+                              style="text"
+                              type="video"
+                            >
+                              <div>
+                                <TextCTA
+                                  media={
+                                    Object {
+                                      "src": "0_uka1msg4",
+                                      "type": "video",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="video"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div>
+                                    <LinkWithIcon
+                                      href="#"
+                                      onClick={[Function]}
+                                    >
+                                      <div
+                                        className="bx--link-with-icon__container"
+                                        data-autoid="dds--link-with-icon"
+                                      >
+                                        <Link
+                                          className="bx--link-with-icon"
+                                          href="#"
+                                          onClick={[Function]}
+                                        >
+                                          <a
+                                            className="bx--link bx--link-with-icon"
+                                            href="#"
+                                            onClick={[Function]}
+                                          >
+                                            <span />
+                                            <ForwardRef(PlayOutline20)>
+                                              <Icon
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
+                                                  />
+                                                  <path
+                                                    d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(PlayOutline20)>
+                                          </a>
+                                        </Link>
+                                      </div>
+                                    </LinkWithIcon>
+                                  </div>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                        </ul>
+                      </div>
+                    </LinkList>
+                    <LinkList
+                      heading="Tutorials"
+                      items={
+                        Array [
+                          Object {
+                            "copy": "Learn more",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "local",
+                          },
+                          Object {
+                            "copy": "Containerization A Complete Guide",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "download",
+                          },
+                          Object {
+                            "copy": "Microservices and containers",
+                            "cta": Object {
+                              "href": "https://ibm.com",
+                            },
+                            "type": "external",
+                          },
+                          Object {
+                            "media": Object {
+                              "src": "0_uka1msg4",
+                              "type": "video",
+                            },
+                            "type": "video",
+                          },
+                        ]
+                      }
+                      style="card"
+                    >
+                      <div
+                        className="bx--link-list"
+                        data-autoid="dds--link-list"
+                      >
+                        <h4
+                          className="bx--link-list__heading"
+                        >
+                          Tutorials
+                        </h4>
+                        <ul
+                          className="bx--link-list__list bx--link-list__list--card"
+                        >
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                            key="0"
+                          >
+                            <CTA
+                              copy="Learn more"
                               cta={
                                 Object {
                                   "href": "https://ibm.com",
@@ -29224,7 +31876,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                             >
                               <div>
                                 <CardCTA
-                                  copy="Why should you use microservices and containers"
+                                  copy="Learn more"
                                   cta={
                                     Object {
                                       "href": "https://ibm.com",
@@ -29244,7 +31896,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                   }
                                 >
                                   <Card
-                                    copy="Why should you use microservices and containers"
+                                    copy="Learn more"
                                     cta={
                                       Object {
                                         "href": "https://ibm.com",
@@ -29290,7 +31942,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                                             className="bx--card__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Why should you use microservices and containers</p>",
+                                                "__html": "<p>Learn more</p>",
                                               }
                                             }
                                           />
@@ -29352,8 +32004,300 @@ exports[`Storyshots Patterns (Sub-Patterns)|LinkList Default 1`] = `
                             </CTA>
                           </li>
                           <li
-                            className="bx--link-list__list__CTA"
+                            className="bx--link-list__list__CTA bx--link-list__list--download"
+                            key="1"
+                          >
+                            <CTA
+                              copy="Containerization A Complete Guide"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="card"
+                              type="download"
+                            >
+                              <div>
+                                <CardCTA
+                                  copy="Containerization A Complete Guide"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="card"
+                                  type="download"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Card
+                                    copy="Containerization A Complete Guide"
+                                    cta={
+                                      Object {
+                                        "href": "https://ibm.com",
+                                        "icon": Object {
+                                          "src": Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "render": [Function],
+                                          },
+                                        },
+                                      }
+                                    }
+                                    customClassName="bx--card__CTA"
+                                    handleClick={[Function]}
+                                    role="region"
+                                    target={null}
+                                    type="link"
+                                  >
+                                    <ClickableTile
+                                      className="bx--card bx--card--link bx--card__CTA"
+                                      clicked={false}
+                                      data-autoid="dds--card"
+                                      handleClick={[Function]}
+                                      handleKeyDown={[Function]}
+                                      href="https://ibm.com"
+                                      light={false}
+                                      onClick={[Function]}
+                                      role="region"
+                                      target={null}
+                                    >
+                                      <a
+                                        className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                        data-autoid="dds--card"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="region"
+                                        target={null}
+                                      >
+                                        <div
+                                          className="bx--card__wrapper"
+                                        >
+                                          <div
+                                            className="bx--card__copy"
+                                            dangerouslySetInnerHTML={
+                                              Object {
+                                                "__html": "<p>Containerization A Complete Guide</p>",
+                                              }
+                                            }
+                                          />
+                                          <div
+                                            className="bx--card__footer"
+                                          >
+                                            <ForwardRef(Download20)
+                                              className="bx--card__cta"
+                                              src={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                }
+                                              }
+                                            >
+                                              <Icon
+                                                className="bx--card__cta"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                src={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  }
+                                                }
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="bx--card__cta"
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <polygon
+                                                    points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                                                  />
+                                                  <path
+                                                    d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(Download20)>
+                                          </div>
+                                        </div>
+                                      </a>
+                                    </ClickableTile>
+                                  </Card>
+                                </CardCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--external"
                             key="2"
+                          >
+                            <CTA
+                              copy="Microservices and containers"
+                              cta={
+                                Object {
+                                  "href": "https://ibm.com",
+                                }
+                              }
+                              style="card"
+                              type="external"
+                            >
+                              <div>
+                                <CardCTA
+                                  copy="Microservices and containers"
+                                  cta={
+                                    Object {
+                                      "href": "https://ibm.com",
+                                    }
+                                  }
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="card"
+                                  type="external"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Card
+                                    copy="Microservices and containers"
+                                    cta={
+                                      Object {
+                                        "href": "https://ibm.com",
+                                        "icon": Object {
+                                          "src": Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "render": [Function],
+                                          },
+                                        },
+                                      }
+                                    }
+                                    customClassName="bx--card__CTA"
+                                    handleClick={[Function]}
+                                    role="region"
+                                    target="_blank"
+                                    type="link"
+                                  >
+                                    <ClickableTile
+                                      className="bx--card bx--card--link bx--card__CTA"
+                                      clicked={false}
+                                      data-autoid="dds--card"
+                                      handleClick={[Function]}
+                                      handleKeyDown={[Function]}
+                                      href="https://ibm.com"
+                                      light={false}
+                                      onClick={[Function]}
+                                      role="region"
+                                      target="_blank"
+                                    >
+                                      <a
+                                        className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                        data-autoid="dds--card"
+                                        href="https://ibm.com"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="region"
+                                        target="_blank"
+                                      >
+                                        <div
+                                          className="bx--card__wrapper"
+                                        >
+                                          <div
+                                            className="bx--card__copy"
+                                            dangerouslySetInnerHTML={
+                                              Object {
+                                                "__html": "<p>Microservices and containers</p>",
+                                              }
+                                            }
+                                          />
+                                          <div
+                                            className="bx--card__footer"
+                                          >
+                                            <ForwardRef(Launch20)
+                                              className="bx--card__cta"
+                                              src={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                }
+                                              }
+                                            >
+                                              <Icon
+                                                className="bx--card__cta"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                src={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  }
+                                                }
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="bx--card__cta"
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                  viewBox="0 0 32 32"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                  />
+                                                  <polygon
+                                                    points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(Launch20)>
+                                          </div>
+                                        </div>
+                                      </a>
+                                    </ClickableTile>
+                                  </Card>
+                                </CardCTA>
+                              </div>
+                            </CTA>
+                          </li>
+                          <li
+                            className="bx--link-list__list__CTA bx--link-list__list--video"
+                            key="3"
                           >
                             <CTA
                               media={
@@ -29744,7 +32688,9 @@ exports[`Storyshots Patterns (Sub-Patterns)|PictogramItem Default 1`] = `
                                               onClick={[Function]}
                                               target={null}
                                             >
-                                              Lorem ipsum dolor
+                                              <span>
+                                                Lorem ipsum dolor
+                                              </span>
                                               <ForwardRef(ArrowRight20)>
                                                 <Icon
                                                   height={20}

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -26625,6 +26625,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -26709,6 +26710,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                 },
                               ]
                             }
+                            style="card"
                           />,
                         }
                       }
@@ -26972,6 +26974,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                       },
                                     ]
                                   }
+                                  style="card"
                                 >
                                   <div
                                     className="bx--link-list"
@@ -26983,7 +26986,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                       Tutorials
                                     </h4>
                                     <ul
-                                      className="bx--link-list__list bx--link-list__list--undefined"
+                                      className="bx--link-list__list bx--link-list__list--card"
                                     >
                                       <li
                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -26996,11 +26999,11 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               "href": "https://ibm.com",
                                             }
                                           }
-                                          style="text"
+                                          style="card"
                                           type="local"
                                         >
                                           <div>
-                                            <TextCTA
+                                            <CardCTA
                                               copy="Containerization A Complete Guide"
                                               cta={
                                                 Object {
@@ -27009,7 +27012,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               }
                                               openLightBox={[Function]}
                                               renderLightBox={false}
-                                              style="text"
+                                              style="card"
                                               type="local"
                                               videoTitle={
                                                 Array [
@@ -27020,58 +27023,111 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                                 ]
                                               }
                                             >
-                                              <LinkWithIcon
-                                                href="https://ibm.com"
-                                                onClick={[Function]}
+                                              <Card
+                                                copy="Containerization A Complete Guide"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://ibm.com",
+                                                    "icon": Object {
+                                                      "src": Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      },
+                                                    },
+                                                  }
+                                                }
+                                                customClassName="bx--card__CTA"
+                                                handleClick={[Function]}
+                                                role="region"
                                                 target={null}
+                                                type="link"
                                               >
-                                                <div
-                                                  className="bx--link-with-icon__container"
-                                                  data-autoid="dds--link-with-icon"
+                                                <ClickableTile
+                                                  className="bx--card bx--card--link bx--card__CTA"
+                                                  clicked={false}
+                                                  data-autoid="dds--card"
+                                                  handleClick={[Function]}
+                                                  handleKeyDown={[Function]}
+                                                  href="https://ibm.com"
+                                                  light={false}
+                                                  onClick={[Function]}
+                                                  role="region"
+                                                  target={null}
                                                 >
-                                                  <Link
-                                                    className="bx--link-with-icon"
+                                                  <a
+                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                    data-autoid="dds--card"
                                                     href="https://ibm.com"
                                                     onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    role="region"
                                                     target={null}
                                                   >
-                                                    <a
-                                                      className="bx--link bx--link-with-icon"
-                                                      href="https://ibm.com"
-                                                      onClick={[Function]}
-                                                      target={null}
+                                                    <div
+                                                      className="bx--card__wrapper"
                                                     >
-                                                      <span>
-                                                        Containerization A Complete Guide
-                                                      </span>
-                                                      <ForwardRef(ArrowRight20)>
-                                                        <Icon
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 20 20"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                      <div
+                                                        className="bx--card__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Containerization A Complete Guide</p>",
+                                                          }
+                                                        }
+                                                      />
+                                                      <div
+                                                        className="bx--card__footer"
+                                                      >
+                                                        <ForwardRef(ArrowRight20)
+                                                          className="bx--card__cta"
+                                                          src={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            }
+                                                          }
                                                         >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            focusable="false"
+                                                          <Icon
+                                                            className="bx--card__cta"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
                                                             viewBox="0 0 20 20"
                                                             width={20}
                                                             xmlns="http://www.w3.org/2000/svg"
                                                           >
-                                                            <polygon
-                                                              points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
-                                                            />
-                                                          </svg>
-                                                        </Icon>
-                                                      </ForwardRef(ArrowRight20)>
-                                                    </a>
-                                                  </Link>
-                                                </div>
-                                              </LinkWithIcon>
-                                            </TextCTA>
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="bx--card__cta"
+                                                              focusable="false"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                              viewBox="0 0 20 20"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <polygon
+                                                                points="11.8,2.8 10.8,3.8 16.2,9.3 1,9.3 1,10.7 16.2,10.7 10.8,16.2 11.8,17.2 19,10"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(ArrowRight20)>
+                                                      </div>
+                                                    </div>
+                                                  </a>
+                                                </ClickableTile>
+                                              </Card>
+                                            </CardCTA>
                                           </div>
                                         </CTA>
                                       </li>
@@ -27086,11 +27142,11 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               "href": "https://ibm.com",
                                             }
                                           }
-                                          style="text"
+                                          style="card"
                                           type="external"
                                         >
                                           <div>
-                                            <TextCTA
+                                            <CardCTA
                                               copy="Why should you use microservices and containers"
                                               cta={
                                                 Object {
@@ -27099,7 +27155,7 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                               }
                                               openLightBox={[Function]}
                                               renderLightBox={false}
-                                              style="text"
+                                              style="card"
                                               type="external"
                                               videoTitle={
                                                 Array [
@@ -27110,61 +27166,114 @@ exports[`Storyshots Patterns (Sub-Patterns)|ContentBlock With aside elements 1`]
                                                 ]
                                               }
                                             >
-                                              <LinkWithIcon
-                                                href="https://ibm.com"
-                                                onClick={[Function]}
+                                              <Card
+                                                copy="Why should you use microservices and containers"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://ibm.com",
+                                                    "icon": Object {
+                                                      "src": Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      },
+                                                    },
+                                                  }
+                                                }
+                                                customClassName="bx--card__CTA"
+                                                handleClick={[Function]}
+                                                role="region"
                                                 target="_blank"
+                                                type="link"
                                               >
-                                                <div
-                                                  className="bx--link-with-icon__container"
-                                                  data-autoid="dds--link-with-icon"
+                                                <ClickableTile
+                                                  className="bx--card bx--card--link bx--card__CTA"
+                                                  clicked={false}
+                                                  data-autoid="dds--card"
+                                                  handleClick={[Function]}
+                                                  handleKeyDown={[Function]}
+                                                  href="https://ibm.com"
+                                                  light={false}
+                                                  onClick={[Function]}
+                                                  role="region"
+                                                  target="_blank"
                                                 >
-                                                  <Link
-                                                    className="bx--link-with-icon"
+                                                  <a
+                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                    data-autoid="dds--card"
                                                     href="https://ibm.com"
                                                     onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    role="region"
                                                     target="_blank"
                                                   >
-                                                    <a
-                                                      className="bx--link bx--link-with-icon"
-                                                      href="https://ibm.com"
-                                                      onClick={[Function]}
-                                                      target="_blank"
+                                                    <div
+                                                      className="bx--card__wrapper"
                                                     >
-                                                      <span>
-                                                        Why should you use microservices and containers
-                                                      </span>
-                                                      <ForwardRef(Launch20)>
-                                                        <Icon
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 32 32"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
+                                                      <div
+                                                        className="bx--card__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Why should you use microservices and containers</p>",
+                                                          }
+                                                        }
+                                                      />
+                                                      <div
+                                                        className="bx--card__footer"
+                                                      >
+                                                        <ForwardRef(Launch20)
+                                                          className="bx--card__cta"
+                                                          src={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            }
+                                                          }
                                                         >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            focusable="false"
+                                                          <Icon
+                                                            className="bx--card__cta"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
                                                             viewBox="0 0 32 32"
                                                             width={20}
                                                             xmlns="http://www.w3.org/2000/svg"
                                                           >
-                                                            <path
-                                                              d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                            />
-                                                            <polygon
-                                                              points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
-                                                            />
-                                                          </svg>
-                                                        </Icon>
-                                                      </ForwardRef(Launch20)>
-                                                    </a>
-                                                  </Link>
-                                                </div>
-                                              </LinkWithIcon>
-                                            </TextCTA>
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="bx--card__cta"
+                                                              focusable="false"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                              viewBox="0 0 32 32"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                              />
+                                                              <polygon
+                                                                points="21 2 21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(Launch20)>
+                                                      </div>
+                                                    </div>
+                                                  </a>
+                                                </ClickableTile>
+                                              </Card>
+                                            </CardCTA>
                                           </div>
                                         </CTA>
                                       </li>

--- a/packages/react/src/components/CTA/TextCTA.js
+++ b/packages/react/src/components/CTA/TextCTA.js
@@ -41,7 +41,7 @@ const TextCTA = ({
         <LinkWithIcon
           href="#"
           onClick={e => CTALogic.setLightBox(e, openLightBox)}>
-          {videoTitle[0].title}
+          <span>{videoTitle[0].title}</span>
           <Icon />
         </LinkWithIcon>
       )}
@@ -51,7 +51,7 @@ const TextCTA = ({
       href={href}
       target={CTALogic.external(type)}
       onClick={e => CTALogic.jump(e, type)}>
-      {otherProps.copy}
+      <span>{otherProps.copy}</span>
       <Icon />
     </LinkWithIcon>
   );

--- a/packages/react/src/patterns/blocks/CalloutQuote/CalloutQuote.js
+++ b/packages/react/src/patterns/blocks/CalloutQuote/CalloutQuote.js
@@ -26,6 +26,7 @@ const { prefix } = settings;
  * @param {string} props.quote.cta.copy cta copy
  * @param {string} props.quote.cta.type type 'local' or 'external'
  * @param {string} props.quote.cta.href cta href
+ * @returns {*} JSX CalloutQuote component
  */
 const CalloutQuote = ({ quote }) => {
   return (

--- a/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMedia/__stories__/ContentBlockMedia.stories.js
@@ -174,7 +174,7 @@ export const WithAsideElements = () => {
   };
 
   const aside = {
-    items: <LinkList {...linkListProps} />,
+    items: <LinkList style="card" {...linkListProps} />,
     border: boolean('border', false),
   };
 

--- a/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockMixed/__stories__/ContentBlockMixed.stories.js
@@ -262,7 +262,7 @@ export const WithAsideElements = () => {
   };
 
   const aside = {
-    items: <LinkList {...linkListProps} />,
+    items: <LinkList style="card" {...linkListProps} />,
     border: boolean('border', false),
   };
 

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -226,7 +226,7 @@ export const WithAsideElements = () => {
   };
 
   const aside = {
-    items: <LinkList {...linkListProps} />,
+    items: <LinkList style="card" {...linkListProps} />,
     border: boolean('border', false),
   };
 

--- a/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
@@ -213,7 +213,7 @@ export const WithAsideElements = () => {
   };
 
   const aside = {
-    items: <LinkList {...linkListProps} />,
+    items: <LinkList style="card" {...linkListProps} />,
     border: boolean('border', false),
   };
 

--- a/packages/react/src/patterns/blocks/ContentGroupHorizontal/README.md
+++ b/packages/react/src/patterns/blocks/ContentGroupHorizontal/README.md
@@ -39,18 +39,24 @@ function App() {
       heading: 'Aliquam condimentum',
       copy:
         'Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin.',
-      cta: [
-        {
-          type: 'local',
-          copy: 'Link text',
-          href: 'https://example.com',
-        },
-        {
-          type: 'external',
-          copy: 'External link text',
-          href: 'https://example.com',
-        },
-      ],
+      cta: {
+        items: [
+          {
+            type: 'local',
+            copy: 'Link text',
+            cta: {
+              href: 'https://example.com',
+            },
+          },
+          {
+            type: 'external',
+            copy: 'External link text',
+            cta: {
+              href: 'https://example.com',
+            },
+          },
+        ],
+      },
     },
     {
       eyebrow: 'Lorem ipsum',

--- a/packages/react/src/patterns/blocks/ContentGroupHorizontal/__stories__/data/items.json
+++ b/packages/react/src/patterns/blocks/ContentGroupHorizontal/__stories__/data/items.json
@@ -4,47 +4,63 @@
       "eyebrow": "Lorem ipsum",
       "heading": "Aliquam condimentum",
       "copy": "Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin.",
-      "cta": [
-        {
-          "type": "local",
-          "copy": "Link text",
-          "href": "https://example.com"
-        },
-        {
-          "type": "external",
-          "copy": "External link text",
-          "href": "https://example.com"
-        }
-      ]
+      "cta": {
+        "items": [
+          {
+            "type": "local",
+            "copy": "Link text",
+            "cta": {
+              "href": "https://example.com"
+            }
+          },
+          {
+            "type": "external",
+            "copy": "External link text",
+            "cta": {
+              "href": "https://example.com"
+            }
+          }
+        ]
+      }
     },
     {
       "eyebrow": "Lorem ipsum",
       "heading": "Aliquam condimentum",
       "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-      "cta": [
-        {
-          "type": "local",
-          "copy": "Link text",
-          "href": "https://example.com"
-        },
-        {
-          "type": "external",
-          "copy": "External link text",
-          "href": "https://example.com"
-        }
-      ]
+      "cta": {
+        "items": [
+          {
+            "type": "local",
+            "copy": "Link text",
+            "cta": {
+              "href": "https://example.com"
+            }
+          },
+          {
+            "type": "external",
+            "copy": "External link text",
+            "cta": {
+              "href": "https://example.com"
+            }
+          }
+        ]
+      }
     },
     {
       "eyebrow": "Lorem ipsum",
       "heading": "Aliquam condimentum",
       "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-      "cta": [
-        {
-          "type": "local",
-          "copy": "Link text",
-          "href": "https://example.com"
-        }
-      ]
+      "cta": {
+        "items": [
+          {
+            "type": "local",
+            "copy": "Link text",
+            "cta": {
+              "href": "https://example.com"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
+++ b/packages/react/src/patterns/sub-patterns/ContentBlock/__stories__/ContentBlock.stories.js
@@ -122,7 +122,7 @@ export const WithAsideElements = () => {
   };
 
   const aside = {
-    items: <LinkList {...linkListProps} />,
+    items: <LinkList style="card" {...linkListProps} />,
     border: boolean('border', false),
   };
 

--- a/packages/react/src/patterns/sub-patterns/ContentItemHorizontal/ContentItemHorizontal.js
+++ b/packages/react/src/patterns/sub-patterns/ContentItemHorizontal/ContentItemHorizontal.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { CTA } from '../../../components/CTA';
 import { settings as ddsSettings } from '@carbon/ibmdotcom-utilities';
+import { LinkList } from '../../../patterns/sub-patterns/LinkList';
 import { markdownToHtml } from '@carbon/ibmdotcom-utilities';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -57,14 +57,7 @@ const ContentItemHorizontal = ({ eyebrow, heading, copy, cta }) => (
           <div
             className={`${prefix}--content-item-horizontal__item--cta`}
             data-autoid={`${stablePrefix}--content-item-horizontal__item--cta`}>
-            {cta.map((cta, index) => (
-              <CTA
-                style="text"
-                {...cta}
-                customClassName={`${prefix}--card__cta`}
-                key={index}
-              />
-            ))}
+            <LinkList style="horizontal" {...cta} />
           </div>
         )}
       </div>

--- a/packages/react/src/patterns/sub-patterns/ContentItemHorizontal/__stories__/ContentItemHorizontal.stories.js
+++ b/packages/react/src/patterns/sub-patterns/ContentItemHorizontal/__stories__/ContentItemHorizontal.stories.js
@@ -28,18 +28,25 @@ export const Default = () => {
     'Copy',
     'Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.'
   );
-  const cta = object('cta', [
-    {
-      type: 'local',
-      copy: 'Link text',
-      href: 'https://example.com',
-    },
-    {
-      type: 'external',
-      copy: 'External link text',
-      href: 'https://example.com',
-    },
-  ]);
+
+  const cta = {
+    items: object('link list items array', [
+      {
+        type: 'local',
+        copy: 'Learn more',
+        cta: {
+          href: 'https://ibm.com',
+        },
+      },
+      {
+        type: 'external',
+        copy: 'Microservices and containers',
+        cta: {
+          href: 'https://ibm.com',
+        },
+      },
+    ]),
+  };
 
   return (
     <div className="bx--grid bx--content-group-story">

--- a/packages/react/src/patterns/sub-patterns/LinkList/LinkList.js
+++ b/packages/react/src/patterns/sub-patterns/LinkList/LinkList.js
@@ -22,17 +22,24 @@ const { prefix } = settings;
  * @param {Array} props.items array of item
  * @returns {*} JSX LinkList component
  */
-const LinkList = ({ heading, items }) => {
+const LinkList = ({ heading, items, style }) => {
+  const linkStyle = style === 'card' ? 'card' : 'text';
   return (
     <div
       className={`${prefix}--link-list`}
       data-autoid={`${stablePrefix}--link-list`}>
-      <h4 className={`${prefix}--link-list__heading`}>{heading}</h4>
-      <ul className={`${prefix}--link-list__list`}>
+      {heading && (
+        <h4 className={`${prefix}--link-list__heading`}>{heading}</h4>
+      )}
+
+      <ul
+        className={`${prefix}--link-list__list ${prefix}--link-list__list--${style}`}>
         {items.map((cta, index) => {
           return (
-            <li className={`${prefix}--link-list__list__CTA`} key={index}>
-              <CTA style="card" {...cta} />
+            <li
+              className={`${prefix}--link-list__list__CTA ${prefix}--link-list__list--${cta.type}`}
+              key={index}>
+              <CTA style={linkStyle} {...cta} />
             </li>
           );
         })}
@@ -44,6 +51,7 @@ const LinkList = ({ heading, items }) => {
 LinkList.propTypes = {
   heading: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(PropTypes.shape(CTA.propTypes)).isRequired,
+  style: PropTypes.string.isRequired,
 };
 
 export default LinkList;

--- a/packages/react/src/patterns/sub-patterns/LinkList/README.md
+++ b/packages/react/src/patterns/sub-patterns/LinkList/README.md
@@ -35,13 +35,17 @@ function App() {
       heading: 'Containerization: A Complete Guide',
       type: 'local',
       copy: 'Lorem ipsum dolor sit amet',
-      href: 'https://ibm.com',
+      cta: {
+        href: 'https://ibm.com',
+      },
     },
     {
       heading: 'Why should you use microservices and containers?',
       type: 'external',
       copy: 'Lorem ipsum dolor sit amet',
-      href: 'https://ibm.com',
+      cta: {
+        href: 'https://ibm.com',
+      },
     },
     {
       type: 'video',
@@ -51,7 +55,13 @@ function App() {
       },
     },
   ];
-  return <LinkList heading={heading} items={items} />;
+  return (
+    <LinkList
+      style="card|horizontal|vertical"
+      heading={heading}
+      items={items}
+    />
+  );
 }
 
 ReactDOM.render(<App />, document.querySelector('#app'));
@@ -69,10 +79,11 @@ Add the following line in your `.env` file at the root of your project.
 
 ## Props
 
-| Name      | Required | Data Type | Default Value | Description                                          |
-| --------- | -------- | --------- | ------------- | ---------------------------------------------------- |
-| `heading` | YES      | String    | text          | Describes heading of LinkList.                       |
-| `items`   | YES      | Array     | null          | Describes the list of CTA. For more See below `CTA`. |
+| Name      | Required | Data Type | Default Value | Description                                                            |
+| --------- | -------- | --------- | ------------- | ---------------------------------------------------------------------- |
+| `heading` | YES      | String    | text          | Describes heading of LinkList.                                         |
+| `items`   | YES      | Array     | null          | Describes the list of CTA. For more See below `CTA`.                   |
+| `style`   | YES      | String    | null          | Orientation of LinkList. Supports `card`, `horizontal`, and `vertical` |
 
 ### CTA
 

--- a/packages/react/src/patterns/sub-patterns/LinkList/__stories__/LinkList.stories.js
+++ b/packages/react/src/patterns/sub-patterns/LinkList/__stories__/LinkList.stories.js
@@ -21,7 +21,7 @@ export default {
   },
 };
 
-const heading = text('heading (required):', 'Tutorials');
+const heading = text('Heading (heading):', 'Tutorials');
 const headlines = [
   'Learn more',
   'Containerization A Complete Guide',
@@ -114,7 +114,7 @@ export const Vertical = () => {
           <LinkList
             style="vertical"
             heading={heading}
-            items={object('Items array ', items)}
+            items={object('Items (items):', items)}
           />
         </div>
       </div>
@@ -130,12 +130,12 @@ export const VerticalWithCards = () => {
           <LinkList
             style="vertical"
             heading={heading}
-            items={object('Items array ', items)}
+            items={object('Items (items):', items)}
           />
           <LinkList
             style="card"
             heading={heading}
-            items={object('Items array ', items)}
+            items={object('Items (items):', items)}
           />
         </div>
       </div>
@@ -151,7 +151,7 @@ export const EndOfSection = () => {
           <LinkList
             style="vertical-end"
             heading={heading}
-            items={object('Items array ', items)}
+            items={object('Items (items):', items)}
           />
         </div>
       </div>

--- a/packages/react/src/patterns/sub-patterns/LinkList/__stories__/LinkList.stories.js
+++ b/packages/react/src/patterns/sub-patterns/LinkList/__stories__/LinkList.stories.js
@@ -21,42 +21,138 @@ export default {
   },
 };
 
-export const Default = () => {
-  const heading = text('heading (required):', 'Tutorials');
-  const headlines = [
-    'Containerization A Complete Guide',
-    'Why should you use microservices and containers',
-  ];
-  const types = ['local', 'external', 'video'];
-  const items = [
-    {
-      type: types[0],
-      copy: headlines[0],
-      cta: {
-        href: 'https://ibm.com',
-      },
+const heading = text('heading (required):', 'Tutorials');
+const headlines = [
+  'Learn more',
+  'Containerization A Complete Guide',
+  'Microservices and containers',
+];
+const types = ['download', 'local', 'external', 'video'];
+const items = [
+  {
+    type: types[1],
+    copy: headlines[0],
+    cta: {
+      href: 'https://ibm.com',
     },
-    {
-      type: types[0],
-      copy: headlines[1],
-      cta: {
-        href: 'https://ibm.com',
-      },
+  },
+  {
+    type: types[0],
+    copy: headlines[1],
+    cta: {
+      href: 'https://ibm.com',
     },
-    {
-      type: types[2],
-      media: {
-        src: '0_uka1msg4',
-        type: 'video',
-      },
+  },
+  {
+    type: types[2],
+    copy: headlines[2],
+    cta: {
+      href: 'https://ibm.com',
     },
-  ];
+  },
+  {
+    type: types[3],
+    media: {
+      src: '0_uka1msg4',
+      type: 'video',
+    },
+  },
+];
 
+export const Default = () => {
   return (
     <div className="bx--grid">
       <div className="bx--row">
         <div className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4">
-          <LinkList heading={heading} items={object('Items array ', items)} />
+          <LinkList
+            style="card"
+            heading={heading}
+            items={object('Items array ', items)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const Horizontal = () => {
+  return (
+    <div className="bx--grid">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-10 bx--offset-lg-4">
+          <LinkList
+            style="horizontal"
+            heading={heading}
+            items={object('Items array ', [
+              {
+                type: types[1],
+                copy: headlines[0],
+                cta: {
+                  href: 'https://ibm.com',
+                },
+              },
+              {
+                type: types[0],
+                copy: headlines[1],
+                cta: {
+                  href: 'https://ibm.com',
+                },
+              },
+            ])}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const Vertical = () => {
+  return (
+    <div className="bx--grid">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4">
+          <LinkList
+            style="vertical"
+            heading={heading}
+            items={object('Items array ', items)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const VerticalWithCards = () => {
+  return (
+    <div className="bx--grid">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-4 bx--offset-lg-4">
+          <LinkList
+            style="vertical"
+            heading={heading}
+            items={object('Items array ', items)}
+          />
+          <LinkList
+            style="card"
+            heading={heading}
+            items={object('Items array ', items)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const EndOfSection = () => {
+  return (
+    <div className="bx--grid">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-8 bx--offset-lg-4">
+          <LinkList
+            style="vertical-end"
+            heading={heading}
+            items={object('Items array ', items)}
+          />
         </div>
       </div>
     </div>

--- a/packages/styles/scss/patterns/sub-patterns/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-item-horizontal/_content-item-horizontal.scss
@@ -59,14 +59,11 @@
       &--cta {
         margin-top: auto;
 
-        .#{$prefix}--card__cta {
-          margin-bottom: $spacing-05;
-          @include carbon--breakpoint(md) {
-            display: inline-block;
-            margin-bottom: 0;
-            &:first-of-type {
-              margin-right: $spacing-07;
-            }
+        .#{$prefix}--link-list {
+          padding: 0;
+
+          &:first-of-type {
+            padding: 0;
           }
         }
       }

--- a/packages/styles/scss/patterns/sub-patterns/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-item-horizontal/_content-item-horizontal.scss
@@ -66,21 +66,27 @@
             padding: 0;
           }
         }
+
+        .#{$prefix}--link-list li {
+          @include carbon--breakpoint(md) {
+            padding-bottom: $carbon--spacing-05;
+          }
+        }
       }
 
       @include carbon--breakpoint(sm) {
-        padding-top: $carbon--layout-03;
-        padding-bottom: $carbon--layout-03;
+        padding-top: $carbon--spacing-07;
+        padding-bottom: $carbon--spacing-07;
       }
 
       @include carbon--breakpoint(md) {
-        padding-top: $carbon--layout-03;
-        padding-bottom: $carbon--layout-05;
+        padding-top: $carbon--spacing-07;
+        padding-bottom: $carbon--spacing-09;
       }
 
       @include carbon--breakpoint(lg) {
-        padding-top: $carbon--layout-03;
-        padding-bottom: $carbon--layout-05;
+        padding-top: $carbon--spacing-07;
+        padding-bottom: $carbon--spacing-09;
       }
 
       padding-left: $carbon--spacing-05;

--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -78,8 +78,6 @@
         }
 
         .#{$prefix}--link-list__list--card & {
-          @include hang;
-
           div .#{$prefix}--tile {
             margin-left: 0;
             margin-right: 0;
@@ -101,6 +99,10 @@
             border-bottom: 1px solid $ui-03;
           }
         }
+      }
+
+      &.#{$prefix}--link-list__list--card {
+        @include hang;
       }
     }
 

--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -1,14 +1,18 @@
-//
-// Copyright IBM Corp. 2016, 2018
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @mixin link-list {
   .#{$prefix}--link-list {
     padding-bottom: $carbon--layout-05;
-    padding-top: $carbon--layout-05;
+
+    &:first-of-type {
+      padding-top: $carbon--layout-05;
+    }
+
     &__heading {
       margin-bottom: $carbon--spacing-05;
 
@@ -17,27 +21,85 @@
       color: $text-01;
     }
     &__list {
-      @include hang;
-      &__CTA {
-        div .#{$prefix}--tile {
-          margin-left: 0;
-          margin-right: 0;
+      overflow: hidden;
 
-          .#{$prefix}--card__wrapper {
-            padding-left: 1rem;
-            padding-right: 1rem;
+      &__CTA {
+        .#{$prefix}--link-list__list--horizontal & {
+          float: left;
+          padding-right: $carbon--spacing-07;
+          padding-bottom: $carbon--spacing-05;
+
+          @include carbon--breakpoint('md') {
+            padding-bottom: 0;
           }
         }
 
-        border-top: 1px solid $ui-03;
-        &:first-child {
-          border-top: 1px solid $ui-03;
+        .#{$prefix}--link-list__list--vertical & {
+          padding-bottom: $carbon--spacing-05;
+
+          &:last-of-type {
+            padding-bottom: 0;
+          }
+
+          .bx--link-with-icon__container {
+            a {
+              flex-direction: row-reverse;
+            }
+          }
+
+          svg {
+            align-self: start;
+            margin-left: 0;
+            margin-right: $carbon--spacing-03;
+          }
+
+          &.#{$prefix}--link-list__list--local {
+            svg {
+              transform: scaleX(-1);
+            }
+          }
         }
-        &:not(:first-child) {
-          border-top: 1px solid $ui-03;
-        }
-        &:last-child {
+
+        .#{$prefix}--link-list__list--vertical-end & {
           border-bottom: 1px solid $ui-03;
+          max-width: 640px;
+
+          &:first-of-type {
+            border-top: 1px solid $ui-03;
+          }
+
+          .bx--link-with-icon__container {
+            width: 100%;
+            a {
+              padding: $carbon--spacing-05 0;
+              justify-content: space-between;
+            }
+          }
+        }
+
+        .#{$prefix}--link-list__list--card & {
+          @include hang;
+
+          div .#{$prefix}--tile {
+            margin-left: 0;
+            margin-right: 0;
+            min-height: 0;
+
+            .#{$prefix}--card__wrapper {
+              padding-left: 1rem;
+              padding-right: 1rem;
+              min-height: 0;
+
+              @include carbon--breakpoint('lg') {
+                min-height: 116px;
+              }
+            }
+          }
+
+          border-top: 1px solid $ui-03;
+          &:last-of-type {
+            border-bottom: 1px solid $ui-03;
+          }
         }
       }
     }
@@ -45,7 +107,20 @@
     .#{$prefix}--card {
       max-width: none;
       &__wrapper {
-        min-height: 116px;
+        flex-direction: row;
+        justify-content: space-between;
+
+        @include carbon--breakpoint('lg') {
+          flex-direction: column;
+        }
+
+        .#{$prefix}--card__copy {
+          margin-bottom: 0;
+
+          @include carbon--breakpoint('lg') {
+            margin-bottom: $carbon--spacing-07;
+          }
+        }
 
         .#{$prefix}--card__copy p {
           color: $link-01;

--- a/tasks/tag-release.sh
+++ b/tasks/tag-release.sh
@@ -140,9 +140,8 @@ change_logs () {
   fi
 
   body=$(printf "%s\n" "$react$patterns$vanilla$services$styles$utilities") > TEMP_RELEASENOTES.md
-  url="$repo?access_token=$token"
 
-response=$(curl -i -X POST $url \
+response=$(curl -i -H "Authorization: token $token" -X POST $repo \
 -d @- << EOF
 {
   "tag_name":"$tagname",


### PR DESCRIPTION
### Related Ticket(s)

#1850 

### Description

This adds `horizontal` and `vertical` layout options to `LinkList`.

### Changelog

**New**

- `horizontal` and `vertical` styling options added to `LinkList`

**Changed**

- various `ContentBlock` patterns updated with `LinkList`
- `ContentItemHorizontal` updated to use `LinkList` instead of `CTA`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
