### PR TITLE
feat(LinkWithIcon): enabled inverse theming

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2405,10 +2405,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     <option
                                       className="bx--tableofcontents__mobile__select__option"
                                       data-autoid="dds}--tableofcontents__mobile__select__option-menuLabel"
-                                      disabled={true}
-                                      hidden={true}
                                       key="0"
-                                      selected={true}
                                       value="menuLabel"
                                     >
                                       Jump to ...
@@ -2617,6 +2614,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           <button
                                                             className="bx--video-player__image-overlay"
                                                             data-autoid="dds--video-player__image-overlay"
+                                                            id="video-thumbnail-overlay"
                                                             onClick={[Function]}
                                                           >
                                                             <Image
@@ -4533,6 +4531,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                 <button
                                                                   className="bx--video-player__image-overlay"
                                                                   data-autoid="dds--video-player__image-overlay"
+                                                                  id="video-thumbnail-overlay"
                                                                   onClick={[Function]}
                                                                 >
                                                                   <Image
@@ -4708,14 +4707,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="vertical"
+                                                  style="horizontal"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--vertical"
+                                                      className="bx--link-list__list bx--link-list__list--horizontal"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -4976,14 +4975,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="vertical"
+                                                  style="horizontal"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--vertical"
+                                                      className="bx--link-list__list bx--link-list__list--horizontal"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -9001,6 +9000,7 @@ exports[`Storyshots Components|Link with Icon Default 1`] = `
       <LinkWithIcon
         disabled={false}
         href="https://www.example.com"
+        inverse={false}
       >
         <div
           className="bx--link-with-icon__container"

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2405,7 +2405,10 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     <option
                                       className="bx--tableofcontents__mobile__select__option"
                                       data-autoid="dds}--tableofcontents__mobile__select__option-menuLabel"
+                                      disabled={true}
+                                      hidden={true}
                                       key="0"
+                                      selected={true}
                                       value="menuLabel"
                                     >
                                       Jump to ...
@@ -2614,7 +2617,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           <button
                                                             className="bx--video-player__image-overlay"
                                                             data-autoid="dds--video-player__image-overlay"
-                                                            id="video-thumbnail-overlay"
                                                             onClick={[Function]}
                                                           >
                                                             <Image
@@ -4531,7 +4533,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                 <button
                                                                   className="bx--video-player__image-overlay"
                                                                   data-autoid="dds--video-player__image-overlay"
-                                                                  id="video-thumbnail-overlay"
                                                                   onClick={[Function]}
                                                                 >
                                                                   <Image
@@ -4707,14 +4708,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="horizontal"
+                                                  style="vertical"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--horizontal"
+                                                      className="bx--link-list__list bx--link-list__list--vertical"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -4975,14 +4976,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="horizontal"
+                                                  style="vertical"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--horizontal"
+                                                      className="bx--link-list__list bx--link-list__list--vertical"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"

--- a/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
+++ b/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
@@ -21,10 +21,9 @@ const { prefix } = settings;
 const LinkWithIcon = ({ children, href, inverse, ...props }) => {
   return (
     <div
-      className={classnames(
-        `${prefix}--link-with-icon__container`,
-        inverse ? `${prefix}--link-with-icon__container__inverse` : null
-      )}
+      className={classnames(`${prefix}--link-with-icon__container`, {
+        [`${prefix}--link-with-icon__container__inverse`]: inverse,
+      })}
       data-autoid={`${stablePrefix}--link-with-icon`}>
       <Link href={href} className={`${prefix}--link-with-icon`} {...props}>
         {children}

--- a/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
+++ b/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import classnames from 'classnames';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import Link from '../../internal/vendor/carbon-components-react/components/Link/Link';
 import PropTypes from 'prop-types';
@@ -17,10 +18,13 @@ const { prefix } = settings;
 /**
  * LinkWithIcon component.
  */
-const LinkWithIcon = ({ children, href, ...props }) => {
+const LinkWithIcon = ({ children, href, inverse, ...props }) => {
   return (
     <div
-      className={`${prefix}--link-with-icon__container`}
+      className={classnames(
+        `${prefix}--link-with-icon__container`,
+        inverse ? `${prefix}--link-with-icon__container__inverse` : null
+      )}
       data-autoid={`${stablePrefix}--link-with-icon`}>
       <Link href={href} className={`${prefix}--link-with-icon`} {...props}>
         {children}
@@ -39,6 +43,11 @@ LinkWithIcon.propTypes = {
    * Url of link.
    */
   href: PropTypes.string,
+
+  /**
+   * Toggles inverse theming
+   */
+  inverse: PropTypes.bool,
 };
 
 LinkWithIcon.defaultProps = {

--- a/packages/react/src/components/LinkWithIcon/__stories__/LinkWithIcon.stories.js
+++ b/packages/react/src/components/LinkWithIcon/__stories__/LinkWithIcon.stories.js
@@ -19,13 +19,14 @@ export default {
     knobs: {
       LinkWithIcon: ({ groupId }) => ({
         disabled: boolean('Disabled', false, groupId),
+        inverse: boolean('Inverse (inverse):', false, groupId),
       }),
     },
   },
 };
 
 export const Default = ({ parameters }) => {
-  const { disabled } = parameters?.props?.LinkWithIcon ?? {};
+  const { disabled, inverse } = parameters?.props?.LinkWithIcon ?? {};
   return (
     <div
       style={{
@@ -34,7 +35,10 @@ export const Default = ({ parameters }) => {
         alignItems: 'center',
         flexDirection: 'column',
       }}>
-      <LinkWithIcon href="https://www.example.com" disabled={disabled}>
+      <LinkWithIcon
+        href="https://www.example.com"
+        inverse={inverse}
+        disabled={disabled}>
         <span>Link text</span>
         <ArrowRight20 />
       </LinkWithIcon>

--- a/packages/react/src/components/LinkWithIcon/__tests__/LinkWithIcon.test.js
+++ b/packages/react/src/components/LinkWithIcon/__tests__/LinkWithIcon.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,9 +12,12 @@ import { shallow } from 'enzyme';
 describe('LinkWithIcon', () => {
   it('renders as expected', () => {
     const linkWithIcon = shallow(
-      <LinkWithIcon href="https://www.example.com" />
+      <LinkWithIcon href="https://www.example.com" inverse={true} />
     );
 
     expect(linkWithIcon.find('.bx--link-with-icon')).toHaveLength(1);
+    expect(
+      linkWithIcon.find('.bx--link-with-icon__container__inverse')
+    ).toHaveLength(1);
   });
 });

--- a/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
+++ b/packages/styles/scss/components/link-with-icon/_link-with-icon.scss
@@ -13,6 +13,19 @@
   .#{$prefix}--link-with-icon {
     &__container {
       display: table;
+
+      &__inverse {
+        .#{$prefix}--link {
+          color: $inverse-link;
+        }
+
+        @include carbon--theme(
+          $carbon--theme--g100,
+          feature-flag-enabled('enable-css-custom-properties')
+        ) {
+          @include link;
+        }
+      }
     }
 
     display: flex;


### PR DESCRIPTION
### Related Ticket(s)

#2295 

### Description

The `inverse` prop was added to `LinkWithIcon`, so we can toggle the inverse theming.