### PR TITLE
fix(styles): import missing styles to various components

### DIFF
--- a/packages/styles/scss/components/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/components/buttongroup/_buttongroup.scss
@@ -7,6 +7,7 @@
 
 @import '../../globals/imports';
 @import 'carbon-components/scss/components/button/button';
+@import '../lightbox-media-viewer/lightbox-media-viewer';
 
 @mixin buttongroup {
   @include button;

--- a/packages/styles/scss/components/card/README.md
+++ b/packages/styles/scss/components/card/README.md
@@ -2,7 +2,7 @@
 
 #### Usage
 
-Import the package css into the top of your main CSS file. card
+Import the package css into the top of your main CSS file.
 
 ```css
 @import '@carbon/ibmdotcom-styles/scss/components/card/index';

--- a/packages/styles/scss/components/card/README.md
+++ b/packages/styles/scss/components/card/README.md
@@ -2,7 +2,7 @@
 
 #### Usage
 
-Import the package css into the top of your main CSS file.
+Import the package css into the top of your main CSS file. card
 
 ```css
 @import '@carbon/ibmdotcom-styles/scss/components/card/index';

--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -11,6 +11,7 @@
 
 @import 'carbon-components/scss/components/link/link';
 @import 'carbon-components/scss/components/tile/tile';
+@import '../lightbox-media-viewer/lightbox-media-viewer';
 
 @mixin card {
   .#{$prefix}--card {

--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -7,6 +7,7 @@
 
 @import '../../globals/imports';
 @import '../../temp-carbon-expressive/link/link-expressive';
+@import '../lightbox-media-viewer/lightbox-media-viewer';
 
 @mixin link-with-icon {
   .#{$prefix}--link-with-icon {

--- a/packages/styles/scss/patterns/blocks/leadspace-block/_leadspace-block.scss
+++ b/packages/styles/scss/patterns/blocks/leadspace-block/_leadspace-block.scss
@@ -8,6 +8,7 @@
 @import '../../../globals/imports';
 @import '../../../globals/utils/content-width';
 @import '../../../globals/utils/hang';
+@import '../../../components/buttongroup/buttongroup';
 
 @mixin leadspace-block {
   .#{$prefix}--leadspace-block {

--- a/packages/styles/scss/patterns/sections/ctasection/_ctasection.scss
+++ b/packages/styles/scss/patterns/sections/ctasection/_ctasection.scss
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+@import '../../../components/buttongroup/buttongroup';
 
 @mixin themed-items {
   color: $text-01;


### PR DESCRIPTION
### Related Ticket(s)

Fix missing ButtonGroup style import for LeadSpaceBlock and CTASection #2838

### Description

Various components are missing style imports for associated components. Importing `buttongroup`  and `lightbox-media-viewer` styles to related component styles.

### Changelog

**New**

- import `buttongroup` and `lightbox-media-viewer` styles