### PR TITLE
chore(lint): add block comments to props

### DIFF
--- a/packages/react/src/components/LocaleModal/LocaleModalCountries.js
+++ b/packages/react/src/components/LocaleModal/LocaleModalCountries.js
@@ -166,7 +166,14 @@ const LocaleModalCountries = ({
  * @type {{regionList: Array, availabilityText: string, unavailabilityText: string, placeHolderText: string, labelText: string}}
  */
 LocaleModalCountries.propTypes = {
+  /**
+   * Array of regions, countries, and languages.
+   */
   regionList: PropTypes.array,
+
+  /**
+   * Func to clear search input.
+   */
   setClearResults: PropTypes.func,
 };
 


### PR DESCRIPTION
### Description

Restores prop block comments removed in https://github.com/carbon-design-system/ibm-dotcom-library/pull/2786.

### Changelog

**New**

- block comments for `LocaleModalCountries` props


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
