### PR TITLE
chore(percy): removing percy false positives in footer

### DIFF
--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -139,7 +139,7 @@
 <style>
   @media only percy {
     [data-autoid='dds--privacy-cp'] {
-      visibility: hidden;
+      display: none !important;
     }
 
     .bx--link-list__list--video {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

I believe the false positives being created is the sporadic rendering
of the privacy link. This will suppress it entirely rather than setting
the visibility to hidden.

### Changelog

**Changed**

- Setting to completely suppress the privacy link in the footer in Percy