### PR TITLE
fix(footer): fixed legal nav spacing

### DIFF
--- a/packages/styles/scss/components/footer/_legal-nav.scss
+++ b/packages/styles/scss/components/footer/_legal-nav.scss
@@ -78,7 +78,7 @@
     &__list-item {
       display: inline-block;
       margin-right: carbon--mini-units(4);
-      padding: temp--padding-diff($TEMP--link-height, $TEMP--link-type) 0 0 0;
+      padding: $spacing-03 0 0 0;
 
       &:last-child {
         margin-right: 0;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2375

### Description

Fixed legal nav padding on the footer

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
