### PR TITLE
fix(Quote): quotation mark spacing adjusted 

### DIFF
--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -45,6 +45,7 @@
       @include carbon--type-style('quotation-01', true);
       @include carbon--font-family('serif');
       @include carbon--breakpoint-down('md') {
+        // this value was chosen by visually stay the closest as possible from the quotation text in the small breakpoint
         left: 1.4rem;
       }
       @include carbon--breakpoint('md') {
@@ -52,6 +53,7 @@
       }
 
       position: absolute;
+      // this value was chosen by visually stay the closest as possible from the quotation text in the md and above breakpoints
       left: 0.6rem;
       color: $text-01;
     }

--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -44,6 +44,9 @@
     &__mark {
       @include carbon--type-style('quotation-01', true);
       @include carbon--font-family('serif');
+      @include carbon--breakpoint-down('md') {
+        left: 1.4rem;
+      }
       @include carbon--breakpoint('md') {
         @include carbon--type-style('quotation-02', true);
       }


### PR DESCRIPTION
### Related Ticket(s)

Pattern: CalloutQuote - Mobile - Left side padding is not as per visual specs. #2385

### Description

**Previous**
![Captura de Tela 2020-06-18 às 15 35 07](https://user-images.githubusercontent.com/42848561/85059107-7b89a980-b179-11ea-858b-72d0cf4de20b.png)

**Current**
![Captura de Tela 2020-06-18 às 15 36 16](https://user-images.githubusercontent.com/42848561/85059137-86dcd500-b179-11ea-9c21-cf42f2797ab0.png)

### Changelog

**New**

- new absolute position to the quotation mark at small breakpoint.