### PR TITLE
fix(Masthead): search icon z-index

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -27,7 +27,6 @@
 
     &--actions {
       position: absolute;
-      z-index: 10001;
       top: 0;
       right: 0;
     }
@@ -95,6 +94,10 @@
       position: absolute;
       z-index: 999;
       width: 100%;
+
+      .#{$prefix}--header__search--actions {
+        z-index: 10001;
+      }
 
       .react-autosuggest__container {
         &::after {


### PR DESCRIPTION
### Related Ticket(s)

#2794

### Description

Change search icon `z-index` only when search is active to prevent persistent visibility.

![Jun-17-2020 10-47-43](https://user-images.githubusercontent.com/909118/84912983-04c0b380-b088-11ea-8a39-0935139b32ab.gif)

### Changelog

**Changed**

- search icon `z-index` when search active



<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
