### PR TITLE
fix(masthead):  added top property to profile-list

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -117,6 +117,7 @@ const Masthead = ({
       `.${prefix}--masthead__profile-item`
     );
     profileMenuList.closest('ul').style.position = 'fixed';
+    profileMenuList.closest('ul').style.top = '48px';
   };
 
   const [isMastheadSticky, setIsMastheadSticky] = useState(false);


### PR DESCRIPTION
### Related Ticket(s)

Learn page - User clicks on the profile icon, drop down is not displayed. #2168

### Description

The problem related in the ticket above was happening in the `DotcomShell` component as well. The profile-list was being set to position fixed, but without the `top` property being specified, which was causing it to render out of the screen limits according the user scroll down.  

### Changelog

**New**

- `top: 48px` property set at the style object in the `setProfileListPosition` function in the `Masthead` component;