### PR TITLE
fix(accessibility): lifting up role=region from anchor tag in CardLink

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1475,7 +1475,6 @@ exports[`Storyshots Components|CardLink Default 1`] = `
               }
               customClassName="bx--card__CTA"
               disabled={false}
-              role="region"
               type="link"
             >
               <ClickableTile
@@ -1488,7 +1487,6 @@ exports[`Storyshots Components|CardLink Default 1`] = `
                 href="https://www.example.com"
                 light={false}
                 onClick={[Function]}
-                role="region"
                 target={null}
               >
                 <a
@@ -1498,7 +1496,6 @@ exports[`Storyshots Components|CardLink Default 1`] = `
                   href="https://www.example.com"
                   onClick={[Function]}
                   onKeyDown={[Function]}
-                  role="region"
                   target={null}
                 >
                   <div
@@ -5334,7 +5331,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             }
                             customClassName="bx--card__CTA"
                             disabled={false}
-                            role="region"
                             target={null}
                             type="link"
                           >
@@ -5348,7 +5344,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                               href="https://ibm.com"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target={null}
                             >
                               <a
@@ -5358,7 +5353,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                 href="https://ibm.com"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <div
@@ -5506,7 +5500,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             }
                             customClassName="bx--card__CTA"
                             disabled={false}
-                            role="region"
                             target={null}
                             type="link"
                           >
@@ -5520,7 +5513,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                               href="https://ibm.com"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target={null}
                             >
                               <a
@@ -5530,7 +5522,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                 href="https://ibm.com"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <div
@@ -5681,7 +5672,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             }
                             customClassName="bx--card__CTA"
                             disabled={false}
-                            role="region"
                             target="_blank"
                             type="link"
                           >
@@ -5695,7 +5685,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                               href="https://ibm.com"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target="_blank"
                             >
                               <a
@@ -5705,7 +5694,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                 href="https://ibm.com"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target="_blank"
                               >
                                 <div
@@ -5857,7 +5845,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             customClassName="bx--card__CTA"
                             disabled={false}
                             handleClick={[Function]}
-                            role="region"
                             type="link"
                           >
                             <ClickableTile
@@ -5870,7 +5857,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                               href="#"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target={null}
                             >
                               <a
@@ -5880,7 +5866,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                 href="#"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <div
@@ -7715,7 +7700,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             }
                             customClassName="bx--card__CTA"
                             disabled={false}
-                            role="region"
                             target={null}
                             type="link"
                           >
@@ -7729,7 +7713,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               href="https://ibm.com"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target={null}
                             >
                               <a
@@ -7739,7 +7722,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 href="https://ibm.com"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <div
@@ -7887,7 +7869,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             }
                             customClassName="bx--card__CTA"
                             disabled={false}
-                            role="region"
                             target={null}
                             type="link"
                           >
@@ -7901,7 +7882,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               href="https://ibm.com"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target={null}
                             >
                               <a
@@ -7911,7 +7891,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 href="https://ibm.com"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <div
@@ -8062,7 +8041,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             }
                             customClassName="bx--card__CTA"
                             disabled={false}
-                            role="region"
                             target="_blank"
                             type="link"
                           >
@@ -8076,7 +8054,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               href="https://ibm.com"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target="_blank"
                             >
                               <a
@@ -8086,7 +8063,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 href="https://ibm.com"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target="_blank"
                               >
                                 <div
@@ -8238,7 +8214,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             customClassName="bx--card__CTA"
                             disabled={false}
                             handleClick={[Function]}
-                            role="region"
                             type="link"
                           >
                             <ClickableTile
@@ -8251,7 +8226,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               href="#"
                               light={false}
                               onClick={[Function]}
-                              role="region"
                               target={null}
                             >
                               <a
@@ -8261,7 +8235,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 href="#"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <div
@@ -13722,7 +13695,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         }
                                         customClassName="bx--card__CTA"
                                         disabled={false}
-                                        role="region"
                                         target={null}
                                         type="link"
                                       >
@@ -13736,7 +13708,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                           href="https://www.example.com"
                                           light={false}
                                           onClick={[Function]}
-                                          role="region"
                                           target={null}
                                         >
                                           <a
@@ -13746,7 +13717,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             href="https://www.example.com"
                                             onClick={[Function]}
                                             onKeyDown={[Function]}
-                                            role="region"
                                             target={null}
                                           >
                                             <div
@@ -14122,7 +14092,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         }
                                         customClassName="bx--card__CTA"
                                         disabled={false}
-                                        role="region"
                                         target={null}
                                         type="link"
                                       >
@@ -14136,7 +14105,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                           href="https://www.example.com"
                                           light={false}
                                           onClick={[Function]}
-                                          role="region"
                                           target={null}
                                         >
                                           <a
@@ -14146,7 +14114,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             href="https://www.example.com"
                                             onClick={[Function]}
                                             onKeyDown={[Function]}
-                                            role="region"
                                             target={null}
                                           >
                                             <div
@@ -15099,7 +15066,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 }
                                                 customClassName="bx--card__CTA"
                                                 disabled={false}
-                                                role="region"
                                                 target={null}
                                                 type="link"
                                               >
@@ -15113,7 +15079,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                   href="https://www.example.com"
                                                   light={false}
                                                   onClick={[Function]}
-                                                  role="region"
                                                   target={null}
                                                 >
                                                   <a
@@ -15123,7 +15088,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                     href="https://www.example.com"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    role="region"
                                                     target={null}
                                                   >
                                                     <div
@@ -15499,7 +15463,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 }
                                                 customClassName="bx--card__CTA"
                                                 disabled={false}
-                                                role="region"
                                                 target={null}
                                                 type="link"
                                               >
@@ -15513,7 +15476,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                   href="https://www.example.com"
                                                   light={false}
                                                   onClick={[Function]}
-                                                  role="region"
                                                   target={null}
                                                 >
                                                   <a
@@ -15523,7 +15485,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                     href="https://www.example.com"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    role="region"
                                                     target={null}
                                                   >
                                                     <div
@@ -15979,7 +15940,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target={null}
                                             type="link"
                                           >
@@ -15993,7 +15953,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target={null}
                                             >
                                               <a
@@ -16003,7 +15962,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target={null}
                                               >
                                                 <div
@@ -16151,7 +16109,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target="_blank"
                                             type="link"
                                           >
@@ -16165,7 +16122,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target="_blank"
                                             >
                                               <a
@@ -16175,7 +16131,6 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target="_blank"
                                               >
                                                 <div
@@ -17965,7 +17920,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                               }
                               customClassName="bx--card__CTA"
                               disabled={false}
-                              role="region"
                               target={null}
                               type="link"
                             >
@@ -17979,7 +17933,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                 href="https://www.ibm.com"
                                 light={false}
                                 onClick={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <a
@@ -17989,7 +17942,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                   href="https://www.ibm.com"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
-                                  role="region"
                                   target={null}
                                 >
                                   <div
@@ -19867,7 +19819,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                       }
                                       customClassName="bx--card__CTA"
                                       disabled={false}
-                                      role="region"
                                       target={null}
                                       type="link"
                                     >
@@ -19881,7 +19832,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                         href="https://www.ibm.com"
                                         light={false}
                                         onClick={[Function]}
-                                        role="region"
                                         target={null}
                                       >
                                         <a
@@ -19891,7 +19841,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                           href="https://www.ibm.com"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
-                                          role="region"
                                           target={null}
                                         >
                                           <div
@@ -20078,7 +20027,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target={null}
                                             type="link"
                                           >
@@ -20092,7 +20040,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target={null}
                                             >
                                               <a
@@ -20102,7 +20049,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target={null}
                                               >
                                                 <div
@@ -20250,7 +20196,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target="_blank"
                                             type="link"
                                           >
@@ -20264,7 +20209,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target="_blank"
                                             >
                                               <a
@@ -20274,7 +20218,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target="_blank"
                                               >
                                                 <div
@@ -21058,7 +21001,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                               }
                               customClassName="bx--card__CTA"
                               disabled={false}
-                              role="region"
                               target={null}
                               type="link"
                             >
@@ -21072,7 +21014,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                 href="https://www.example.com"
                                 light={false}
                                 onClick={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <a
@@ -21082,7 +21023,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                   href="https://www.example.com"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
-                                  role="region"
                                   target={null}
                                 >
                                   <div
@@ -21761,7 +21701,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                       }
                                       customClassName="bx--card__CTA"
                                       disabled={false}
-                                      role="region"
                                       target={null}
                                       type="link"
                                     >
@@ -21775,7 +21714,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                         href="https://www.example.com"
                                         light={false}
                                         onClick={[Function]}
-                                        role="region"
                                         target={null}
                                       >
                                         <a
@@ -21785,7 +21723,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           href="https://www.example.com"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
-                                          role="region"
                                           target={null}
                                         >
                                           <div
@@ -21972,7 +21909,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target={null}
                                             type="link"
                                           >
@@ -21986,7 +21922,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target={null}
                                             >
                                               <a
@@ -21996,7 +21931,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target={null}
                                               >
                                                 <div
@@ -22144,7 +22078,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target="_blank"
                                             type="link"
                                           >
@@ -22158,7 +22091,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target="_blank"
                                             >
                                               <a
@@ -22168,7 +22100,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target="_blank"
                                               >
                                                 <div
@@ -22571,7 +22502,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                               }
                               customClassName="bx--card__CTA"
                               disabled={false}
-                              role="region"
                               target={null}
                               type="link"
                             >
@@ -22585,7 +22515,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                 href="https://www.ibm.com"
                                 light={false}
                                 onClick={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <a
@@ -22595,7 +22524,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                   href="https://www.ibm.com"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
-                                  role="region"
                                   target={null}
                                 >
                                   <div
@@ -23083,7 +23011,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                       }
                                       customClassName="bx--card__CTA"
                                       disabled={false}
-                                      role="region"
                                       target={null}
                                       type="link"
                                     >
@@ -23097,7 +23024,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                         href="https://www.ibm.com"
                                         light={false}
                                         onClick={[Function]}
-                                        role="region"
                                         target={null}
                                       >
                                         <a
@@ -23107,7 +23033,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                           href="https://www.ibm.com"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
-                                          role="region"
                                           target={null}
                                         >
                                           <div
@@ -23294,7 +23219,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target={null}
                                             type="link"
                                           >
@@ -23308,7 +23232,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target={null}
                                             >
                                               <a
@@ -23318,7 +23241,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target={null}
                                               >
                                                 <div
@@ -23466,7 +23388,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                             }
                                             customClassName="bx--card__CTA"
                                             disabled={false}
-                                            role="region"
                                             target="_blank"
                                             type="link"
                                           >
@@ -23480,7 +23401,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                               href="https://ibm.com"
                                               light={false}
                                               onClick={[Function]}
-                                              role="region"
                                               target="_blank"
                                             >
                                               <a
@@ -23490,7 +23410,6 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                                 href="https://ibm.com"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
-                                                role="region"
                                                 target="_blank"
                                               >
                                                 <div
@@ -25783,7 +25702,6 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupSimple Default 1`] = `
                               }
                               customClassName="bx--card__CTA"
                               disabled={false}
-                              role="region"
                               target={null}
                               type="link"
                             >
@@ -25797,7 +25715,6 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupSimple Default 1`] = `
                                 href="https://www.example.com"
                                 light={false}
                                 onClick={[Function]}
-                                role="region"
                                 target={null}
                               >
                                 <a
@@ -25807,7 +25724,6 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupSimple Default 1`] = `
                                   href="https://www.example.com"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
-                                  role="region"
                                   target={null}
                                 >
                                   <div
@@ -27607,7 +27523,6 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                   }
                                   customClassName="bx--card__CTA"
                                   disabled={false}
-                                  role="region"
                                   target={null}
                                   type="link"
                                 >
@@ -27621,7 +27536,6 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     href="http://local.url.com/"
                                     light={false}
                                     onClick={[Function]}
-                                    role="region"
                                     target={null}
                                   >
                                     <a
@@ -27631,7 +27545,6 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                       href="http://local.url.com/"
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
-                                      role="region"
                                       target={null}
                                     >
                                       <div

--- a/packages/react/src/components/CardLink/CardLink.js
+++ b/packages/react/src/components/CardLink/CardLink.js
@@ -25,7 +25,6 @@ const CardLink = ({ card, disabled }) => {
     <Card
       customClassName={cardLinkClassname}
       {...card}
-      role="region"
       type={type}
       disabled={disabled}
     />


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2610

### Description

We went through this one in the QA standup, a few minutes ago

### Changelog

**Removed**

- `role=region` from `CardLink`