### PR TITLE
fix(Image): fix invalid aria-describedby

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -3850,7 +3850,6 @@ exports[`Storyshots Components|FeatureCard Default 1`] = `
                       >
                         <img
                           alt="Image alt text"
-                          aria-describedby=""
                           className="bx--image__img bx--card__img"
                           src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
                         />
@@ -4408,7 +4407,6 @@ exports[`Storyshots Components|Image Default 1`] = `
               />
               <img
                 alt="Image alt text"
-                aria-describedby=""
                 className="bx--image__img"
                 src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
               />
@@ -4511,7 +4509,6 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
                     />
                     <img
                       alt="image with caption image"
-                      aria-describedby=""
                       className="bx--image__img"
                       src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
                     />
@@ -4996,7 +4993,6 @@ exports[`Storyshots Components|LightboxMediaViewer Default 1`] = `
                             >
                               <img
                                 alt="Image alt text"
-                                aria-describedby=""
                                 className="bx--image__img"
                                 src="https://dummyimage.com/1280x720/ee5396/161616&amp;text=16:9"
                               />
@@ -12509,7 +12505,6 @@ exports[`Storyshots Patterns (Blocks)|CalloutWithMedia Default 1`] = `
                                             />
                                             <img
                                               alt="Image alt text"
-                                              aria-describedby=""
                                               className="bx--image__img"
                                               src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                             />
@@ -13621,7 +13616,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         />
                                         <img
                                           alt="Image alt text"
-                                          aria-describedby=""
                                           className="bx--image__img"
                                           src="https://dummyimage.com/672x378/ee5396/161616&amp;text=16:9"
                                         />
@@ -14013,7 +14007,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         />
                                         <img
                                           alt="Image alt text"
-                                          aria-describedby=""
                                           className="bx--image__img"
                                           src="https://dummyimage.com/672x378/ee5396/161616&amp;text=16:9"
                                         />
@@ -14435,7 +14428,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                               >
                                                 <img
                                                   alt="Image alt text"
-                                                  aria-describedby=""
                                                   className="bx--image__img bx--card__img"
                                                   src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
                                                 />
@@ -14979,7 +14971,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 />
                                                 <img
                                                   alt="Image alt text"
-                                                  aria-describedby=""
                                                   className="bx--image__img"
                                                   src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                 />
@@ -15371,7 +15362,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 />
                                                 <img
                                                   alt="Image alt text"
-                                                  aria-describedby=""
                                                   className="bx--image__img"
                                                   src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                 />
@@ -15793,7 +15783,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                       >
                                                         <img
                                                           alt="Image alt text"
-                                                          aria-describedby=""
                                                           className="bx--image__img bx--card__img"
                                                           src="https://dummyimage.com/672x672/ee5396/161616&text=1x1"
                                                         />
@@ -17799,7 +17788,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                         />
                                         <img
                                           alt="Image alt text"
-                                          aria-describedby=""
                                           className="bx--image__img"
                                           src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                         />
@@ -19693,7 +19681,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                                 />
                                                 <img
                                                   alt="Image alt text"
-                                                  aria-describedby=""
                                                   className="bx--image__img"
                                                   src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                 />
@@ -20549,7 +20536,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                               />
                               <img
                                 alt="Image alt text"
-                                aria-describedby=""
                                 className="bx--image__img"
                                 src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                               />
@@ -20827,7 +20813,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                       />
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby=""
                                         className="bx--image__img"
                                         src="https://dummyimage.com/672x378/ee5396/161616&amp;text=16:9"
                                       />
@@ -21429,7 +21414,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                       />
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby=""
                                         className="bx--image__img"
                                         src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                       />
@@ -21608,7 +21592,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                               />
                                               <img
                                                 alt="Image alt text"
-                                                aria-describedby=""
                                                 className="bx--image__img"
                                                 src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                               />
@@ -22391,7 +22374,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                 />
                                 <img
                                   alt="Image alt text"
-                                  aria-describedby=""
                                   className="bx--image__img"
                                   src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                 />
@@ -22895,7 +22877,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                         />
                                         <img
                                           alt="Image alt text"
-                                          aria-describedby=""
                                           className="bx--image__img"
                                           src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                         />
@@ -25478,7 +25459,6 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupSimple Default 1`] = `
                               />
                               <img
                                 alt="Image alt text"
-                                aria-describedby=""
                                 className="bx--image__img"
                                 src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                               />
@@ -25830,7 +25810,6 @@ exports[`Storyshots Patterns (Blocks)|FeatureCardBlockLarge Default 1`] = `
                       >
                         <img
                           alt="Image alt text"
-                          aria-describedby=""
                           className="bx--image__img bx--card__img"
                           src="https://dummyimage.com/600x300/ee5396/161616&amp;text=2:1"
                         />
@@ -26065,7 +26044,6 @@ exports[`Storyshots Patterns (Blocks)|FeatureCardBlockMedium Default 1`] = `
                                 >
                                   <img
                                     alt="Image alt text"
-                                    aria-describedby=""
                                     className="bx--image__img bx--card__img"
                                     src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
                                   />
@@ -26369,7 +26347,6 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                               />
                               <img
                                 alt="Image alt text"
-                                aria-describedby=""
                                 className="bx--image__img"
                                 src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                               />
@@ -28287,7 +28264,6 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                               >
                                 <img
                                   alt="Image alt text"
-                                  aria-describedby=""
                                   className="bx--image__img bx--card__img"
                                   src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
                                 />
@@ -28420,7 +28396,6 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                               >
                                 <img
                                   alt="Image alt text"
-                                  aria-describedby=""
                                   className="bx--image__img bx--card__img"
                                   src="https://dummyimage.com/792x1056/ee5396/161616%26text=3:4"
                                 />
@@ -28553,7 +28528,6 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                               >
                                 <img
                                   alt="Image alt text"
-                                  aria-describedby=""
                                   className="bx--image__img bx--card__img"
                                   src="https://dummyimage.com/1056x1056/ee5396/161616%26text=1:1"
                                 />
@@ -28686,7 +28660,6 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                               >
                                 <img
                                   alt="Image alt text"
-                                  aria-describedby=""
                                   className="bx--image__img bx--card__img"
                                   src="https://dummyimage.com/1056x528/ee5396/161616%26text=2:1"
                                 />
@@ -28819,7 +28792,6 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                               >
                                 <img
                                   alt="Image alt text"
-                                  aria-describedby=""
                                   className="bx--image__img bx--card__img"
                                   src="https://dummyimage.com/1056x594/ee5396/161616%26text=16:9"
                                 />
@@ -30012,7 +29984,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
               />
               <img
                 alt="lead space image"
-                aria-describedby=""
                 className="bx--image__img"
                 src="https://picsum.photos/id/1076/1056/480"
               />

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -66,7 +66,7 @@ const Image = ({ classname, sources, defaultSrc, alt, longDescription }) => {
           className={classnames(`${prefix}--image__img`, classname)}
           src={defaultSrc}
           alt={alt}
-          aria-describedby={longDescription ? `${id}` : ''}
+          aria-describedby={longDescription ? `${id}` : undefined}
         />
       </picture>
       {longDescription ? (


### PR DESCRIPTION
### Related Ticket(s)

Refs #2387.

### Description

This change fixes invalid `aria-describedby` value, which was an empty string. Seems that it happens in a condition that there should be no valid target for `aria-describedby`, and thus fixed it by simply removing the attribute.

### Changelog

**Removed**

- `aria-describedby` from `<Image>` in a condition where the attribute is not needed.