### PR TITLE
feat(styles): support CSS custom properties in theme zoning

### DIFF
--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -71,10 +71,25 @@ addDecorator((story, { parameters }) => {
   return story();
 });
 
+let preservedTheme;
+
+addDecorator((story, { parameters }) => {
+  const root = document.documentElement;
+  if (parameters['carbon-theme']?.disabled) {
+    root.setAttribute('storybook-carbon-theme', '');
+  } else {
+    root.setAttribute('storybook-carbon-theme', preservedTheme || '');
+  }
+  return story();
+});
+
 addDecorator(story => <Container story={story} />);
 
 addons.getChannel().on(CURRENT_THEME, theme => {
-  document.documentElement.setAttribute('storybook-carbon-theme', theme);
+  document.documentElement.setAttribute(
+    'storybook-carbon-theme',
+    (preservedTheme = theme)
+  );
   addons.getChannel().emit(coreEvents.FORCE_RE_RENDER);
 });
 

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -392,7 +392,7 @@ exports[`Storyshots Components|Card Link/Clickable 1`] = `
     }
   >
     <div
-      className="bx--card--null"
+      className="bx--card--white"
     >
       <div
         className="bx--grid"
@@ -535,7 +535,7 @@ exports[`Storyshots Components|Card Static 1`] = `
     }
   >
     <div
-      className="bx--card--null"
+      className="bx--card--white"
     >
       <div
         className="bx--grid"
@@ -10764,7 +10764,7 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
         menuItems={null}
         menuLabel="Jump to"
         stickyOffset={null}
-        theme={null}
+        theme=""
       >
         <section
           className="bx--tableofcontents"
@@ -11107,7 +11107,7 @@ exports[`Storyshots Components|Table of Contents Manually define Menu Items 1`] 
       menuLabel="Jump to"
       menuRule={false}
       stickyOffset={null}
-      theme={null}
+      theme=""
     >
       <section
         className="bx--tableofcontents"
@@ -11672,7 +11672,7 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
         menuLabel="Jump to"
         menuRule={false}
         stickyOffset={null}
-        theme={null}
+        theme=""
       >
         <section
           className="bx--tableofcontents"
@@ -28259,7 +28259,7 @@ exports[`Storyshots Patterns (Sections)|CTASection Default 1`] = `
           },
         ]
       }
-      theme={null}
+      theme=""
     >
       <section
         className="bx--cta-section"
@@ -28756,7 +28756,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
         ]
       }
       heading="Aliquam condimentum interdum"
-      theme={null}
+      theme=""
     >
       <ContentSection
         autoid="dds--card-group-images-group"
@@ -29604,7 +29604,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
         }
       }
       heading="Aliquam condimentum interdum"
-      theme={null}
+      theme=""
     >
       <ContentSection
         autoid="dds--card-group-simple-group"
@@ -30426,7 +30426,7 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
           ],
         }
       }
-      theme={null}
+      theme=""
       title="Lead space title"
       type="small"
     >
@@ -30751,7 +30751,7 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
           ]
         }
         copy="Use this area for a short line of copy to support the title"
-        theme={null}
+        theme=""
         title="Lead space title"
         type="small"
       >

--- a/packages/react/src/components/Card/__stories__/Card.stories.js
+++ b/packages/react/src/components/Card/__stories__/Card.stories.js
@@ -47,7 +47,8 @@ export const Static = ({ parameters }) => {
     },
   });
 
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme');
+  const theme =
+    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
 
   return (
     <div className={`bx--card--${theme}`}>
@@ -74,7 +75,8 @@ export const LinkClickable = ({ parameters }) => {
       src: ArrowRight20,
     },
   });
-  const theme = document.documentElement.getAttribute('storybook-carbon-theme');
+  const theme =
+    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
 
   return (
     <div className={`bx--card--${theme}`}>

--- a/packages/react/src/components/ExpressiveModal/__stories__/ExpressiveModal.stories.js
+++ b/packages/react/src/components/ExpressiveModal/__stories__/ExpressiveModal.stories.js
@@ -43,6 +43,7 @@ export default {
 
   parameters: {
     ...readme.parameters,
+    'carbon-theme': { disabled: true },
     knobs: {
       ExpressiveModal: ({ groupId }) => ({
         open: boolean('Toggle modal', true, groupId),

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -94,17 +94,26 @@
     @include themed-items;
   }
   .#{$prefix}--card-group.#{$prefix}--card-group--g10 {
-    @include carbon--theme($carbon--theme--g10) {
+    @include carbon--theme(
+      $carbon--theme--g10,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
   .#{$prefix}--card-group.#{$prefix}--card-group--g90 {
-    @include carbon--theme($carbon--theme--g90) {
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
   .#{$prefix}--card-group.#{$prefix}--card-group--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }

--- a/packages/styles/scss/components/footer/_footer-logo.scss
+++ b/packages/styles/scss/components/footer/_footer-logo.scss
@@ -11,52 +11,55 @@
 
 @mixin footer-logo {
   .#{$prefix}--footer-logo {
-    @include carbon--make-col-ready;
-    @include carbon--make-col(2, 4);
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
+      @include carbon--make-col-ready;
+      @include carbon--make-col(2, 4);
 
-    margin-bottom: carbon--mini-units(6);
+      margin-bottom: carbon--mini-units(6);
 
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col(2, 8);
-    }
-
-    @include carbon--breakpoint('lg') {
-      @include carbon--make-col(2, 16);
-    }
-
-    &__link {
-      $logo-padding: $carbon--grid-gutter / 2;
-      $logo-size: carbon--mini-units(16) + ($logo-padding * 2);
-
-      color: $text-01;
-      margin-top: -1 * $logo-padding;
-      margin-left: -1 * $logo-padding;
-      padding: $logo-padding;
-      display: block;
-
-      &:focus {
-        outline: none;
-        box-shadow: inset 0 0 0 2px $focus;
-      }
-
-      @include carbon--breakpoint-down($TEMP--breakpoint-down--md) {
-        max-width: $logo-size;
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col(2, 8);
       }
 
       @include carbon--breakpoint('lg') {
-        min-width: $logo-size;
+        @include carbon--make-col(2, 16);
       }
-    }
 
-    &__logo {
-      fill: currentColor;
-      display: block;
+      &__link {
+        $logo-padding: $carbon--grid-gutter / 2;
+        $logo-size: carbon--mini-units(16) + ($logo-padding * 2);
+
+        color: $text-01;
+        margin-top: -1 * $logo-padding;
+        margin-left: -1 * $logo-padding;
+        padding: $logo-padding;
+        display: block;
+
+        &:focus {
+          outline: none;
+          box-shadow: inset 0 0 0 2px $focus;
+        }
+
+        @include carbon--breakpoint-down($TEMP--breakpoint-down--md) {
+          max-width: $logo-size;
+        }
+
+        @include carbon--breakpoint('lg') {
+          min-width: $logo-size;
+        }
+      }
+
+      &__logo {
+        fill: currentColor;
+        display: block;
+      }
     }
   }
 }
 
 @include exports('footer-logo') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include footer-logo;
-  }
+  @include footer-logo;
 }

--- a/packages/styles/scss/components/footer/_footer-nav-group.scss
+++ b/packages/styles/scss/components/footer/_footer-nav-group.scss
@@ -13,91 +13,94 @@
   $TEMP--footer-nav-group-type: 'heading-02';
 
   .#{$prefix}--footer-nav-group {
-    padding-left: 0;
-    margin-bottom: 0;
-    &__title {
-      // need to remove once 16 variants come out
-      @include carbon--type-style($TEMP--footer-nav-group-type);
-
-      display: none;
-    }
-
-    .#{$prefix}--accordion__content {
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       padding-left: 0;
-      padding-right: 0;
-    }
-
-    .#{$prefix}--link {
-      @include carbon--breakpoint-down($TEMP--breakpoint-down--md) {
-        margin-top: 0;
-        display: block;
-        padding: temp--padding-diff($TEMP--link-height, $TEMP--link-type)
-          ($carbon--grid-gutter / 2);
-
-        &:hover,
-        &:active {
-          text-decoration: none;
-        }
-
-        &:hover {
-          background-color: $hover-ui;
-        }
-
-        &:active {
-          background-color: $active-ui;
-        }
-
-        &:focus {
-          outline-width: 0;
-          box-shadow: inset 0 0 0 1px $focus;
-        }
-      }
-    }
-
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col-ready;
-
-      padding-left: 0;
-      display: inline-block;
-      margin-bottom: carbon--mini-units(6);
-
+      margin-bottom: 0;
       &__title {
-        display: block;
-      }
+        // need to remove once 16 variants come out
+        @include carbon--type-style($TEMP--footer-nav-group-type);
 
-      &__item {
-        margin-top: carbon--mini-units(1);
-      }
-
-      &.#{$prefix}--accordion__item {
-        border-top: 0 transparent;
-
-        &:last-child {
-          border-bottom: 0;
-        }
-      }
-
-      .#{$prefix}--accordion__heading {
         display: none;
       }
 
       .#{$prefix}--accordion__content {
-        display: block;
-        height: auto;
-        opacity: 1;
-        visibility: visible;
+        padding-left: 0;
+        padding-right: 0;
       }
 
-      .#{$prefix}--accordion__content,
-      &.#{$prefix}--accordion__item--active .#{$prefix}--accordion__content {
-        padding: 0;
+      .#{$prefix}--link {
+        @include carbon--breakpoint-down($TEMP--breakpoint-down--md) {
+          margin-top: 0;
+          display: block;
+          padding: temp--padding-diff($TEMP--link-height, $TEMP--link-type)
+            ($carbon--grid-gutter / 2);
+
+          &:hover,
+          &:active {
+            text-decoration: none;
+          }
+
+          &:hover {
+            background-color: $hover-ui;
+          }
+
+          &:active {
+            background-color: $active-ui;
+          }
+
+          &:focus {
+            outline-width: 0;
+            box-shadow: inset 0 0 0 1px $focus;
+          }
+        }
+      }
+
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col-ready;
+
+        padding-left: 0;
+        display: inline-block;
+        margin-bottom: carbon--mini-units(6);
+
+        &__title {
+          display: block;
+        }
+
+        &__item {
+          margin-top: carbon--mini-units(1);
+        }
+
+        &.#{$prefix}--accordion__item {
+          border-top: 0 transparent;
+
+          &:last-child {
+            border-bottom: 0;
+          }
+        }
+
+        .#{$prefix}--accordion__heading {
+          display: none;
+        }
+
+        .#{$prefix}--accordion__content {
+          display: block;
+          height: auto;
+          opacity: 1;
+          visibility: visible;
+        }
+
+        .#{$prefix}--accordion__content,
+        &.#{$prefix}--accordion__item--active .#{$prefix}--accordion__content {
+          padding: 0;
+        }
       }
     }
   }
 }
 
 @include exports('footer-nav-group') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include footer-nav-group;
-  }
+  @include footer-nav-group;
 }

--- a/packages/styles/scss/components/footer/_footer-nav.scss
+++ b/packages/styles/scss/components/footer/_footer-nav.scss
@@ -14,50 +14,53 @@
 
 @mixin footer-nav {
   .#{$prefix}--footer-nav {
-    @include accordion;
-    @include temp-accordion-expressive;
-    @include carbon--make-col-ready;
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
+      @include accordion;
+      @include temp-accordion-expressive;
+      @include carbon--make-col-ready;
 
-    padding: 0;
-    order: 1;
+      padding: 0;
+      order: 1;
 
-    .#{$prefix}--footer--short & {
-      display: none;
-    }
+      .#{$prefix}--footer--short & {
+        display: none;
+      }
 
-    @include carbon--breakpoint('md') {
-      padding: 0 $carbon--grid-gutter / 2;
-    }
-
-    @include carbon--breakpoint-between('md', $TEMP--breakpoint-down--lg) {
-      padding-top: carbon--mini-units(2);
-      border-top: 1px solid $ui-03;
-    }
-
-    @include carbon--breakpoint('lg') {
-      @include carbon--make-col(12, 16);
-      @include carbon--make-col-offset(2, 16);
-    }
-
-    &__container {
       @include carbon--breakpoint('md') {
-        @include carbon--make-row;
+        padding: 0 $carbon--grid-gutter / 2;
+      }
 
-        display: block;
-        column-count: 2;
-        column-gap: $carbon--grid-gutter;
+      @include carbon--breakpoint-between('md', $TEMP--breakpoint-down--lg) {
+        padding-top: carbon--mini-units(2);
+        border-top: 1px solid $ui-03;
       }
 
       @include carbon--breakpoint('lg') {
-        column-count: 3;
-        column-gap: $carbon--grid-gutter;
+        @include carbon--make-col(12, 16);
+        @include carbon--make-col-offset(2, 16);
+      }
+
+      &__container {
+        @include carbon--breakpoint('md') {
+          @include carbon--make-row;
+
+          display: block;
+          column-count: 2;
+          column-gap: $carbon--grid-gutter;
+        }
+
+        @include carbon--breakpoint('lg') {
+          column-count: 3;
+          column-gap: $carbon--grid-gutter;
+        }
       }
     }
   }
 }
 
 @include exports('footer-nav') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include footer-nav;
-  }
+  @include footer-nav;
 }

--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -13,69 +13,74 @@
 
 @mixin footer {
   .#{$prefix}--footer {
-    @include temp-link-expressive;
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
+      @include temp-link-expressive;
 
-    color: $text-01;
-    background-color: $ui-background;
-    padding-top: carbon--mini-units(6);
+      color: $text-01;
+      background-color: $ui-background;
+      padding-top: carbon--mini-units(6);
 
-    &--short {
-      padding-top: carbon--mini-units(4);
-    }
-
-    &__main {
-      @include carbon--make-container;
-    }
-
-    &__main-container {
-      @include carbon--make-row;
-
-      flex-direction: column;
-
-      .#{$prefix}--footer--short & {
-        flex-direction: row;
+      &--short {
+        padding-top: carbon--mini-units(4);
       }
 
-      @include carbon--breakpoint('lg') {
-        flex-direction: row;
-      }
-    }
-
-    .#{$prefix}--footer__link.#{$prefix}--link {
-      &,
-      &:visited,
-      &:visited:hover {
-        color: $text-02;
+      &__main {
+        @include carbon--make-container;
       }
 
-      &:focus {
-        outline-color: $focus;
-        outline-offset: -1px;
+      &__main-container {
+        @include carbon--make-row;
+
+        flex-direction: column;
+
+        .#{$prefix}--footer--short & {
+          flex-direction: row;
+        }
+
+        @include carbon--breakpoint('lg') {
+          flex-direction: row;
+        }
       }
 
-      &:active {
-        color: $text-04;
-      }
-
-      &:hover {
-        color: $text-01;
-      }
-    }
-
-    .#{$prefix}--legal-nav__list
-      .#{$prefix}--legal-nav__list-item
-      .#{$prefix}--link {
-      color: $text-02;
-      &:hover {
-        color: $text-01;
-      }
-    }
-
-    .#{$prefix}--modal-content {
-      .#{$prefix}--link {
+      .#{$prefix}--footer__link.#{$prefix}--link {
         &,
-        &:visited {
-          color: $inverse-01;
+        &:visited,
+        &:visited:hover {
+          color: $text-02;
+        }
+
+        &:focus {
+          outline-color: $focus;
+          outline-offset: -1px;
+        }
+
+        &:active {
+          color: $text-04;
+        }
+
+        &:hover {
+          color: $text-01;
+        }
+      }
+
+      .#{$prefix}--legal-nav__list
+        .#{$prefix}--legal-nav__list-item
+        .#{$prefix}--link {
+        color: $text-02;
+        &:hover {
+          color: $text-01;
+        }
+      }
+
+      .#{$prefix}--modal-content {
+        .#{$prefix}--link {
+          &,
+          &:visited {
+            color: $inverse-01;
+          }
         }
       }
     }
@@ -83,7 +88,5 @@
 }
 
 @include exports('footer') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include footer;
-  }
+  @include footer;
 }

--- a/packages/styles/scss/components/footer/_language-selector.scss
+++ b/packages/styles/scss/components/footer/_language-selector.scss
@@ -19,76 +19,79 @@
 
 @mixin language-selector {
   .#{$prefix}--language-selector__container {
-    @include combo-box;
-    @include listbox;
-    @include text-input;
-    @include combo-box-expressive;
-    @include list-box-expressive;
-    @include text-input-expressive;
-    @include carbon--make-col-ready;
-    @include carbon--make-col(4, 4);
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
+      @include combo-box;
+      @include listbox;
+      @include text-input;
+      @include combo-box-expressive;
+      @include list-box-expressive;
+      @include text-input-expressive;
+      @include carbon--make-col-ready;
+      @include carbon--make-col(4, 4);
 
-    margin-top: $spacing-05;
-    padding-left: 0;
-    padding-right: 0;
-    order: 0;
+      margin-top: $spacing-05;
+      padding-left: 0;
+      padding-right: 0;
+      order: 0;
 
-    .#{$prefix}--language-selector {
-      max-width: 100%;
-      width: 100%;
+      .#{$prefix}--language-selector {
+        max-width: 100%;
+        width: 100%;
 
-      @include carbon--breakpoint('md') {
-        min-width: carbon--mini-units(27);
-        max-width: carbon--mini-units(40);
+        @include carbon--breakpoint('md') {
+          min-width: carbon--mini-units(27);
+          max-width: carbon--mini-units(40);
 
-        .#{$prefix}--footer--short & {
-          float: right;
+          .#{$prefix}--footer--short & {
+            float: right;
+          }
+        }
+
+        // Expressive styles
+        .#{$prefix}--text-input,
+        .#{$prefix}--list-box__menu-item__option {
+          @include carbon--type-style('body-long-02');
         }
       }
 
-      // Expressive styles
-      .#{$prefix}--text-input,
-      .#{$prefix}--list-box__menu-item__option {
-        @include carbon--type-style('body-long-02');
-      }
-    }
-
-    .#{$prefix}--footer--short & {
-      margin-top: 0;
-    }
-
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col(4, 8);
-
-      margin-bottom: carbon--mini-units(2);
-
       .#{$prefix}--footer--short & {
-        @include carbon--make-col-offset(2, 8);
+        margin-top: 0;
       }
-    }
 
-    @include carbon--breakpoint('lg') {
-      @include carbon--make-col(4, 16);
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col(4, 8);
 
-      order: 1;
+        margin-bottom: carbon--mini-units(2);
 
-      .#{$prefix}--footer--short & {
-        @include carbon--make-col-offset(10, 16);
+        .#{$prefix}--footer--short & {
+          @include carbon--make-col-offset(2, 8);
+        }
       }
-    }
 
-    @include carbon--breakpoint('max') {
-      @include carbon--make-col(3, 16);
+      @include carbon--breakpoint('lg') {
+        @include carbon--make-col(4, 16);
 
-      .#{$prefix}--footer--short & {
-        @include carbon--make-col-offset(11, 16);
+        order: 1;
+
+        .#{$prefix}--footer--short & {
+          @include carbon--make-col-offset(10, 16);
+        }
+      }
+
+      @include carbon--breakpoint('max') {
+        @include carbon--make-col(3, 16);
+
+        .#{$prefix}--footer--short & {
+          @include carbon--make-col-offset(11, 16);
+        }
       }
     }
   }
 }
 
 @include exports('language-selector') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include language-selector;
-  }
+  @include language-selector;
 }

--- a/packages/styles/scss/components/footer/_legal-nav.scss
+++ b/packages/styles/scss/components/footer/_legal-nav.scss
@@ -11,84 +11,87 @@
 
 @mixin legal-nav {
   .#{$prefix}--legal-nav {
-    @include carbon--make-row;
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
+      @include carbon--make-row;
 
-    border-top: 1px solid $ui-03;
+      border-top: 1px solid $ui-03;
 
-    .#{$prefix}--footer:not(.#{$prefix}--footer--short) & {
-      @include carbon--breakpoint-down($TEMP--breakpoint-down--md) {
-        border-top: 0;
+      .#{$prefix}--footer:not(.#{$prefix}--footer--short) & {
+        @include carbon--breakpoint-down($TEMP--breakpoint-down--md) {
+          border-top: 0;
+        }
       }
-    }
 
-    &__container {
-      @include carbon--make-container;
-    }
+      &__container {
+        @include carbon--make-container;
+      }
 
-    &__list {
-      @include carbon--make-col-ready;
-
-      display: flex;
-      flex-wrap: wrap;
-      padding-bottom: $carbon--layout-04;
-    }
-
-    &__holder {
-      @include carbon--make-col-ready;
-      @include carbon--breakpoint-down('lg') {
-        @include carbon--make-col(4, 4);
+      &__list {
+        @include carbon--make-col-ready;
 
         display: flex;
-        flex-direction: column;
-        padding-left: 0;
+        flex-wrap: wrap;
+        padding-bottom: $carbon--layout-04;
+      }
 
-        @include carbon--breakpoint('md') {
-          @include carbon--make-col(2, 4);
+      &__holder {
+        @include carbon--make-col-ready;
+        @include carbon--breakpoint-down('lg') {
+          @include carbon--make-col(4, 4);
+
+          display: flex;
+          flex-direction: column;
+          padding-left: 0;
+
+          @include carbon--breakpoint('md') {
+            @include carbon--make-col(2, 4);
+
+            display: flex;
+            flex-direction: column;
+
+            &:not(:first-child) {
+              padding-left: $carbon--layout-01;
+            }
+
+            &:nth-child(odd):not(:first-child) {
+              padding-left: 0;
+            }
+          }
+        }
+
+        @include carbon--breakpoint('lg') {
+          @include carbon--make-col(1, 4);
 
           display: flex;
           flex-direction: column;
 
-          &:not(:first-child) {
-            padding-left: $carbon--layout-01;
+          &:nth-child(odd) {
+            padding-left: $carbon--spacing-06;
           }
+          &:first-child {
+            @include carbon--make-col-offset(1, 4);
 
-          &:nth-child(odd):not(:first-child) {
-            padding-left: 0;
+            padding-left: $carbon--spacing-03;
           }
         }
       }
 
-      @include carbon--breakpoint('lg') {
-        @include carbon--make-col(1, 4);
+      &__list-item {
+        display: inline-block;
+        margin-right: carbon--mini-units(4);
+        padding: $spacing-03 0 0 0;
 
-        display: flex;
-        flex-direction: column;
-
-        &:nth-child(odd) {
-          padding-left: $carbon--spacing-06;
+        &:last-child {
+          margin-right: 0;
         }
-        &:first-child {
-          @include carbon--make-col-offset(1, 4);
-
-          padding-left: $carbon--spacing-03;
-        }
-      }
-    }
-
-    &__list-item {
-      display: inline-block;
-      margin-right: carbon--mini-units(4);
-      padding: $spacing-03 0 0 0;
-
-      &:last-child {
-        margin-right: 0;
       }
     }
   }
 }
 
 @include exports('legal-nav') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include legal-nav;
-  }
+  @include legal-nav;
 }

--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -14,66 +14,69 @@
 
 @mixin local-button {
   .#{$prefix}--locale-btn__container {
-    @include button;
-    @include temp-button-expressive;
-    @include carbon--make-col-ready;
-    @include carbon--make-col(4, 4);
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
+      @include button;
+      @include temp-button-expressive;
+      @include carbon--make-col-ready;
+      @include carbon--make-col(4, 4);
 
-    margin-top: carbon--mini-units(2);
-    padding-left: 0;
-    padding-right: 0;
-    order: 0;
+      margin-top: carbon--mini-units(2);
+      padding-left: 0;
+      padding-right: 0;
+      order: 0;
 
-    .#{$prefix}--locale-btn {
-      max-width: 100%;
-      width: 100%;
+      .#{$prefix}--locale-btn {
+        max-width: 100%;
+        width: 100%;
 
-      @include carbon--breakpoint('md') {
-        min-width: carbon--mini-units(27);
-        max-width: carbon--mini-units(40);
+        @include carbon--breakpoint('md') {
+          min-width: carbon--mini-units(27);
+          max-width: carbon--mini-units(40);
 
-        .#{$prefix}--footer--short & {
-          float: right;
+          .#{$prefix}--footer--short & {
+            float: right;
+          }
         }
       }
-    }
-
-    .#{$prefix}--footer--short & {
-      margin-top: 0;
-    }
-
-    @include carbon--breakpoint('md') {
-      @include carbon--make-col(4, 8);
-
-      margin-bottom: carbon--mini-units(2);
 
       .#{$prefix}--footer--short & {
-        @include carbon--make-col-offset(2, 8);
+        margin-top: 0;
       }
-    }
 
-    @include carbon--breakpoint('lg') {
-      @include carbon--make-col(4, 16);
+      @include carbon--breakpoint('md') {
+        @include carbon--make-col(4, 8);
 
-      order: 1;
+        margin-bottom: carbon--mini-units(2);
 
-      .#{$prefix}--footer--short & {
-        @include carbon--make-col-offset(10, 16);
+        .#{$prefix}--footer--short & {
+          @include carbon--make-col-offset(2, 8);
+        }
       }
-    }
 
-    @include carbon--breakpoint('max') {
-      @include carbon--make-col(3, 16);
+      @include carbon--breakpoint('lg') {
+        @include carbon--make-col(4, 16);
 
-      .#{$prefix}--footer--short & {
-        @include carbon--make-col-offset(11, 16);
+        order: 1;
+
+        .#{$prefix}--footer--short & {
+          @include carbon--make-col-offset(10, 16);
+        }
+      }
+
+      @include carbon--breakpoint('max') {
+        @include carbon--make-col(3, 16);
+
+        .#{$prefix}--footer--short & {
+          @include carbon--make-col-offset(11, 16);
+        }
       }
     }
   }
 }
 
 @include exports('local-button') {
-  @include carbon--theme($carbon--theme--g90) {
-    @include local-button;
-  }
+  @include local-button;
 }

--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -169,13 +169,19 @@
   }
 
   .#{$prefix}--tableofcontents--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
 
   .#{$prefix}--tableofcontents--g10 {
-    @include carbon--theme($carbon--theme--g10) {
+    @include carbon--theme(
+      $carbon--theme--g10,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }

--- a/packages/styles/scss/internal/content-section/_content-section.scss
+++ b/packages/styles/scss/internal/content-section/_content-section.scss
@@ -54,17 +54,26 @@
   }
 
   .#{$prefix}--content-section--g10 {
-    @include carbon--theme($carbon--theme--g10) {
+    @include carbon--theme(
+      $carbon--theme--g10,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
   .#{$prefix}--content-section--g90 {
-    @include carbon--theme($carbon--theme--g90) {
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
   .#{$prefix}--content-section--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }

--- a/packages/styles/scss/patterns/blocks/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-media/_content-block-media.scss
@@ -25,7 +25,10 @@
   }
 
   .#{$prefix}--content-block-media--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }

--- a/packages/styles/scss/patterns/sections/ctasection/_ctasection.scss
+++ b/packages/styles/scss/patterns/sections/ctasection/_ctasection.scss
@@ -142,19 +142,28 @@
   }
 
   .#{$prefix}--cta-section--g10 {
-    @include carbon--theme($carbon--theme--g10) {
+    @include carbon--theme(
+      $carbon--theme--g10,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
 
   .#{$prefix}--cta-section--g90 {
-    @include carbon--theme($carbon--theme--g90) {
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
 
   .#{$prefix}--cta-section--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }

--- a/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
@@ -143,7 +143,10 @@ $btn-min-width: 26;
   }
 
   .#{$prefix}--leadspace--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
@@ -302,7 +305,10 @@ $btn-min-width: 26;
     }
   }
   .#{$prefix}--leadspace--centered--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }

--- a/packages/styles/scss/patterns/sections/simplebenefits/_simplebenefits.scss
+++ b/packages/styles/scss/patterns/sections/simplebenefits/_simplebenefits.scss
@@ -77,17 +77,26 @@
   }
 
   .#{$prefix}--simplebenefits--g100 {
-    @include carbon--theme($carbon--theme--g100) {
+    @include carbon--theme(
+      $carbon--theme--g100,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
   .#{$prefix}--simplebenefits--g90 {
-    @include carbon--theme($carbon--theme--g90) {
+    @include carbon--theme(
+      $carbon--theme--g90,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }
   .#{$prefix}--simplebenefits--g10 {
-    @include carbon--theme($carbon--theme--g10) {
+    @include carbon--theme(
+      $carbon--theme--g10,
+      feature-flag-enabled('enable-css-custom-properties')
+    ) {
       @include themed-items;
     }
   }


### PR DESCRIPTION
(Please use gear icon - Hide whitespace changes for reviewing)

### Related Ticket(s)

Refs #2733.

### Description

This change makes the theme zoning code in several components, notably footer, work with a theme set outside footer via CSS custom properties. It means that, with this fix, footer remains in `g90` color even if `white` theme is applied in `<body>` with CSS custom properties.

This change also:

* Implements a logic to reset the theme to default for stories that disable theme chooser. This logic is implemented in Storybook configuration code so that our theme chooser add-on focuses on its UI and ensures its re-usable in a way ibmdotcom library-specific requirements not baked in
* Disables theme chooser for expressive modal, too

### Changelog

**New**

- Support for CSS custom properties in our theme zoning code (notably footer).
- A logic to reset the theme to default for stories that disable theme chooser.

**Changed**

- Theme chooser disabled for expressive modal.