### PR TITLE
chore(styles): update carbon imports

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -7,7 +7,7 @@
 
 @import '../../globals/imports';
 @import '../../temp-carbon-expressive/temp-carbon-expressive';
-@import '@carbon/motion/scss/motion.scss';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/motion/motion.scss';
 
 @import 'carbon-components/scss/components/link/link';
 @import 'carbon-components/scss/components/tile/tile';

--- a/packages/styles/scss/components/image-with-caption/image-with-caption.scss
+++ b/packages/styles/scss/components/image-with-caption/image-with-caption.scss
@@ -6,7 +6,7 @@
  */
 
 @import '../../globals/imports';
-@import '@carbon/motion/scss/motion.scss';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/motion/motion.scss';
 
 @mixin image-with-caption {
   .#{$prefix}--image-with-caption {

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/themes/scss/themes';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/themes';
 
 /// @access private
 /// @group dotcom ui-shell Masthead L1

--- a/packages/styles/scss/globals/_imports.scss
+++ b/packages/styles/scss/globals/_imports.scss
@@ -13,13 +13,13 @@
 // isolated as helper functions/mixins/utilities and should have minimal
 // effect on the final artifact size
 
-@import '@carbon/type/scss/type';
-@import '@carbon/themes/scss/themes';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/type';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/themes';
 @import 'carbon-components/scss/globals/scss/vars';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/layout';
-@import '@carbon/import-once/scss/import-once';
-@import '@carbon/grid/scss/index';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/grid/index';
 @import 'carbon-components/scss/globals/scss/css--reset';
 
 @import '../themes/expressive/index';

--- a/packages/styles/scss/globals/_tokens.scss
+++ b/packages/styles/scss/globals/_tokens.scss
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/type/scss/font-family';
-@import '@carbon/type/scss/scale';
-@import '@carbon/type/scss/styles';
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/font-family';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/scale';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/styles';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-------------------------
 // Tokens

--- a/packages/styles/scss/temp-carbon-expressive/_temp-carbon-expressive.scss
+++ b/packages/styles/scss/temp-carbon-expressive/_temp-carbon-expressive.scss
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/type/scss/styles';
-@import '@carbon/layout/scss/mini-unit';
-@import '@carbon/layout/scss/breakpoint';
-@import '@carbon/themes/scss/themes';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/styles';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/mini-unit';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/breakpoint';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/themes';
 
 // Mixins
 @function temp--padding-diff(

--- a/packages/styles/scss/themes/expressive/_tokens.scss
+++ b/packages/styles/scss/themes/expressive/_tokens.scss
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/type/scss/styles';
-@import '@carbon/type/scss/font-family';
-@import '@carbon/type/scss/scale';
-@import '@carbon/layout/scss/convert';
-@import '@carbon/themes/scss/mixins';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/styles';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/font-family';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/scale';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
 
 /// Global token theme
 /// @access private

--- a/packages/styles/scss/themes/expressive/components/_accordion.scss
+++ b/packages/styles/scss/themes/expressive/components/_accordion.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Accordion (expressive)

--- a/packages/styles/scss/themes/expressive/components/_button.scss
+++ b/packages/styles/scss/themes/expressive/components/_button.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Button (expressive)

--- a/packages/styles/scss/themes/expressive/components/_code-snippet.scss
+++ b/packages/styles/scss/themes/expressive/components/_code-snippet.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Code snippet (expressive)

--- a/packages/styles/scss/themes/expressive/components/_combo-box.scss
+++ b/packages/styles/scss/themes/expressive/components/_combo-box.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Combo Box (expressive)

--- a/packages/styles/scss/themes/expressive/components/_content-switcher.scss
+++ b/packages/styles/scss/themes/expressive/components/_content-switcher.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Content Switcher (expressive)

--- a/packages/styles/scss/themes/expressive/components/_copy-button.scss
+++ b/packages/styles/scss/themes/expressive/components/_copy-button.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Copy button (expressive)

--- a/packages/styles/scss/themes/expressive/components/_data-table.scss
+++ b/packages/styles/scss/themes/expressive/components/_data-table.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Data Table (expressive)

--- a/packages/styles/scss/themes/expressive/components/_date-picker.scss
+++ b/packages/styles/scss/themes/expressive/components/_date-picker.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Date Picker (expressive)

--- a/packages/styles/scss/themes/expressive/components/_dropdown.scss
+++ b/packages/styles/scss/themes/expressive/components/_dropdown.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Date Picker (expressive)

--- a/packages/styles/scss/themes/expressive/components/_file-uploader.scss
+++ b/packages/styles/scss/themes/expressive/components/_file-uploader.scss
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
+
 //-----------------------------
 // File Uploader (expressive)
 //-----------------------------

--- a/packages/styles/scss/themes/expressive/components/_inline-loading.scss
+++ b/packages/styles/scss/themes/expressive/components/_inline-loading.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 //-----------------------------
 // Inline Loading  (expressive)
 //-----------------------------

--- a/packages/styles/scss/themes/expressive/components/_inline-notifications.scss
+++ b/packages/styles/scss/themes/expressive/components/_inline-notifications.scss
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
+
 //-----------------------------
 // Inline Notifications  (expressive)
 //-----------------------------

--- a/packages/styles/scss/themes/expressive/components/_list-box.scss
+++ b/packages/styles/scss/themes/expressive/components/_list-box.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // List Box (Expressive)

--- a/packages/styles/scss/themes/expressive/components/_loading.scss
+++ b/packages/styles/scss/themes/expressive/components/_loading.scss
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
+
 //-----------------------------
 // Loading  (expressive)
 //-----------------------------

--- a/packages/styles/scss/themes/expressive/components/_modal.scss
+++ b/packages/styles/scss/themes/expressive/components/_modal.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Modal (expressive)

--- a/packages/styles/scss/themes/expressive/components/_number-input.scss
+++ b/packages/styles/scss/themes/expressive/components/_number-input.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Number Input (expressive)

--- a/packages/styles/scss/themes/expressive/components/_overflow-menu.scss
+++ b/packages/styles/scss/themes/expressive/components/_overflow-menu.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Overflow Menu (expressive)

--- a/packages/styles/scss/themes/expressive/components/_progressive-indicator.scss
+++ b/packages/styles/scss/themes/expressive/components/_progressive-indicator.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Progressive Indicator (expressive)

--- a/packages/styles/scss/themes/expressive/components/_search.scss
+++ b/packages/styles/scss/themes/expressive/components/_search.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Search (expressive)

--- a/packages/styles/scss/themes/expressive/components/_select.scss
+++ b/packages/styles/scss/themes/expressive/components/_select.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Select (expressive)

--- a/packages/styles/scss/themes/expressive/components/_structured-list.scss
+++ b/packages/styles/scss/themes/expressive/components/_structured-list.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Structured List (expressive)

--- a/packages/styles/scss/themes/expressive/components/_tabs.scss
+++ b/packages/styles/scss/themes/expressive/components/_tabs.scss
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
-@import '@carbon/grid/scss/mixins';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/grid/mixins';
 
 //-----------------------------
 // Tabs (expressive)

--- a/packages/styles/scss/themes/expressive/components/_tag.scss
+++ b/packages/styles/scss/themes/expressive/components/_tag.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Tag (expressive)

--- a/packages/styles/scss/themes/expressive/components/_text-area.scss
+++ b/packages/styles/scss/themes/expressive/components/_text-area.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Text Area (expressive)

--- a/packages/styles/scss/themes/expressive/components/_text-input.scss
+++ b/packages/styles/scss/themes/expressive/components/_text-input.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Text Input (expressive)

--- a/packages/styles/scss/themes/expressive/components/_tile.scss
+++ b/packages/styles/scss/themes/expressive/components/_tile.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Tile (expressive)

--- a/packages/styles/scss/themes/expressive/components/_time-picker.scss
+++ b/packages/styles/scss/themes/expressive/components/_time-picker.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Time Picker (expressive)

--- a/packages/styles/scss/themes/expressive/components/_tooltip.scss
+++ b/packages/styles/scss/themes/expressive/components/_tooltip.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/layout/scss/convert';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/layout/convert';
 
 //-----------------------------
 // Tooltip (expressive)

--- a/packages/styles/scss/themes/expressive/index.scss
+++ b/packages/styles/scss/themes/expressive/index.scss
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '@carbon/import-once/scss/import-once';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import 'carbon-components/scss/globals/scss/vars';
 @import '../../globals/feature-flags';
 @import 'tokens';


### PR DESCRIPTION
### Related Ticket(s)

Fixes #2437 

### Description

Update `scss` to import consistently from the same location. This allows `import-once` to work as it should and eliminate css duplication.

### Changelog

**Changed**

- imports from `@carbon` change to `carbon-components/scss/globals/scss/vendor/@carbon`


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
