### PR TITLE
fix(table-of-contents): added max-width for select text on mobile view

### DIFF
--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -72,7 +72,7 @@
         border: none;
         background-color: transparent;
         height: carbon--rem(48px);
-        width: 100%;
+        width: 90%;
         appearance: none;
         @include carbon--type-style(body-short-02);
         @include focus-outline('reset');


### PR DESCRIPTION
### Related Ticket(s)

#2572 

### Description

Added `width` so the select text don't overlap the icon on mobile view