### PR TITLE
fix(services): fix uncaught rejections

### DIFF
--- a/packages/services/src/services/DDO/__tests__/DDO.test.js
+++ b/packages/services/src/services/DDO/__tests__/DDO.test.js
@@ -38,17 +38,35 @@ describe('DDOAPI', () => {
     expect(root.digitalData.page.version).toEqual('dds.v1.0.0');
   });
 
-  it('should set a loop if the data layer is not ready', () => {
+  it('should set a loop if the data layer is not ready', async () => {
     root.digitalData.page.isDataLayerReady = false;
     jest.useFakeTimers();
 
-    DDOAPI.isReady();
+    const promise = DDOAPI.isReady();
 
     setTimeout(() => {
       root.digitalData.page.isDataLayerReady = true;
     }, 500);
-    jest.runAllTimers();
+    jest.advanceTimersByTime(500);
 
     expect(root.digitalData.page.isDataLayerReady).toEqual(true);
+
+    await promise; // Rejection of this promise should fail this test
+  });
+
+  it('should not increase the retry count upon multiple calls of isReady()', async () => {
+    root.digitalData.page.isDataLayerReady = false;
+    jest.useFakeTimers();
+
+    const promiseReadies = Promise.all(
+      Array.from({ length: 100 }).map(() => DDOAPI.isReady())
+    );
+
+    setTimeout(() => {
+      root.digitalData.page.isDataLayerReady = true;
+    }, 500);
+    jest.advanceTimersByTime(500);
+
+    await promiseReadies; // Rejection of this promise should fail this test
   });
 });

--- a/packages/services/src/services/global/__tests__/global.test.js
+++ b/packages/services/src/services/global/__tests__/global.test.js
@@ -11,7 +11,7 @@ import { globalInit } from '../';
 
 jest.mock('../../DDO', () => ({
   DDOAPI: {
-    setVersion: jest.fn(),
+    setVersion: jest.fn(async () => {}),
   },
 }));
 jest.mock('../../Analytics', () => ({

--- a/packages/services/src/services/global/global.js
+++ b/packages/services/src/services/global/global.js
@@ -27,7 +27,12 @@ export function globalInit() {
   }
 
   // Sets the version of the library in the DDO
-  DDOAPI.setVersion();
+  DDOAPI.setVersion().catch(error => {
+    console.error(
+      'Error setting the version of the library in the DDO:',
+      error
+    );
+  });
 
   // analytics tracking
   AnalyticsAPI.initAll();

--- a/packages/vanilla/src/components/footer/footer.js
+++ b/packages/vanilla/src/components/footer/footer.js
@@ -38,7 +38,7 @@ class Footer {
    * @returns {Promise} Returned HTML content
    */
   static async getFooterWithData(type) {
-    const lang = LocaleAPI.getLang();
+    const lang = await LocaleAPI.getLang();
     const response = await TranslationAPI.getTranslation(lang);
 
     return footerTemplate({

--- a/packages/vanilla/src/components/masthead/masthead.js
+++ b/packages/vanilla/src/components/masthead/masthead.js
@@ -259,7 +259,7 @@ class Masthead {
       mastheadProps = Object.assign(defaultProps, { hasProfile: hasProfile });
     }
 
-    const lang = LocaleAPI.getLang();
+    const lang = await LocaleAPI.getLang();
     const response = await TranslationAPI.getTranslation(lang);
 
     if (searchProps.hasSearch) {


### PR DESCRIPTION
### Description

This change fixes swallowed promise rejections found in several places during manual test of vanilla CodeSandbox examples.

Such swallowed promise rejection was thrown from `DDOAPI.isReady()`, where a couple additional things were found (and fixed):

1. When `DDOAPI.isReady()` was called multiple times in a short amount of time, the "time elapsed" counter increases every time `DDOAPI.isReady()` is called, which causes `DDOAPI.isReady()` yield to a rejected promise at the 50th call, even before the actual timeout (`5s`) happens.
2. It was hard to trace the series of problem because the rejected promise was not created with an error object. It made investigation of integration test failure hard.

### Changelog

**Changed**

- Fixed swallowed promise rejections in various places.
- Made sure the promise rejection in `DDOAPI.isReady()` come with an error object.
- Made sure "time elapsed" counter won't be increased every time `DDOAPI.isReady()` is called.