### PR TITLE
fix(Masthead): fix for rtl masthead profile menu

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -320,6 +320,9 @@ $search-transition-timing: 95ms;
     background-color: $ui-background;
     position: fixed;
     z-index: 99999;
+    /* !rtl:raw:
+    left: 0 !important;
+    */
 
     &__btn {
       @include carbon--type-style(body-short-02, true);


### PR DESCRIPTION
### Related Ticket(s)

Refs #1744

### Description

This is a fix for properly setting the profile menu dropdown in the
masthead. This uses rtlcss, and unfortunately will need to set as
!important for now until we can find a more elegant solution.

### Changelog

**Changed**

- Added positioning fix for RTL

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
