### PR TITLE
fix(FeatCardBlockLarge): copy width 90% above md breakpoint

### DIFF
--- a/packages/styles/scss/patterns/blocks/feature-card-block-large/_feature-card-block-large.scss
+++ b/packages/styles/scss/patterns/blocks/feature-card-block-large/_feature-card-block-large.scss
@@ -102,6 +102,16 @@ $fcb-breakpoint-up--lg: map-get(
           padding: $layout-05;
         }
 
+        .#{$prefix}--card__eyebrow,
+        .#{$prefix}--card__heading,
+        .#{$prefix}--card__copy {
+          width: 100%;
+          @include carbon--breakpoint('md') {
+            width: 90%;
+            max-width: carbon--rem(480px);
+          }
+        }
+
         .#{$prefix}--card__eyebrow {
           margin: 0 0 $spacing-05 0;
           color: $inverse-01;


### PR DESCRIPTION
### Related Ticket(s)

https://app.zenhub.com/workspaces/ibmcom-library-5d449f3642eb1962336cbe52/issues/carbon-design-system/ibm-dotcom-library/2411

### Description

fixed the styling bug based on design QA feedback: all card copy goes to 90% past the md breakpoint. all copy has a 480 max width.

### Changelog

**Changed**

- _feature-card-block-large.scss styles changed

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
