### PR TITLE
style(pattern): fix feature-card-block-large styles

### DIFF
--- a/packages/styles/scss/patterns/blocks/feature-card-block-large/_feature-card-block-large.scss
+++ b/packages/styles/scss/patterns/blocks/feature-card-block-large/_feature-card-block-large.scss
@@ -19,8 +19,6 @@ $fcb-large-custom-bp-nocopy: 752px;
     color: $text-01;
     background: $ui-background;
     position: relative;
-    padding-top: 20px;
-    padding-bottom: 20px;
     height: 100%;
 
     @include carbon--breakpoint-between($fcb-large-custom-bp-copy, 'lg') {
@@ -78,8 +76,9 @@ $fcb-large-custom-bp-nocopy: 752px;
         background: $inverse-02;
         min-height: 50%;
         height: auto;
+        padding: $spacing-07 $spacing-05;
 
-        @include carbon--breakpoint('xlg') {
+        @include carbon--breakpoint('md') {
           padding: $layout-03;
         }
 
@@ -88,14 +87,9 @@ $fcb-large-custom-bp-nocopy: 752px;
         }
 
         .#{$prefix}--card__eyebrow {
-          margin-bottom: $spacing-05;
+          margin: 0 0 $spacing-05 0;
           color: $inverse-01;
           @include carbon--type-style('body-long-02');
-
-          @include carbon--breakpoint-down('md') {
-            margin-top: $spacing-07;
-            margin-bottom: $spacing-05;
-          }
         }
 
         .#{$prefix}--card__heading {


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Feature Card Block Large: Spacing fixes #2410

### Description

Fixes:
✅  Internal card spacing for large breakpoint;
✅  Extra padding above the feature card for small, medium, and large breakpoints;
✅  Extra space above the eyebrow on small breakpoint.

### Changelog

**Changed**

- `FeatureCardBlockLarge` pattern styles;
