### PR TITLE
fix(useVideoData): fix a call in TDZ

### DIFF
--- a/packages/react/src/internal/hooks/useVideoData/useVideoData.js
+++ b/packages/react/src/internal/hooks/useVideoData/useVideoData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,10 +17,6 @@ import { VideoPlayerAPI } from '@carbon/ibmdotcom-services';
  */
 function useVideoData(type, videoId) {
   const [videoTitle, setVideoTitle] = useState([{ title: '', key: 0 }]);
-
-  useEffect(() => {
-    getVideoData();
-  }, [getVideoData, type]);
 
   /**
    * retrieve duration and title information from the video if
@@ -44,6 +40,10 @@ function useVideoData(type, videoId) {
       setVideoTitle(title);
     }
   }, [type, videoId]);
+
+  useEffect(() => {
+    getVideoData();
+  }, [getVideoData, type]);
 
   return videoTitle;
 }


### PR DESCRIPTION
### Description

This change fixes an issue where `getVideoData()` is called in the corresponding variable's temporal dead zone. This is revealed in a Babel configuration where `const` is not transpiled to `var.

### Changelog

**Changed**

- `getVideoData()` in `useVideoData()` so that `getVideoData()` is not called in TDZ.