### PR TITLE
fix(ContentItemHorizontal): grid alignment

### DIFF
--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -56,7 +56,6 @@
         @include carbon--breakpoint(lg) {
           margin-bottom: $layout-05;
         }
-
         p {
           color: $text-01;
         }
@@ -67,10 +66,8 @@
         @include carbon--breakpoint(md) {
           margin-left: $carbon--spacing-06;
         }
-
         .#{$prefix}--link-list {
           padding: 0;
-
           &:first-of-type {
             padding: 0;
           }

--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -50,6 +50,7 @@
           margin-bottom: $carbon--spacing-07;
         }
         @include carbon--breakpoint(md) {
+          margin-left: $carbon--spacing-06;
           margin-bottom: $layout-05;
         }
         @include carbon--breakpoint(lg) {
@@ -63,6 +64,9 @@
 
       &--cta {
         margin-top: auto;
+        @include carbon--breakpoint(md) {
+          margin-left: $carbon--spacing-06;
+        }
 
         .#{$prefix}--link-list {
           padding: 0;


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Content group horizontal: Grid alignment #2670

### Description

Added padding so item could be aligned to the grid system
Please note: Besides the issue is about a pattern (Content Group Horizontal), i need to fix on the component (Content Item Horizontal).

- Screenshot of max breakpoint 
![image](https://user-images.githubusercontent.com/37422384/85459117-3948d980-b578-11ea-9090-d872e7d80975.png)

 - Screenshot of xlg breakpoint
![image](https://user-images.githubusercontent.com/37422384/85458596-ac9e1b80-b577-11ea-95e0-877640d784b7.png)

- Screenshot of lg breakpoint
![image](https://user-images.githubusercontent.com/37422384/85458809-e4a55e80-b577-11ea-9ae1-55510bf93b7f.png)

- Screenshot of md breakpoint
![image](https://user-images.githubusercontent.com/37422384/85459022-1fa79200-b578-11ea-8050-7f96e0f45924.png)



### Changelog

**New**

- **margin-left** on md breakpoint for '&--cta' and '&--copy' classes  
- **mixin @include carbon--breakpoint(md)** for '&--cta' class



