### PR TITLE
fix(pattern): icon size in FeatureCardBlockLarge corrected

### DIFF
--- a/packages/styles/scss/patterns/blocks/feature-card-block-large/_feature-card-block-large.scss
+++ b/packages/styles/scss/patterns/blocks/feature-card-block-large/_feature-card-block-large.scss
@@ -34,6 +34,9 @@ $fcb-large-custom-bp-nocopy: 752px;
     &__card.#{$prefix}--card--inverse .#{$prefix}--card__cta:visited {
       float: none;
       color: $inverse-link;
+      width: $layout-03;
+      height: $layout-03;
+
       @include carbon--type-style('productive-heading-05');
     }
 


### PR DESCRIPTION
### Related Ticket(s)

https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/2400

### Description

CTA Icon font size corrected

### Changelog

**Changed**

Font size of CTA Icon changed from 20px to 32px

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
