### PR TITLE
fix(sub-patterns): adding deprecation and breadcrumb imports

### DIFF
--- a/packages/styles/scss/patterns/sub-patterns/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/patterns/sub-patterns/buttongroup/_buttongroup.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/buttongroup/buttongroup"
+
+@import '../../../components/buttongroup/buttongroup';

--- a/packages/styles/scss/patterns/sub-patterns/callout/_callout.scss
+++ b/packages/styles/scss/patterns/sub-patterns/callout/_callout.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/callout/callout"
+
+@import '../../../components/callout/callout';

--- a/packages/styles/scss/patterns/sub-patterns/card-group/_card-group.scss
+++ b/packages/styles/scss/patterns/sub-patterns/card-group/_card-group.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/card-group/card-group"
+
+@import '../../../components/card-group/card-group';

--- a/packages/styles/scss/patterns/sub-patterns/card/index.scss
+++ b/packages/styles/scss/patterns/sub-patterns/card/index.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/card/index"
+
+@import '../../../components/card/index';

--- a/packages/styles/scss/patterns/sub-patterns/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/patterns/sub-patterns/content-item-horizontal/_content-item-horizontal.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/content-item-horizontal/content-item-horizontal"
+
+@import '../../../components/content-item-horizontal/content-item-horizontal';

--- a/packages/styles/scss/patterns/sub-patterns/feature-card/_feature-card.scss
+++ b/packages/styles/scss/patterns/sub-patterns/feature-card/_feature-card.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/feature-card/feature-card"
+
+@import '../../../components/feature-card/feature-card';

--- a/packages/styles/scss/patterns/sub-patterns/layout/_layout.scss
+++ b/packages/styles/scss/patterns/sub-patterns/layout/_layout.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/layout/layout"
+
+@import '../../../components/layout/layout';

--- a/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/_link-list.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/link-list/link-list"
+
+@import '../../../components/link-list/link-list';

--- a/packages/styles/scss/patterns/sub-patterns/link-list/index.scss
+++ b/packages/styles/scss/patterns/sub-patterns/link-list/index.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/link-list/index"
+
+@import '../../../components/link-list/index';

--- a/packages/styles/scss/patterns/sub-patterns/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/patterns/sub-patterns/pictogram-item/_pictogram-item.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/pictogram-item/pictogram-item"
+
+@import '../../../components/pictogram-item/pictogram-item';

--- a/packages/styles/scss/patterns/sub-patterns/quote/_quote.scss
+++ b/packages/styles/scss/patterns/sub-patterns/quote/_quote.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/quote/quote"
+
+@import '../../../components/quote/quote';

--- a/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/patterns/sub-patterns/tableofcontents/_tableofcontents.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/tableofcontents/tableofcontents"
+
+@import '../../../components/tableofcontents/tableofcontents';

--- a/packages/styles/scss/patterns/sub-patterns/tableofcontents/index.scss
+++ b/packages/styles/scss/patterns/sub-patterns/tableofcontents/index.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// @deprecated Remap import to "@carbon/ibmdotcom-styles/scss/components/tableofcontents/index"
+
+@import '../../../components/tableofcontents/index';


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2576

### Description

This adds back a breadcrumb to import the new location of the subpattern style files.

### Changelog

**New**

- sub-pattern style imports with deprecation notice