### PR TITLE
fix(VideoPlayer): fix for mocking VideoPlayerAPI in storyshots

### DIFF
--- a/packages/react/config/jest/__mocks__/LocaleAPI.js
+++ b/packages/react/config/jest/__mocks__/LocaleAPI.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import mocklist from '../../../src/components/Footer/__data__/locale-list';
+
+module.exports = {
+  getLocale: jest.fn(() => Promise.resolve({ cc: 'us', lc: 'en' })),
+  getList: jest.fn(() => Promise.resolve(mocklist)),
+};

--- a/packages/react/config/jest/__mocks__/VideoPlayerAPI.js
+++ b/packages/react/config/jest/__mocks__/VideoPlayerAPI.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import apiResponse from '../../../../services/src/services/VideoPlayer/__tests__/data/response.json';
+
+module.exports = {
+  getThumbnailUrl: jest.fn(() => {
+    return 'https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320';
+  }),
+  api: jest.fn(() => Promise.resolve(apiResponse)),
+  getVideoDuration: jest.fn(() => {
+    return '(1:00)';
+  }),
+  fireEvent: jest.fn(() => {}),
+  embedVideo: jest.fn(() => Promise.resolve()),
+};

--- a/packages/react/config/jest/setup.js
+++ b/packages/react/config/jest/setup.js
@@ -22,6 +22,12 @@ global.window.location = {
   href: 'http://localhost',
 };
 
+jest.mock('@carbon/ibmdotcom-services', () => ({
+  LocaleAPI: require('./__mocks__/LocaleAPI'),
+  VideoPlayerAPI: require('./__mocks__/VideoPlayerAPI'),
+  globalInit: jest.fn(() => {}),
+}));
+
 const enzyme = require.requireActual('enzyme');
 const Adapter = require.requireActual('enzyme-adapter-react-16');
 

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1709,6 +1709,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                   "href": "https://ibm.com",
                                 }
                               }
+                              disableImage={true}
                               href=""
                               style="text"
                               type="local"
@@ -1721,6 +1722,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                       "href": "https://ibm.com",
                                     }
                                   }
+                                  disableImage={true}
                                   formatCTAcopy={[Function]}
                                   href=""
                                   openLightBox={[Function]}
@@ -1803,6 +1805,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                   "href": "https://ibm.com",
                                 }
                               }
+                              disableImage={true}
                               href=""
                               style="text"
                               type="external"
@@ -1815,6 +1818,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                       "href": "https://ibm.com",
                                     }
                                   }
+                                  disableImage={true}
                                   formatCTAcopy={[Function]}
                                   href=""
                                   openLightBox={[Function]}
@@ -5288,6 +5292,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="card"
                     type="local"
@@ -5303,6 +5308,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         href=""
                         media={null}
                         openLightBox={[Function]}
@@ -5465,6 +5471,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="card"
                     type="download"
@@ -5480,6 +5487,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         href=""
                         media={null}
                         openLightBox={[Function]}
@@ -5645,6 +5653,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="card"
                     type="external"
@@ -5660,6 +5669,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         href=""
                         media={null}
                         openLightBox={[Function]}
@@ -5820,6 +5830,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                 >
                   <CTA
                     copy=""
+                    disableImage={true}
                     href=""
                     media={
                       Object {
@@ -5837,6 +5848,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                       <CardCTA
                         copy=""
                         cta={null}
+                        disableImage={true}
                         href=""
                         media={
                           Object {
@@ -5874,11 +5886,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                               },
                               "handleClick": [Function],
                               "href": "",
-                              "image": Object {
-                                "alt": "",
-                                "defaultSrc": "https://cdnsecakmi.kaltura.com/p/1773841/thumbnail/entry_id/0_uka1msg4/width/320",
-                                "icon": [Function],
-                              },
+                              "image": undefined,
                               "media": Object {
                                 "src": "0_uka1msg4",
                                 "type": "video",
@@ -5906,13 +5914,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                             disabled={false}
                             handleClick={[Function]}
                             href=""
-                            image={
-                              Object {
-                                "alt": "",
-                                "defaultSrc": "https://cdnsecakmi.kaltura.com/p/1773841/thumbnail/entry_id/0_uka1msg4/width/320",
-                                "icon": [Function],
-                              }
-                            }
                             media={
                               Object {
                                 "src": "0_uka1msg4",
@@ -5954,12 +5955,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                 onKeyDown={[Function]}
                                 target={null}
                               >
-                                <Image
-                                  alt=""
-                                  classname="bx--card__img"
-                                  defaultSrc="https://cdnsecakmi.kaltura.com/p/1773841/thumbnail/entry_id/0_uka1msg4/width/320"
-                                  icon={[Function]}
-                                />
                                 <div
                                   className="bx--card__wrapper"
                                 >
@@ -6121,6 +6116,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="local"
@@ -6133,6 +6129,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -6215,6 +6212,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="download"
@@ -6227,6 +6225,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -6312,6 +6311,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="external"
@@ -6324,6 +6324,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -6404,6 +6405,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                 >
                   <CTA
                     copy=""
+                    disableImage={true}
                     href=""
                     media={
                       Object {
@@ -6417,6 +6419,7 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                     <div>
                       <TextCTA
                         copy=""
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         media={
@@ -6578,6 +6581,7 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="local"
@@ -6590,6 +6594,7 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -6672,6 +6677,7 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="download"
@@ -6684,6 +6690,7 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -6854,6 +6861,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="local"
@@ -6866,6 +6874,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -6948,6 +6957,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="download"
@@ -6960,6 +6970,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -7045,6 +7056,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="external"
@@ -7057,6 +7069,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -7137,6 +7150,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                 >
                   <CTA
                     copy=""
+                    disableImage={true}
                     href=""
                     media={
                       Object {
@@ -7150,6 +7164,7 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                     <div>
                       <TextCTA
                         copy=""
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         media={
@@ -7325,6 +7340,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="local"
@@ -7337,6 +7353,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -7419,6 +7436,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="download"
@@ -7431,6 +7449,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -7516,6 +7535,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="text"
                     type="external"
@@ -7528,6 +7548,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         openLightBox={[Function]}
@@ -7608,6 +7629,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                 >
                   <CTA
                     copy=""
+                    disableImage={true}
                     href=""
                     media={
                       Object {
@@ -7621,6 +7643,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                     <div>
                       <TextCTA
                         copy=""
+                        disableImage={true}
                         formatCTAcopy={[Function]}
                         href=""
                         media={
@@ -7762,6 +7785,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="card"
                     type="local"
@@ -7777,6 +7801,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         href=""
                         media={null}
                         openLightBox={[Function]}
@@ -7939,6 +7964,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="card"
                     type="download"
@@ -7954,6 +7980,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         href=""
                         media={null}
                         openLightBox={[Function]}
@@ -8119,6 +8146,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                         "href": "https://ibm.com",
                       }
                     }
+                    disableImage={true}
                     href=""
                     style="card"
                     type="external"
@@ -8134,6 +8162,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             "href": "https://ibm.com",
                           }
                         }
+                        disableImage={true}
                         href=""
                         media={null}
                         openLightBox={[Function]}
@@ -8294,6 +8323,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                 >
                   <CTA
                     copy=""
+                    disableImage={true}
                     href=""
                     media={
                       Object {
@@ -8311,6 +8341,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                       <CardCTA
                         copy=""
                         cta={null}
+                        disableImage={true}
                         href=""
                         media={
                           Object {
@@ -8348,11 +8379,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               },
                               "handleClick": [Function],
                               "href": "",
-                              "image": Object {
-                                "alt": "",
-                                "defaultSrc": "https://cdnsecakmi.kaltura.com/p/1773841/thumbnail/entry_id/0_uka1msg4/width/320",
-                                "icon": [Function],
-                              },
+                              "image": undefined,
                               "media": Object {
                                 "src": "0_uka1msg4",
                                 "type": "video",
@@ -8380,13 +8407,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                             disabled={false}
                             handleClick={[Function]}
                             href=""
-                            image={
-                              Object {
-                                "alt": "",
-                                "defaultSrc": "https://cdnsecakmi.kaltura.com/p/1773841/thumbnail/entry_id/0_uka1msg4/width/320",
-                                "icon": [Function],
-                              }
-                            }
                             media={
                               Object {
                                 "src": "0_uka1msg4",
@@ -8428,12 +8448,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 onKeyDown={[Function]}
                                 target={null}
                               >
-                                <Image
-                                  alt=""
-                                  classname="bx--card__img"
-                                  defaultSrc="https://cdnsecakmi.kaltura.com/p/1773841/thumbnail/entry_id/0_uka1msg4/width/320"
-                                  icon={[Function]}
-                                />
                                 <div
                                   className="bx--card__wrapper"
                                 >
@@ -13854,6 +13868,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         "href": "https://www.example.com",
                                       }
                                     }
+                                    disableImage={false}
                                     href=""
                                     media={null}
                                     openLightBox={[Function]}
@@ -14261,6 +14276,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         "href": "https://www.example.com",
                                       }
                                     }
+                                    disableImage={false}
                                     href=""
                                     media={null}
                                     openLightBox={[Function]}
@@ -15250,6 +15266,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 "href": "https://www.example.com",
                                               }
                                             }
+                                            disableImage={false}
                                             href=""
                                             media={null}
                                             openLightBox={[Function]}
@@ -15657,6 +15674,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                 "href": "https://www.example.com",
                                               }
                                             }
+                                            disableImage={false}
                                             href=""
                                             media={null}
                                             openLightBox={[Function]}
@@ -16132,6 +16150,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="local"
@@ -16147,6 +16166,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -16309,6 +16329,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="external"
@@ -16324,6 +16345,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -18151,6 +18173,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                               "href": "https://www.ibm.com",
                             }
                           }
+                          disableImage={false}
                           href=""
                           media={null}
                           openLightBox={[Function]}
@@ -20066,6 +20089,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                       "href": "https://www.ibm.com",
                                     }
                                   }
+                                  disableImage={false}
                                   href=""
                                   media={null}
                                   openLightBox={[Function]}
@@ -20267,6 +20291,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="local"
@@ -20282,6 +20307,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -20444,6 +20470,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="external"
@@ -20459,6 +20486,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -21280,6 +21308,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                               "href": "https://www.example.com",
                             }
                           }
+                          disableImage={false}
                           href=""
                           media={null}
                           openLightBox={[Function]}
@@ -21992,6 +22021,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                       "href": "https://www.example.com",
                                     }
                                   }
+                                  disableImage={false}
                                   href=""
                                   media={null}
                                   openLightBox={[Function]}
@@ -22193,6 +22223,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="local"
@@ -22208,6 +22239,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -22370,6 +22402,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="external"
@@ -22385,6 +22418,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -22815,6 +22849,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                               "href": "https://www.ibm.com",
                             }
                           }
+                          disableImage={false}
                           href=""
                           media={null}
                           openLightBox={[Function]}
@@ -23330,6 +23365,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                       "href": "https://www.ibm.com",
                                     }
                                   }
+                                  disableImage={false}
                                   href=""
                                   media={null}
                                   openLightBox={[Function]}
@@ -23531,6 +23567,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="local"
@@ -23546,6 +23583,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -23708,6 +23746,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                         "href": "https://ibm.com",
                                       }
                                     }
+                                    disableImage={true}
                                     href=""
                                     style="card"
                                     type="external"
@@ -23723,6 +23762,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                             "href": "https://ibm.com",
                                           }
                                         }
+                                        disableImage={true}
                                         href=""
                                         media={null}
                                         openLightBox={[Function]}
@@ -24694,6 +24734,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                           "href": "https://example.com",
                                         }
                                       }
+                                      disableImage={true}
                                       href=""
                                       style="text"
                                       type="local"
@@ -24706,6 +24747,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                               "href": "https://example.com",
                                             }
                                           }
+                                          disableImage={true}
                                           formatCTAcopy={[Function]}
                                           href=""
                                           openLightBox={[Function]}
@@ -24788,6 +24830,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                           "href": "https://example.com",
                                         }
                                       }
+                                      disableImage={true}
                                       href=""
                                       style="text"
                                       type="external"
@@ -24800,6 +24843,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                               "href": "https://example.com",
                                             }
                                           }
+                                          disableImage={true}
                                           formatCTAcopy={[Function]}
                                           href=""
                                           openLightBox={[Function]}
@@ -24986,6 +25030,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                           "href": "https://example.com",
                                         }
                                       }
+                                      disableImage={true}
                                       href=""
                                       style="text"
                                       type="local"
@@ -24998,6 +25043,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                               "href": "https://example.com",
                                             }
                                           }
+                                          disableImage={true}
                                           formatCTAcopy={[Function]}
                                           href=""
                                           openLightBox={[Function]}
@@ -25080,6 +25126,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                           "href": "https://example.com",
                                         }
                                       }
+                                      disableImage={true}
                                       href=""
                                       style="text"
                                       type="external"
@@ -25092,6 +25139,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                               "href": "https://example.com",
                                             }
                                           }
+                                          disableImage={true}
                                           formatCTAcopy={[Function]}
                                           href=""
                                           openLightBox={[Function]}
@@ -25264,6 +25312,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                           "href": "https://example.com",
                                         }
                                       }
+                                      disableImage={true}
                                       href=""
                                       style="text"
                                       type="local"
@@ -25276,6 +25325,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                                               "href": "https://example.com",
                                             }
                                           }
+                                          disableImage={true}
                                           formatCTAcopy={[Function]}
                                           href=""
                                           openLightBox={[Function]}
@@ -26061,6 +26111,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupSimple Default 1`] = `
                               "href": "https://www.example.com",
                             }
                           }
+                          disableImage={false}
                           href=""
                           media={null}
                           openLightBox={[Function]}
@@ -26942,6 +26993,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                                   "href": "https://ibm.com",
                                 }
                               }
+                              disableImage={true}
                               href=""
                               style="text"
                               type="local"
@@ -26954,6 +27006,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                                       "href": "https://ibm.com",
                                     }
                                   }
+                                  disableImage={true}
                                   formatCTAcopy={[Function]}
                                   href=""
                                   openLightBox={[Function]}
@@ -27036,6 +27089,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                                   "href": "https://ibm.com",
                                 }
                               }
+                              disableImage={true}
                               href=""
                               style="text"
                               type="local"
@@ -27048,6 +27102,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                                       "href": "https://ibm.com",
                                     }
                                   }
+                                  disableImage={true}
                                   formatCTAcopy={[Function]}
                                   href=""
                                   openLightBox={[Function]}
@@ -27130,6 +27185,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                                   "href": "https://ibm.com",
                                 }
                               }
+                              disableImage={true}
                               href=""
                               style="text"
                               type="download"
@@ -27142,6 +27198,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                                       "href": "https://ibm.com",
                                     }
                                   }
+                                  disableImage={true}
                                   formatCTAcopy={[Function]}
                                   href=""
                                   openLightBox={[Function]}
@@ -27924,6 +27981,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                   "href": "http://local.url.com/",
                                 }
                               }
+                              disableImage={false}
                               href=""
                               media={null}
                               openLightBox={[Function]}

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5082,7 +5082,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                               videoId="0_uka1msg4"
                             >
                               <div
-                                aria-label="undefined undefined"
+                                aria-label=" (1:00)"
                                 className="bx--video-player"
                               >
                                 <div
@@ -12199,7 +12199,7 @@ exports[`Storyshots Components|VideoPlayer Default 1`] = `
             videoId="0_uka1msg4"
           >
             <div
-              aria-label="undefined undefined"
+              aria-label=" (1:00)"
               className="bx--video-player"
             >
               <div
@@ -12215,6 +12215,7 @@ exports[`Storyshots Components|VideoPlayer Default 1`] = `
                 className="bx--video-player__video-caption"
               >
                  
+                (1:00)
               </div>
             </div>
           </VideoPlayer>

--- a/packages/react/src/components/CTA/CardCTA.js
+++ b/packages/react/src/components/CTA/CardCTA.js
@@ -22,22 +22,27 @@ const CardCTA = ({
   openLightBox,
   renderLightBox,
   videoTitle,
+  disableImage,
   ...otherProps
 }) => {
   // eslint-disable-next-line no-unused-vars
   const { style, ...cardProps } = otherProps;
 
   if (type === 'video') {
-    // use image src if passed in through props, otherwise use Kaltura's generated thumbnail image
-    const image = cardProps.image
-      ? cardProps.image
-      : {
-          defaultSrc: VideoPlayerAPI.getThumbnailUrl({
-            videoId: cardProps.media?.src,
-            width: '320',
-          }),
-          alt: videoTitle[0].title,
-        };
+    let image;
+    if (!disableImage) {
+      // use image src if passed in through props, otherwise use Kaltura's generated thumbnail image
+      image = cardProps.image
+        ? cardProps.image
+        : {
+            defaultSrc: VideoPlayerAPI.getThumbnailUrl({
+              videoId: cardProps.media?.src,
+              width: '320',
+            }),
+            alt: videoTitle[0].title,
+          };
+      image = { ...image, icon: PlayIcon };
+    }
 
     return (
       <>
@@ -58,7 +63,7 @@ const CardCTA = ({
                 },
                 copy: videoTitle[0].duration?.replace(/\(|\)/g, ''),
               },
-              image: { ...image, icon: PlayIcon },
+              image: image,
               copy: videoTitle[0].title,
               handleClick: e => CTALogic.setLightBox(e, openLightBox),
             }}
@@ -127,6 +132,10 @@ CardCTA.propTypes = {
   ]),
 
   /**
+   * Boolean to determine whether to disable image for card
+   */
+  disableImage: PropTypes.bool,
+  /**
    * Func to set renderLightBox state.
    */
   openLightBox: PropTypes.func,
@@ -152,6 +161,7 @@ CardCTA.defaultProps = {
   type: 'default',
   copy: '',
   cta: null,
+  disableImage: false,
   media: null,
 };
 

--- a/packages/react/src/components/LinkList/LinkList.js
+++ b/packages/react/src/components/LinkList/LinkList.js
@@ -39,7 +39,7 @@ const LinkList = ({ heading, items, style }) => {
             <li
               className={`${prefix}--link-list__list__CTA ${prefix}--link-list__list--${cta.type}`}
               key={index}>
-              <CTA style={linkStyle} {...cta} />
+              <CTA style={linkStyle} {...cta} disableImage={true} />
             </li>
           );
         })}

--- a/packages/react/src/components/VideoPlayer/VideoPlayer.js
+++ b/packages/react/src/components/VideoPlayer/VideoPlayer.js
@@ -19,7 +19,7 @@ const { prefix } = settings;
  * VideoPlayer component.
  */
 const VideoPlayer = ({ inverse, showCaption, videoId, customClassName }) => {
-  const [videoData, setVideoData] = useState({ description: '' });
+  const [videoData, setVideoData] = useState({ description: '', name: '' });
   const videoPlayerId = `video-player__video-${videoId}`;
   const videoDuration = VideoPlayerAPI.getVideoDuration(videoData.msDuration);
 
@@ -56,7 +56,8 @@ const VideoPlayer = ({ inverse, showCaption, videoId, customClassName }) => {
         data-autoid={`${stablePrefix}--${videoPlayerId}`}>
         <div
           className={`${prefix}--video-player__video`}
-          id={`${prefix}--${videoPlayerId}`}></div>
+          id={`${prefix}--${videoPlayerId}`}
+        />
       </div>
       {showCaption && (
         <div className={`${prefix}--video-player__video-caption`}>

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -99,6 +99,10 @@
             border-bottom: 1px solid $ui-03;
           }
         }
+
+        &.#{$prefix}--link-list__list--video .#{$prefix}--card__footer span {
+          color: $link-01;
+        }
       }
 
       &.#{$prefix}--link-list__list--card {

--- a/packages/utilities/src/utilities/smoothScroll/smoothScroll.js
+++ b/packages/utilities/src/utilities/smoothScroll/smoothScroll.js
@@ -27,7 +27,6 @@ const smoothScroll = (e, selector, offset = 0) => {
   if (e !== null) {
     e.preventDefault();
     getSelector = e.currentTarget.getAttribute('href');
-    console.log('getSelector', getSelector);
   } else if (selector) {
     getSelector = selector;
   } else {


### PR DESCRIPTION
### Related Ticket(s)

Refs #2688 

### Description

The CI checks were running with obfuscated Kaltura IDs since they are
passed in as environment variables, so this is setting up a mock for
the VideoPlayerAPI service to return back mocked data instead.

### Changelog

**Changed**

- Created jest mock for `@carbon/ibmdotcom-services` in React package