### PR TITLE
chore(percy): hiding video link in linklist for percy tests

### DIFF
--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -142,9 +142,8 @@
       visibility: hidden;
     }
 
-    .bx--link-list__list--video .bx--card__copy,
-    .bx--link-list__list--video span {
-      visibility: hidden;
+    .bx--link-list__list--video {
+      display: none !important;
     }
   }
 </style>


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2595

### Description

We have been getting a lot of false positives with the video link in
LinkList, so going to add this to suppress that item entirely instead.

### Changelog

**Changed**

- Modified elements hidden in percy for LinkList


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
