### PR TITLE
fix(content-block): updated copy token to match updated designs

### DIFF
--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -44,7 +44,7 @@
     }
     &__copy {
       p {
-        @include carbon--type-style('expressive-paragraph-01', true);
+        @include carbon--type-style('expressive-heading-03', true);
 
         color: $text-01;
         margin-bottom: $carbon--spacing-07;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2501

Updates content block copy token

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
