### PR TITLE
Fix/percy hide css

### DIFF
--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -1,3 +1,10 @@
+//
+// Copyright IBM Corp. 2016, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 // IMPORTANT: This import path should _not_ be used outside our source tree
 // as `src` directory is _not_ meant to be shipped in our NPM package.
 // Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
@@ -36,10 +43,4 @@
 // hide the cookie button
 #teconsent {
   visibility: hidden;
-}
-
-@media only percy {
-  [data-autoid='dds--privacy-cp'] {
-    visibility: hidden;
-  }
 }

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -141,5 +141,10 @@
     [data-autoid='dds--privacy-cp'] {
       visibility: hidden;
     }
+
+    .bx--link-list__list--video .bx--card__copy,
+    .bx--link-list__list--video span {
+      visibility: hidden;
+    }
   }
 </style>

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -135,3 +135,11 @@
 
 <!-- IBM Tag Management and Site Analytics -->
 <script src="//1.www.s81c.com/common/stats/ibm-common.js"></script>
+
+<style>
+  @media only percy {
+    [data-autoid='dds--privacy-cp'] {
+      visibility: hidden;
+    }
+  }
+</style>


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2487

### Description

This hides the cookie preferences link as well as the video description link in LinkList.

### Changelog

**Changed**

- Percy style overrides
