### PR TITLE
fix(decodeString): updated decode-string to work on server-side rendering

### DIFF
--- a/packages/utilities/src/utilities/decodeString/decodeString.js
+++ b/packages/utilities/src/utilities/decodeString/decodeString.js
@@ -20,9 +20,9 @@
  *
  */
 function decodeString(str) {
-  const parser = new DOMParser();
-  return parser.parseFromString(`<!doctype html><body>${str}`, 'text/html').body
-    .textContent;
+  const div = document.createElement('div');
+  div.innerHTML = str;
+  return div.textContent;
 }
 
 export default decodeString;


### PR DESCRIPTION
### Description

While creating a new `Next.js` page, I've noticed that `DomParser` is not supported on a server side rendered page, this updates change the implementation of `decodeString` to fix this issue.