### PR TITLE
chore(devenv): remove `.bx--visually-hidden` override

### DIFF
--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -36,10 +36,6 @@
   width: 100%;
 }
 
-.bx--visually-hidden {
-  display: none;
-}
-
 // hide the cookie button
 #teconsent {
   visibility: hidden;

--- a/packages/styles/.storybook/_container.scss
+++ b/packages/styles/.storybook/_container.scss
@@ -1,3 +1,10 @@
+//
+// Copyright IBM Corp. 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 // IMPORTANT: This import path should _not_ be used outside our source tree
 // as `src` directory is _not_ meant to be shipped in our NPM package.
 // Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
@@ -41,8 +48,4 @@ $feature-flags: (
 
 .storybook-readme-story {
   width: 100%;
-}
-
-.bx--visually-hidden {
-  display: none;
 }

--- a/packages/vanilla/.storybook/_container.scss
+++ b/packages/vanilla/.storybook/_container.scss
@@ -1,3 +1,10 @@
+//
+// Copyright IBM Corp. 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 // IMPORTANT: This import path should _not_ be used outside our source tree
 // as `src` directory is _not_ meant to be shipped in our NPM package.
 // Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
@@ -25,8 +32,4 @@
 
 .storybook-readme-story {
   width: 100%;
-}
-
-.bx--visually-hidden {
-  display: none;
 }


### PR DESCRIPTION
### Related Ticket(s)

Refs #2725.

### Description

This change removes our CSS override for `.bx--visually-hidden` class that is defined in our Storybook environment.

Setting `display:none` to that class makes the DOM element no longer keyboard focusable that is against its purpose, which is, "hidden visually, but navigable with screen readers".

Carbon modal's focus wrap behavior relies on elements with `.bx--visually-hidden` keyboard-focusable to detect changes in focused element that goes out of modal.

### Changelog

**Removed**

- Our CSS override in Storybook for `.bx--visually-hidden`.