### PR TITLE
style(Quote): serif font added; $quotation-01 token added

### DIFF
--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -29,12 +29,14 @@
 
     &__copy {
       @include carbon--make-col-ready;
-      @include carbon--type-style(quotation-02, true);
+      @include carbon--type-style('quotation-01', true);
+      @include carbon--font-family('serif');
 
-      padding: 0 2rem $carbon--layout-04 2rem;
+      padding: 0 2rem $carbon--layout-03 2rem;
 
-      @include carbon--breakpoint-down('md') {
-        padding-bottom: $carbon--layout-03;
+      @include carbon--breakpoint('md') {
+        padding-bottom: $carbon--layout-04;
+        @include carbon--type-style('quotation-02', true);
       }
     }
 

--- a/packages/styles/scss/globals/_imports.scss
+++ b/packages/styles/scss/globals/_imports.scss
@@ -14,6 +14,7 @@
 // effect on the final artifact size
 
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/type';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/font-family';
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/themes';
 @import 'carbon-components/scss/globals/scss/vars';
 @import 'carbon-components/scss/globals/scss/helper-mixins';


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Callout Quote: Incorrect text styles #2398

### Description

The `quote` component was missing the `quotation-01` token. Also, it looks like we found a bug in the carbon expressive theme. The `quotation-` tokens aren't making use of the IBM Plex Serif mixin.
![Captura de Tela 2020-06-09 às 10 19 15](https://user-images.githubusercontent.com/42848561/84152224-bd5c7680-aa3a-11ea-8e65-497af52d16d4.png)

### Changelog

**New**

- `IBM Plex Serif` import;
- `quotation-01` token for `sm` breakpoint in the `Quote` component;