### PR TITLE
chore(exports): restored exports from blocks

### DIFF
--- a/packages/react/src/patterns/blocks/index.js
+++ b/packages/react/src/patterns/blocks/index.js
@@ -4,3 +4,19 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+export * from './CalloutQuote';
+export * from './CalloutWithMedia';
+export * from './ContentBlockCards';
+export * from './ContentBlockMedia';
+export * from './ContentBlockMixed';
+export * from './ContentBlockSegmented';
+export * from './ContentBlockSimple';
+export * from './ContentGroupCards';
+export * from './ContentGroupHorizontal';
+export * from './ContentGroupPictograms';
+export * from './ContentGroupSimple';
+export * from './FeatureCardBlockLarge';
+export * from './FeatureCardBlockMedium';
+export * from './LeadSpaceBlock';
+export * from './LogoGrid';


### PR DESCRIPTION
### Description

Restored the exports for `blocks` folder.