### PR TITLE
fix(PictogramItem): add missing style import

### DIFF
--- a/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
+++ b/packages/styles/scss/components/pictogram-item/_pictogram-item.scss
@@ -6,6 +6,8 @@
  */
 
 @import '../../globals/imports';
+@import '../../internal/content-item/content-item';
+@import '../link-with-icon/link-with-icon';
 
 @mixin pictogram-item {
   .#{$prefix}--pictogram-item {


### PR DESCRIPTION
### Description

Add missing css import to `PictogramItem`

### Changelog

**New**

- import `ContentItem` and `LinkWithIcon` styles

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
