### PR TITLE
chore(devenv): fix font-family in RTL environment

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -15,7 +15,6 @@ export default class Container extends Component {
     if (process.env.REACT_STORYBOOK_USE_RTL === 'true') {
       document.documentElement.dir = 'rtl';
       document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl');
-      document.body.classList.add('bx--body');
     }
   }
 


### PR DESCRIPTION
### Description

This change fixes broken `font-family` in our React Storybook environemnt in RTL mode. It was caused by redundant Carbon `.bx--body` class that sets `font-family: inherit` that overrides Carbon `font-family` definition for `<body>` tag.

![image](https://user-images.githubusercontent.com/1259051/84556854-a088b180-ad60-11ea-8cae-6838c6f00d7f.png)

### Changelog

**Removed**

- `.bx--body` class that was set in RTL environment of our React Storybook environment, that was not needed.