### PR TITLE
chore(footer): splitting the footer story into two

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2507,7 +2507,6 @@ exports[`Storyshots Components|Footer Default 1`] = `
                 languageOnly={false}
                 mastheadProps={null}
                 navigation={null}
-                type=""
               />
             </React.Fragment>,
             "type": "STORY",
@@ -2551,7 +2550,6 @@ exports[`Storyshots Components|Footer Default 1`] = `
                 languageOnly={false}
                 mastheadProps={null}
                 navigation={null}
-                type=""
               >
                 <footer
                   className="bx--footer"
@@ -2595,6 +2593,198 @@ exports[`Storyshots Components|Footer Default 1`] = `
                       <FooterNav
                         groups={Array []}
                       />
+                      <LocaleButton
+                        aria=""
+                        displayLang=""
+                      >
+                        <div
+                          className="bx--locale-btn__container"
+                        >
+                          <ForwardRef(Button)
+                            aria-label=""
+                            className="bx--locale-btn"
+                            data-autoid="dds--locale-btn"
+                            disabled={false}
+                            iconDescription="Earth Filled Icon"
+                            kind="secondary"
+                            onClick={[Function]}
+                            renderIcon={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                            tabIndex={0}
+                            type="button"
+                          >
+                            <button
+                              aria-label=""
+                              className="bx--locale-btn bx--btn bx--btn--secondary"
+                              data-autoid="dds--locale-btn"
+                              disabled={false}
+                              onClick={[Function]}
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <ForwardRef(EarthFilled20)
+                                aria-hidden="true"
+                                aria-label="Earth Filled Icon"
+                                className="bx--btn__icon"
+                              >
+                                <Icon
+                                  aria-hidden="true"
+                                  aria-label="Earth Filled Icon"
+                                  className="bx--btn__icon"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 32 32"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-label="Earth Filled Icon"
+                                    className="bx--btn__icon"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    role="img"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M16,2A14,14,0,1,0,30,16,14.0158,14.0158,0,0,0,16,2ZM4.02,16.394l1.3384.4458L7,19.3027v1.2831a1,1,0,0,0,.2929.7071L10,24v2.3765A11.9941,11.9941,0,0,1,4.02,16.394ZM16,28a11.9682,11.9682,0,0,1-2.5718-.2847L14,26l1.8046-4.5116a1,1,0,0,0-.0964-.9261l-1.4113-2.117A1,1,0,0,0,13.4648,18h-4.93L7.2866,16.1274,9.4141,14H11v2h2V13.2656l3.8682-6.7695-1.7364-.9922L14.2769,7H11.5352l-1.086-1.6289A11.861,11.861,0,0,1,20,4.7V8a1,1,0,0,0,1,1h1.4648a1,1,0,0,0,.8321-.4453l.8769-1.3154A12.0331,12.0331,0,0,1,26.8945,11H22.82a1,1,0,0,0-.9806.8039l-.7221,4.4708a1,1,0,0,0,.54,1.0539L25,19l.6851,4.0557A11.9793,11.9793,0,0,1,16,28Z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(EarthFilled20)>
+                            </button>
+                          </ForwardRef(Button)>
+                        </div>
+                      </LocaleButton>
+                    </div>
+                  </section>
+                  <LegalNav
+                    links={Array []}
+                  />
+                </footer>
+              </Footer>
+            </div>
+          </div>
+        </_default>
+      </div>
+    </ReadmeContent>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Components|Footer Short 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  >
+    <ReadmeContent
+      codeTheme="github"
+      layout={
+        Array [
+          Object {
+            "content": <React.Fragment>
+              <Footer
+                disableLocaleButton={false}
+                footerProps={null}
+                langCode={null}
+                mastheadProps={null}
+                navigation={null}
+                type="short"
+              />
+            </React.Fragment>,
+            "type": "STORY",
+          },
+        ]
+      }
+      theme={Object {}}
+      types={
+        Array [
+          "MD",
+          "STORY",
+          "STORY_SOURCE",
+          "PROPS",
+          "FOOTER_MD",
+          "HEADER_MD",
+        ]
+      }
+    >
+      <div
+        className="storybook-readme-story"
+      >
+        <_default
+          key="0"
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <Footer
+                disableLocaleButton={false}
+                footerProps={null}
+                langCode={null}
+                mastheadProps={null}
+                navigation={null}
+                type="short"
+              >
+                <footer
+                  className="bx--footer bx--footer--short"
+                  data-autoid="dds--footer"
+                >
+                  <section
+                    className="bx--footer__main"
+                  >
+                    <div
+                      className="bx--footer__main-container"
+                    >
+                      <Logo>
+                        <div
+                          className="bx--footer-logo"
+                          data-autoid="dds--footer-logo"
+                        >
+                          <a
+                            className="bx--footer-logo__link"
+                            data-autoid="dds--footer-logo__link"
+                            href="https://www.ibm.com/"
+                          >
+                            <FooterLogo
+                              className="bx--footer-logo__logo"
+                              viewBox="0 0 157 65"
+                            >
+                              <svg
+                                className="bx--footer-logo__logo"
+                                viewBox="0 0 157 65"
+                              >
+                                <title>
+                                  IBM Logo
+                                </title>
+                                <path
+                                  d="M30.444 60.208v4.03H0v-4.03h30.444zm78.291-.001v4.03H86.983v-4.03h21.752zm47.858 0v4.03H134.84v-4.03h21.753zm-33.416 0l-1.398 4.03-1.38-4.03h2.778zm-88.384 0h42.775c-2.797 2.426-6.39 3.925-10.327 4.025l-.423.006H34.793v-4.03h42.775zm-4.35-8.46v4.03H0v-4.03h30.444zm52.402 0c-.332 1.248-.8 2.44-1.389 3.555l-.259.474H34.793v-4.029h48.052zm73.748-.005v4.031H134.84v-4.03h21.753zm-47.858 0v4.031H86.983v-4.03h21.752zm17.375 0l-1.398 4.031h-5.85l-1.395-4.03h8.643zM21.745 43.285v4.03H8.698v-4.03h13.047zm61.195 0a17.32 17.32 0 0 1 .476 3.51l.008.52H68.796v-4.03H82.94zm-26.401 0v4.03H43.491v-4.03H56.54zm72.502-.007l-1.396 4.03H115.93l-1.397-4.03h14.507zm18.85 0v4.03h-13.05v-4.03h13.05zm-39.156 0v4.03H95.684v-4.03h13.051zm-86.99-8.454v4.03H8.698v-4.03h13.047zm56.117 0a16.945 16.945 0 0 1 2.926 3.582l.264.447h-37.56v-4.03h34.37zm30.873-.01v4.03H95.684v-4.03h13.051zm39.157 0v4.03H134.84v-4.03h13.052zm-15.919 0l-1.396 4.03h-17.579l-1.396-4.03h20.371zm-50.778-8.452a16.963 16.963 0 0 1-2.82 3.674l-.37.355H43.49v-4.029h37.704zm-59.45 0v4.03H8.698v-4.03h13.047zm126.147-.013v4.031H134.84v-3.839l-1.33 3.839h-11.456l1.373-4.03h24.465zm-27.743 0l1.372 4.031h-11.456l-1.33-3.839v3.84H95.684v-4.032h24.465zm-98.404-8.448v4.03H8.698V17.9h13.047zm61.68 0c0 1.215-.134 2.399-.375 3.542l-.11.487H68.796V17.9h14.628zM56.538 17.9v4.03H43.491V17.9H56.54zm91.352-.015v4.03h-22.954l1.37-4.03h21.584zm-30.624 0l1.372 4.03H95.684v-4.03h21.583zM30.444 9.437v4.03H0v-4.03h30.444zm50.753 0a17.048 17.048 0 0 1 1.498 3.499l.15.531H34.794v-4.03h46.403zm75.396-.018v4.03h-28.776l1.373-4.03h27.403zm-42.207 0l1.372 4.031H86.982V9.42h27.404zM30.444.978v4.03H0V.977h30.444zm36.374 0c3.96 0 7.594 1.415 10.448 3.772l.303.257H34.794V.977h32.024zm89.775-.022v4.031h-25.894l1.372-4.03h24.522zm-45.098 0l1.372 4.03H86.982V.955h24.513z"
+                                />
+                              </svg>
+                            </FooterLogo>
+                          </a>
+                        </div>
+                      </Logo>
                       <LocaleButton
                         aria=""
                         displayLang=""

--- a/packages/react/src/components/Footer/__stories__/Footer.stories.js
+++ b/packages/react/src/components/Footer/__stories__/Footer.stories.js
@@ -1,11 +1,11 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { boolean, object, select, withKnobs } from '@storybook/addon-knobs';
+import { boolean, object, withKnobs } from '@storybook/addon-knobs';
 import { DDS_LANGUAGE_SELECTOR } from '../../../internal/FeatureFlags';
 import { Footer } from '../';
 import footerMenu from '../__data__/footer-menu.json';
@@ -26,18 +26,12 @@ export default {
   },
 };
 
+/**
+ * Footer (default configuration)
+ *
+ * @returns {*} CSF story
+ */
 export const Default = () => {
-  const footerTypeOptions = {
-    tall: '',
-    short: 'short',
-  };
-
-  let type = select(
-    'sets the type of footer (type)',
-    footerTypeOptions,
-    footerTypeOptions.tall
-  );
-
   let isCustom = boolean('show custom navigation (not a prop)', inPercy());
 
   let navigation = isCustom
@@ -72,13 +66,42 @@ export const Default = () => {
   return (
     <Footer
       navigation={isCustom ? navigation : null}
-      type={type}
       disableLocaleButton={disableLocaleButton}
       langCode={inPercy() ? { lc: 'en', cc: 'us' } : null}
       languageOnly={languageOnly}
       languageItems={languageOnly ? items : null}
       languageInitialItem={{ id: 'en', text: 'English' }}
       languageCallback={languageCallback}
+    />
+  );
+};
+
+/**
+ * Footer (short)
+ *
+ * @returns {*} CSF story
+ */
+export const Short = () => {
+  let isCustom = boolean('show custom navigation (not a prop)', inPercy());
+
+  let navigation = isCustom
+    ? object('custom navigation data (navigation)', {
+        footerMenu,
+        footerThin,
+      })
+    : null;
+
+  let disableLocaleButton = boolean(
+    'hide the locale button (disableLocaleButton)',
+    false
+  );
+
+  return (
+    <Footer
+      navigation={isCustom ? navigation : null}
+      type="short"
+      disableLocaleButton={disableLocaleButton}
+      langCode={inPercy() ? { lc: 'en', cc: 'us' } : null}
     />
   );
 };


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This splits the Footer storybook story from a single story into two separate stories. The default shows the tall footer, and there is now a second story for the "short" footer.

### Changelog

**Changed**

- Footer storybook stories