### PR TITLE
fix(LegalNav): `key` prop added to the trustE <li/> item

### DIFF
--- a/packages/react/src/components/Footer/LegalNav.js
+++ b/packages/react/src/components/Footer/LegalNav.js
@@ -17,13 +17,15 @@ const { prefix } = settings;
 /**
  * Placeholder <li/> element for injection of the TrustE cookie preferences link
  *
+ * @param {number} key - the key for the JSX object
  * @returns {*} JSX object
  */
-const renderTrusteItem = () => {
+const renderTrusteItem = key => {
   return (
     <li
       className={`${prefix}--legal-nav__list-item`}
       data-autoid={`${stablePrefix}--privacy-cp`}
+      key={key}
     />
   );
 };
@@ -73,7 +75,8 @@ function renderListItems(links) {
     );
   });
 
-  renderedLinks.push(renderTrusteItem());
+  const key = parseFloat(renderedLinks[renderedLinks.length - 1].key) + 1;
+  renderedLinks.push(renderTrusteItem(key));
 
   const chunked_arr = [];
   let index = 0;


### PR DESCRIPTION
### Related Ticket(s)

Footer IBM links violate react rules #2656

### Description

Added a `key` property to the `<li />` item, so the dev console doesn't throw an error.

### Changelog

**New**

- `key` prop in the `<li/>` item;

