### PR TITLE
chore(rtl): fixing rtl attribute for dev environments

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React, { Component } from 'react';
 import './_container.scss';
 import { settings } from 'carbon-components';
@@ -7,6 +14,7 @@ export default class Container extends Component {
   componentDidMount() {
     if (process.env.REACT_STORYBOOK_USE_RTL === 'true') {
       document.documentElement.dir = 'rtl';
+      document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl');
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2653

### Description

The "rtl" setting does not seem to be properly set in dev environments,
but is ok for static builds of storybook. This is an additional change
so that when running storybook in dev mode, this is set correctly.

### Changelog

**Changed**

- storybook container explicitly setting `dir="rtl"` in the html element