### PR TITLE
chore(Dotcomshell): avoid side effect in story module

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2172,716 +2172,683 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                 }
               }
             >
-              <TableOfContents
-                menuItems={null}
-                menuLabel="Jump to"
-                stickyOffset={null}
-                theme="white"
-              >
-                <section
-                  className="bx--tableofcontents bx--tableofcontents--white"
-                  data-autoid="dds--tableofcontents"
+              <Content>
+                <TableOfContents
+                  menuItems={null}
+                  menuLabel="Jump to"
+                  stickyOffset={null}
+                  theme="white"
                 >
-                  <Layout
-                    border={false}
-                    marginBottom="none"
-                    marginTop="none"
-                    nested={false}
-                    stickyOffset={null}
-                    type="1-3"
+                  <section
+                    className="bx--tableofcontents bx--tableofcontents--white"
+                    data-autoid="dds--tableofcontents"
                   >
-                    <section
-                      className="bx--grid bx--layout--top-none bx--layout--bottom-none"
-                      data-autoid="dds--layout"
+                    <Layout
+                      border={false}
+                      marginBottom="none"
+                      marginTop="none"
+                      nested={false}
+                      stickyOffset={null}
+                      type="1-3"
                     >
-                      <div
-                        className="bx--row"
+                      <section
+                        className="bx--grid bx--layout--top-none bx--layout--bottom-none"
+                        data-autoid="dds--layout"
                       >
                         <div
-                          className="bx--tableofcontents__sidebar bx--col-lg-4"
-                          key="0"
+                          className="bx--row"
                         >
                           <div
-                            className="bx--tableofcontents__mobile-top"
-                          />
-                          <div
-                            style={
-                              Object {
-                                "position": "sticky",
-                                "top": "0",
-                              }
-                            }
+                            className="bx--tableofcontents__sidebar bx--col-lg-4"
+                            key="0"
                           >
-                            <TOCDesktop
-                              menuItems={
-                                Array [
-                                  Object {
-                                    "id": "menuLabel",
-                                    "title": "Jump to ...",
-                                  },
-                                ]
+                            <div
+                              className="bx--tableofcontents__mobile-top"
+                            />
+                            <div
+                              style={
+                                Object {
+                                  "position": "sticky",
+                                  "top": "0",
+                                }
                               }
-                              menuLabel="Jump to"
-                              selectedId=""
-                              selectedTitle=""
-                              updateState={[Function]}
                             >
-                              <div
-                                className="bx--tableofcontents__desktop"
-                                data-autoid="dds--tableofcontents__desktop"
-                              >
-                                <ul />
-                              </div>
-                            </TOCDesktop>
-                            <TOCMobile
-                              menuItems={
-                                Array [
-                                  Object {
-                                    "id": "menuLabel",
-                                    "title": "Jump to ...",
-                                  },
-                                ]
-                              }
-                              menuLabel="Jump to"
-                              selectedId=""
-                              selectedTitle=""
-                              updateState={[Function]}
-                            >
-                              <div
-                                className="bx--tableofcontents__mobile"
-                                data-autoid="dds--tableofcontents__mobile"
+                              <TOCDesktop
+                                menuItems={
+                                  Array [
+                                    Object {
+                                      "id": "menuLabel",
+                                      "title": "Jump to ...",
+                                    },
+                                  ]
+                                }
+                                menuLabel="Jump to"
+                                selectedId=""
+                                selectedTitle=""
+                                updateState={[Function]}
                               >
                                 <div
-                                  className="bx--tableofcontents__mobile__select__wrapper"
+                                  className="bx--tableofcontents__desktop"
+                                  data-autoid="dds--tableofcontents__desktop"
                                 >
-                                  <select
-                                    className="bx--tableofcontents__mobile__select"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    value=""
+                                  <ul />
+                                </div>
+                              </TOCDesktop>
+                              <TOCMobile
+                                menuItems={
+                                  Array [
+                                    Object {
+                                      "id": "menuLabel",
+                                      "title": "Jump to ...",
+                                    },
+                                  ]
+                                }
+                                menuLabel="Jump to"
+                                selectedId=""
+                                selectedTitle=""
+                                updateState={[Function]}
+                              >
+                                <div
+                                  className="bx--tableofcontents__mobile"
+                                  data-autoid="dds--tableofcontents__mobile"
+                                >
+                                  <div
+                                    className="bx--tableofcontents__mobile__select__wrapper"
                                   >
-                                    <option
-                                      className="bx--tableofcontents__mobile__select__option"
-                                      data-autoid="dds}--tableofcontents__mobile__select__option-menuLabel"
-                                      disabled={true}
-                                      hidden={true}
-                                      key="0"
-                                      selected={true}
-                                      value="menuLabel"
+                                    <select
+                                      className="bx--tableofcontents__mobile__select"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      value=""
                                     >
-                                      Jump to ...
-                                    </option>
-                                  </select>
-                                  <ForwardRef(TableOfContents20)
-                                    aria-label="menu icon"
-                                    className="bx--tableofcontents__mobile__select__icon"
-                                  >
-                                    <Icon
+                                      <option
+                                        className="bx--tableofcontents__mobile__select__option"
+                                        data-autoid="dds}--tableofcontents__mobile__select__option-menuLabel"
+                                        disabled={true}
+                                        hidden={true}
+                                        key="0"
+                                        selected={true}
+                                        value="menuLabel"
+                                      >
+                                        Jump to ...
+                                      </option>
+                                    </select>
+                                    <ForwardRef(TableOfContents20)
                                       aria-label="menu icon"
                                       className="bx--tableofcontents__mobile__select__icon"
-                                      height={20}
-                                      preserveAspectRatio="xMidYMid meet"
-                                      viewBox="0 0 32 32"
-                                      width={20}
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <Icon
                                         aria-label="menu icon"
                                         className="bx--tableofcontents__mobile__select__icon"
-                                        focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
-                                        role="img"
                                         viewBox="0 0 32 32"
                                         width={20}
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M4 6H22V8H4zM4 12H22V14H4zM4 18H22V20H4zM4 24H22V26H4zM26 6H28V8H26zM26 12H28V14H26zM26 18H28V20H26zM26 24H28V26H26z"
-                                        />
-                                        <title>
-                                          menu icon
-                                        </title>
-                                      </svg>
-                                    </Icon>
-                                  </ForwardRef(TableOfContents20)>
+                                        <svg
+                                          aria-label="menu icon"
+                                          className="bx--tableofcontents__mobile__select__icon"
+                                          focusable="false"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          role="img"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M4 6H22V8H4zM4 12H22V14H4zM4 18H22V20H4zM4 24H22V26H4zM26 6H28V8H26zM26 12H28V14H26zM26 18H28V20H26zM26 24H28V26H26z"
+                                          />
+                                          <title>
+                                            menu icon
+                                          </title>
+                                        </svg>
+                                      </Icon>
+                                    </ForwardRef(TableOfContents20)>
+                                  </div>
                                 </div>
-                              </div>
-                            </TOCMobile>
+                              </TOCMobile>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--tableofcontents__content bx--col-lg-12"
-                          key="1"
-                        >
                           <div
-                            className="bx--tableofcontents__content-wrapper"
+                            className="bx--tableofcontents__content bx--col-lg-12"
+                            key="1"
                           >
-                            <a
-                              data-title="Lorem ipsum dolor sit amet"
-                              name="section-1"
-                            />
-                            <Layout
-                              border={false}
-                              marginBottom={null}
-                              marginTop={null}
-                              nested={false}
-                              stickyOffset={null}
-                              type="2-1"
+                            <div
+                              className="bx--tableofcontents__content-wrapper"
                             >
-                              <section
-                                className="bx--grid"
-                                data-autoid="dds--layout"
+                              <a
+                                data-title="Lorem ipsum dolor sit amet"
+                                name="section-1"
+                              />
+                              <Layout
+                                border={false}
+                                marginBottom={null}
+                                marginTop={null}
+                                nested={false}
+                                stickyOffset={null}
+                                type="2-1"
                               >
-                                <div
-                                  className="bx--row"
+                                <section
+                                  className="bx--grid"
+                                  data-autoid="dds--layout"
                                 >
                                   <div
-                                    className="bx--layout-2-3"
-                                    key="0"
+                                    className="bx--row"
                                   >
-                                    <LeadSpaceBlock
-                                      copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-                                      cta={
-                                        Object {
-                                          "buttons": Array [
-                                            Object {
-                                              "copy": "Excepteur sint occaecat",
-                                              "href": "https://example.com/",
-                                              "iconDescription": "right arrow icon",
-                                              "onClick": [Function],
-                                              "renderIcon": Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "render": [Function],
-                                              },
-                                              "target": null,
-                                              "type": "local",
-                                            },
-                                          ],
-                                          "style": "button",
-                                          "type": "local",
-                                        }
-                                      }
-                                      heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
-                                      items={
-                                        Object {
-                                          "heading": "Featured products",
-                                          "items": Array [
-                                            Object {
-                                              "copy": "IBM Cloud Continuous Delivery",
-                                              "cta": Object {
-                                                "href": "https://ibm.com",
-                                              },
-                                              "type": "local",
-                                            },
-                                            Object {
-                                              "copy": "UrbanCode",
-                                              "cta": Object {
-                                                "href": "https://ibm.com",
-                                              },
-                                              "type": "local",
-                                            },
-                                            Object {
-                                              "copy": "View all products",
-                                              "cta": Object {
-                                                "href": "https://ibm.com",
-                                              },
-                                              "type": "local",
-                                            },
-                                          ],
-                                        }
-                                      }
-                                      mediaData={
-                                        Object {
-                                          "showDescription": true,
-                                          "videoId": "0_uka1msg4",
-                                        }
-                                      }
-                                      mediaType="video"
-                                      title="Lorem ipsum dolor sit amet"
+                                    <div
+                                      className="bx--layout-2-3"
+                                      key="0"
                                     >
-                                      <div
-                                        className="bx--leadspace-block"
-                                        data-autoid="dds--leadspace-block"
+                                      <LeadSpaceBlock
+                                        copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                                        cta={
+                                          Object {
+                                            "buttons": Array [
+                                              Object {
+                                                "copy": "Excepteur sint occaecat",
+                                                "href": "https://example.com/",
+                                                "iconDescription": "right arrow icon",
+                                                "onClick": [Function],
+                                                "renderIcon": Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                },
+                                                "target": null,
+                                                "type": "local",
+                                              },
+                                            ],
+                                            "style": "button",
+                                            "type": "local",
+                                          }
+                                        }
+                                        heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
+                                        items={
+                                          Object {
+                                            "heading": "Featured products",
+                                            "items": Array [
+                                              Object {
+                                                "copy": "IBM Cloud Continuous Delivery",
+                                                "cta": Object {
+                                                  "href": "https://ibm.com",
+                                                },
+                                                "type": "local",
+                                              },
+                                              Object {
+                                                "copy": "UrbanCode",
+                                                "cta": Object {
+                                                  "href": "https://ibm.com",
+                                                },
+                                                "type": "local",
+                                              },
+                                              Object {
+                                                "copy": "View all products",
+                                                "cta": Object {
+                                                  "href": "https://ibm.com",
+                                                },
+                                                "type": "local",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        mediaData={
+                                          Object {
+                                            "showDescription": true,
+                                            "videoId": "0_uka1msg4",
+                                          }
+                                        }
+                                        mediaType="video"
+                                        title="Lorem ipsum dolor sit amet"
                                       >
-                                        <div>
-                                          <h1
-                                            className="bx--leadspace-block__title"
-                                            data-autoid="dds--leadspace-block__title"
-                                          >
-                                            Lorem ipsum dolor sit amet
-                                          </h1>
-                                        </div>
-                                        <ContentBlock
-                                          border={false}
-                                          copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-                                          heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
+                                        <div
+                                          className="bx--leadspace-block"
+                                          data-autoid="dds--leadspace-block"
                                         >
-                                          <div
-                                            className="bx--content-block"
-                                            data-autoid="dds--content-block"
-                                          >
-                                            <div>
-                                              <h2
-                                                className="bx--content-block__heading"
-                                                data-autoid="dds--content-block__heading"
-                                              >
-                                                Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.
-                                              </h2>
-                                            </div>
-                                            <div
-                                              className="bx--content-block__copy"
-                                              dangerouslySetInnerHTML={
-                                                Object {
-                                                  "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>",
-                                                }
-                                              }
-                                            />
-                                            <div
-                                              className="bx--content-block__children"
-                                              data-autoid="dds--content-block__children"
+                                          <div>
+                                            <h1
+                                              className="bx--leadspace-block__title"
+                                              data-autoid="dds--leadspace-block__title"
                                             >
-                                              <div
-                                                className="bx--leadspace-block__media"
-                                                data-autoid="dds--leadspace-block__media"
-                                              >
-                                                <VideoPlayer
-                                                  autoPlay={false}
-                                                  showDescription={true}
-                                                  videoId="0_uka1msg4"
+                                              Lorem ipsum dolor sit amet
+                                            </h1>
+                                          </div>
+                                          <ContentBlock
+                                            border={false}
+                                            copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                                            heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
+                                          >
+                                            <div
+                                              className="bx--content-block"
+                                              data-autoid="dds--content-block"
+                                            >
+                                              <div>
+                                                <h2
+                                                  className="bx--content-block__heading"
+                                                  data-autoid="dds--content-block__heading"
                                                 >
-                                                  <div
-                                                    aria-label=" (1:00)"
-                                                    className="bx--video-player"
+                                                  Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.
+                                                </h2>
+                                              </div>
+                                              <div
+                                                className="bx--content-block__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--content-block__children"
+                                                data-autoid="dds--content-block__children"
+                                              >
+                                                <div
+                                                  className="bx--leadspace-block__media"
+                                                  data-autoid="dds--leadspace-block__media"
+                                                >
+                                                  <VideoPlayer
+                                                    autoPlay={false}
+                                                    showDescription={true}
+                                                    videoId="0_uka1msg4"
                                                   >
                                                     <div
-                                                      className="bx--video-player__video-container"
-                                                      data-autoid="dds--video-player__video-0_uka1msg4"
+                                                      aria-label=" (1:00)"
+                                                      className="bx--video-player"
                                                     >
                                                       <div
-                                                        className="bx--video-player__video"
-                                                        id="bx--video-player__video-0_uka1msg4"
+                                                        className="bx--video-player__video-container"
+                                                        data-autoid="dds--video-player__video-0_uka1msg4"
                                                       >
-                                                        <VideoImageOverlay
-                                                          embedVideo={[Function]}
-                                                          videoData={
-                                                            Object {
-                                                              "description": "",
-                                                              "name": "",
-                                                            }
-                                                          }
-                                                          videoId="0_uka1msg4"
+                                                        <div
+                                                          className="bx--video-player__video"
+                                                          id="bx--video-player__video-0_uka1msg4"
                                                         >
-                                                          <button
-                                                            className="bx--video-player__image-overlay"
-                                                            data-autoid="dds--video-player__image-overlay"
-                                                            onClick={[Function]}
+                                                          <VideoImageOverlay
+                                                            embedVideo={[Function]}
+                                                            videoData={
+                                                              Object {
+                                                                "description": "",
+                                                                "name": "",
+                                                              }
+                                                            }
+                                                            videoId="0_uka1msg4"
                                                           >
-                                                            <Image
-                                                              alt=""
-                                                              defaultSrc="https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320"
-                                                              icon={[Function]}
-                                                            />
-                                                          </button>
-                                                        </VideoImageOverlay>
+                                                            <button
+                                                              className="bx--video-player__image-overlay"
+                                                              data-autoid="dds--video-player__image-overlay"
+                                                              onClick={[Function]}
+                                                            >
+                                                              <Image
+                                                                alt=""
+                                                                defaultSrc="https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320"
+                                                                icon={[Function]}
+                                                              />
+                                                            </button>
+                                                          </VideoImageOverlay>
+                                                        </div>
                                                       </div>
                                                     </div>
-                                                  </div>
-                                                </VideoPlayer>
-                                              </div>
-                                              <LinkList
-                                                heading="Featured products"
-                                                items={
-                                                  Array [
-                                                    Object {
-                                                      "copy": "IBM Cloud Continuous Delivery",
-                                                      "cta": Object {
-                                                        "href": "https://ibm.com",
-                                                      },
-                                                      "type": "local",
-                                                    },
-                                                    Object {
-                                                      "copy": "UrbanCode",
-                                                      "cta": Object {
-                                                        "href": "https://ibm.com",
-                                                      },
-                                                      "type": "local",
-                                                    },
-                                                    Object {
-                                                      "copy": "View all products",
-                                                      "cta": Object {
-                                                        "href": "https://ibm.com",
-                                                      },
-                                                      "type": "local",
-                                                    },
-                                                  ]
-                                                }
-                                                style="vertical-end"
-                                              >
-                                                <div
-                                                  className="bx--link-list"
-                                                  data-autoid="dds--link-list"
-                                                >
-                                                  <h4
-                                                    className="bx--link-list__heading"
-                                                  >
-                                                    Featured products
-                                                  </h4>
-                                                  <ul
-                                                    className="bx--link-list__list bx--link-list__list--vertical-end"
-                                                  >
-                                                    <li
-                                                      className="bx--link-list__list__CTA bx--link-list__list--local"
-                                                      key="0"
-                                                    >
-                                                      <CTA
-                                                        copy="IBM Cloud Continuous Delivery"
-                                                        cta={
-                                                          Object {
-                                                            "href": "https://ibm.com",
-                                                          }
-                                                        }
-                                                        disableImage={true}
-                                                        href=""
-                                                        style="text"
-                                                        type="local"
-                                                      >
-                                                        <div>
-                                                          <TextCTA
-                                                            copy="IBM Cloud Continuous Delivery"
-                                                            cta={
-                                                              Object {
-                                                                "href": "https://ibm.com",
-                                                              }
-                                                            }
-                                                            disableImage={true}
-                                                            formatCTAcopy={[Function]}
-                                                            href=""
-                                                            openLightBox={[Function]}
-                                                            renderLightBox={false}
-                                                            style="text"
-                                                            type="local"
-                                                            videoTitle={
-                                                              Array [
-                                                                Object {
-                                                                  "duration": "",
-                                                                  "key": 0,
-                                                                  "title": "",
-                                                                },
-                                                              ]
-                                                            }
-                                                          >
-                                                            <LinkWithIcon
-                                                              href="https://ibm.com"
-                                                              onClick={[Function]}
-                                                              target={null}
-                                                            >
-                                                              <div
-                                                                className="bx--link-with-icon__container"
-                                                                data-autoid="dds--link-with-icon"
-                                                              >
-                                                                <Link
-                                                                  className="bx--link-with-icon"
-                                                                  href="https://ibm.com"
-                                                                  onClick={[Function]}
-                                                                  target={null}
-                                                                >
-                                                                  <a
-                                                                    className="bx--link bx--link-with-icon"
-                                                                    href="https://ibm.com"
-                                                                    onClick={[Function]}
-                                                                    target={null}
-                                                                  >
-                                                                    <span>
-                                                                      IBM Cloud Continuous Delivery
-                                                                    </span>
-                                                                    <ForwardRef(ArrowRight20)>
-                                                                      <Icon
-                                                                        height={20}
-                                                                        preserveAspectRatio="xMidYMid meet"
-                                                                        viewBox="0 0 20 20"
-                                                                        width={20}
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <svg
-                                                                          aria-hidden={true}
-                                                                          focusable="false"
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 20 20"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <path
-                                                                            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                          />
-                                                                        </svg>
-                                                                      </Icon>
-                                                                    </ForwardRef(ArrowRight20)>
-                                                                  </a>
-                                                                </Link>
-                                                              </div>
-                                                            </LinkWithIcon>
-                                                          </TextCTA>
-                                                        </div>
-                                                      </CTA>
-                                                    </li>
-                                                    <li
-                                                      className="bx--link-list__list__CTA bx--link-list__list--local"
-                                                      key="1"
-                                                    >
-                                                      <CTA
-                                                        copy="UrbanCode"
-                                                        cta={
-                                                          Object {
-                                                            "href": "https://ibm.com",
-                                                          }
-                                                        }
-                                                        disableImage={true}
-                                                        href=""
-                                                        style="text"
-                                                        type="local"
-                                                      >
-                                                        <div>
-                                                          <TextCTA
-                                                            copy="UrbanCode"
-                                                            cta={
-                                                              Object {
-                                                                "href": "https://ibm.com",
-                                                              }
-                                                            }
-                                                            disableImage={true}
-                                                            formatCTAcopy={[Function]}
-                                                            href=""
-                                                            openLightBox={[Function]}
-                                                            renderLightBox={false}
-                                                            style="text"
-                                                            type="local"
-                                                            videoTitle={
-                                                              Array [
-                                                                Object {
-                                                                  "duration": "",
-                                                                  "key": 0,
-                                                                  "title": "",
-                                                                },
-                                                              ]
-                                                            }
-                                                          >
-                                                            <LinkWithIcon
-                                                              href="https://ibm.com"
-                                                              onClick={[Function]}
-                                                              target={null}
-                                                            >
-                                                              <div
-                                                                className="bx--link-with-icon__container"
-                                                                data-autoid="dds--link-with-icon"
-                                                              >
-                                                                <Link
-                                                                  className="bx--link-with-icon"
-                                                                  href="https://ibm.com"
-                                                                  onClick={[Function]}
-                                                                  target={null}
-                                                                >
-                                                                  <a
-                                                                    className="bx--link bx--link-with-icon"
-                                                                    href="https://ibm.com"
-                                                                    onClick={[Function]}
-                                                                    target={null}
-                                                                  >
-                                                                    <span>
-                                                                      UrbanCode
-                                                                    </span>
-                                                                    <ForwardRef(ArrowRight20)>
-                                                                      <Icon
-                                                                        height={20}
-                                                                        preserveAspectRatio="xMidYMid meet"
-                                                                        viewBox="0 0 20 20"
-                                                                        width={20}
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <svg
-                                                                          aria-hidden={true}
-                                                                          focusable="false"
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 20 20"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <path
-                                                                            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                          />
-                                                                        </svg>
-                                                                      </Icon>
-                                                                    </ForwardRef(ArrowRight20)>
-                                                                  </a>
-                                                                </Link>
-                                                              </div>
-                                                            </LinkWithIcon>
-                                                          </TextCTA>
-                                                        </div>
-                                                      </CTA>
-                                                    </li>
-                                                    <li
-                                                      className="bx--link-list__list__CTA bx--link-list__list--local"
-                                                      key="2"
-                                                    >
-                                                      <CTA
-                                                        copy="View all products"
-                                                        cta={
-                                                          Object {
-                                                            "href": "https://ibm.com",
-                                                          }
-                                                        }
-                                                        disableImage={true}
-                                                        href=""
-                                                        style="text"
-                                                        type="local"
-                                                      >
-                                                        <div>
-                                                          <TextCTA
-                                                            copy="View all products"
-                                                            cta={
-                                                              Object {
-                                                                "href": "https://ibm.com",
-                                                              }
-                                                            }
-                                                            disableImage={true}
-                                                            formatCTAcopy={[Function]}
-                                                            href=""
-                                                            openLightBox={[Function]}
-                                                            renderLightBox={false}
-                                                            style="text"
-                                                            type="local"
-                                                            videoTitle={
-                                                              Array [
-                                                                Object {
-                                                                  "duration": "",
-                                                                  "key": 0,
-                                                                  "title": "",
-                                                                },
-                                                              ]
-                                                            }
-                                                          >
-                                                            <LinkWithIcon
-                                                              href="https://ibm.com"
-                                                              onClick={[Function]}
-                                                              target={null}
-                                                            >
-                                                              <div
-                                                                className="bx--link-with-icon__container"
-                                                                data-autoid="dds--link-with-icon"
-                                                              >
-                                                                <Link
-                                                                  className="bx--link-with-icon"
-                                                                  href="https://ibm.com"
-                                                                  onClick={[Function]}
-                                                                  target={null}
-                                                                >
-                                                                  <a
-                                                                    className="bx--link bx--link-with-icon"
-                                                                    href="https://ibm.com"
-                                                                    onClick={[Function]}
-                                                                    target={null}
-                                                                  >
-                                                                    <span>
-                                                                      View all products
-                                                                    </span>
-                                                                    <ForwardRef(ArrowRight20)>
-                                                                      <Icon
-                                                                        height={20}
-                                                                        preserveAspectRatio="xMidYMid meet"
-                                                                        viewBox="0 0 20 20"
-                                                                        width={20}
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <svg
-                                                                          aria-hidden={true}
-                                                                          focusable="false"
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 20 20"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <path
-                                                                            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                          />
-                                                                        </svg>
-                                                                      </Icon>
-                                                                    </ForwardRef(ArrowRight20)>
-                                                                  </a>
-                                                                </Link>
-                                                              </div>
-                                                            </LinkWithIcon>
-                                                          </TextCTA>
-                                                        </div>
-                                                      </CTA>
-                                                    </li>
-                                                  </ul>
+                                                  </VideoPlayer>
                                                 </div>
-                                              </LinkList>
-                                              <CTA
-                                                buttons={
-                                                  Array [
-                                                    Object {
-                                                      "copy": "Excepteur sint occaecat",
-                                                      "href": "https://example.com/",
-                                                      "iconDescription": "right arrow icon",
-                                                      "onClick": [Function],
-                                                      "renderIcon": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
+                                                <LinkList
+                                                  heading="Featured products"
+                                                  items={
+                                                    Array [
+                                                      Object {
+                                                        "copy": "IBM Cloud Continuous Delivery",
+                                                        "cta": Object {
+                                                          "href": "https://ibm.com",
+                                                        },
+                                                        "type": "local",
                                                       },
-                                                      "target": null,
-                                                      "type": "local",
-                                                    },
-                                                  ]
-                                                }
-                                                copy=""
-                                                customClassName="bx--leadspace-block__cta bx--leadspace-block__cta-col"
-                                                href=""
-                                                style="button"
-                                                type="local"
-                                              >
-                                                <div
-                                                  className="bx--leadspace-block__cta bx--leadspace-block__cta-col"
+                                                      Object {
+                                                        "copy": "UrbanCode",
+                                                        "cta": Object {
+                                                          "href": "https://ibm.com",
+                                                        },
+                                                        "type": "local",
+                                                      },
+                                                      Object {
+                                                        "copy": "View all products",
+                                                        "cta": Object {
+                                                          "href": "https://ibm.com",
+                                                        },
+                                                        "type": "local",
+                                                      },
+                                                    ]
+                                                  }
+                                                  style="vertical-end"
                                                 >
-                                                  <ButtonCTA
-                                                    buttons={
-                                                      Array [
-                                                        Object {
-                                                          "copy": "Excepteur sint occaecat",
-                                                          "href": "https://example.com/",
-                                                          "iconDescription": "right arrow icon",
-                                                          "onClick": [Function],
-                                                          "renderIcon": Object {
-                                                            "$$typeof": Symbol(react.forward_ref),
-                                                            "render": [Function],
-                                                          },
-                                                          "target": null,
-                                                          "type": "local",
-                                                        },
-                                                      ]
-                                                    }
-                                                    copy=""
-                                                    formatCTAcopy={[Function]}
-                                                    href=""
-                                                    openLightBox={[Function]}
-                                                    renderLightBox={false}
-                                                    style="button"
-                                                    type="local"
-                                                    videoTitle={
-                                                      Array [
-                                                        Object {
-                                                          "duration": "",
-                                                          "key": 0,
-                                                          "title": "",
-                                                        },
-                                                      ]
-                                                    }
+                                                  <div
+                                                    className="bx--link-list"
+                                                    data-autoid="dds--link-list"
                                                   >
-                                                    <ButtonGroup
+                                                    <h4
+                                                      className="bx--link-list__heading"
+                                                    >
+                                                      Featured products
+                                                    </h4>
+                                                    <ul
+                                                      className="bx--link-list__list bx--link-list__list--vertical-end"
+                                                    >
+                                                      <li
+                                                        className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                        key="0"
+                                                      >
+                                                        <CTA
+                                                          copy="IBM Cloud Continuous Delivery"
+                                                          cta={
+                                                            Object {
+                                                              "href": "https://ibm.com",
+                                                            }
+                                                          }
+                                                          disableImage={true}
+                                                          href=""
+                                                          style="text"
+                                                          type="local"
+                                                        >
+                                                          <div>
+                                                            <TextCTA
+                                                              copy="IBM Cloud Continuous Delivery"
+                                                              cta={
+                                                                Object {
+                                                                  "href": "https://ibm.com",
+                                                                }
+                                                              }
+                                                              disableImage={true}
+                                                              formatCTAcopy={[Function]}
+                                                              href=""
+                                                              openLightBox={[Function]}
+                                                              renderLightBox={false}
+                                                              style="text"
+                                                              type="local"
+                                                              videoTitle={
+                                                                Array [
+                                                                  Object {
+                                                                    "duration": "",
+                                                                    "key": 0,
+                                                                    "title": "",
+                                                                  },
+                                                                ]
+                                                              }
+                                                            >
+                                                              <LinkWithIcon
+                                                                href="https://ibm.com"
+                                                                onClick={[Function]}
+                                                                target={null}
+                                                              >
+                                                                <div
+                                                                  className="bx--link-with-icon__container"
+                                                                  data-autoid="dds--link-with-icon"
+                                                                >
+                                                                  <Link
+                                                                    className="bx--link-with-icon"
+                                                                    href="https://ibm.com"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <a
+                                                                      className="bx--link bx--link-with-icon"
+                                                                      href="https://ibm.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <span>
+                                                                        IBM Cloud Continuous Delivery
+                                                                      </span>
+                                                                      <ForwardRef(ArrowRight20)>
+                                                                        <Icon
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 20 20"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <svg
+                                                                            aria-hidden={true}
+                                                                            focusable="false"
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <path
+                                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                            />
+                                                                          </svg>
+                                                                        </Icon>
+                                                                      </ForwardRef(ArrowRight20)>
+                                                                    </a>
+                                                                  </Link>
+                                                                </div>
+                                                              </LinkWithIcon>
+                                                            </TextCTA>
+                                                          </div>
+                                                        </CTA>
+                                                      </li>
+                                                      <li
+                                                        className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                        key="1"
+                                                      >
+                                                        <CTA
+                                                          copy="UrbanCode"
+                                                          cta={
+                                                            Object {
+                                                              "href": "https://ibm.com",
+                                                            }
+                                                          }
+                                                          disableImage={true}
+                                                          href=""
+                                                          style="text"
+                                                          type="local"
+                                                        >
+                                                          <div>
+                                                            <TextCTA
+                                                              copy="UrbanCode"
+                                                              cta={
+                                                                Object {
+                                                                  "href": "https://ibm.com",
+                                                                }
+                                                              }
+                                                              disableImage={true}
+                                                              formatCTAcopy={[Function]}
+                                                              href=""
+                                                              openLightBox={[Function]}
+                                                              renderLightBox={false}
+                                                              style="text"
+                                                              type="local"
+                                                              videoTitle={
+                                                                Array [
+                                                                  Object {
+                                                                    "duration": "",
+                                                                    "key": 0,
+                                                                    "title": "",
+                                                                  },
+                                                                ]
+                                                              }
+                                                            >
+                                                              <LinkWithIcon
+                                                                href="https://ibm.com"
+                                                                onClick={[Function]}
+                                                                target={null}
+                                                              >
+                                                                <div
+                                                                  className="bx--link-with-icon__container"
+                                                                  data-autoid="dds--link-with-icon"
+                                                                >
+                                                                  <Link
+                                                                    className="bx--link-with-icon"
+                                                                    href="https://ibm.com"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <a
+                                                                      className="bx--link bx--link-with-icon"
+                                                                      href="https://ibm.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <span>
+                                                                        UrbanCode
+                                                                      </span>
+                                                                      <ForwardRef(ArrowRight20)>
+                                                                        <Icon
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 20 20"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <svg
+                                                                            aria-hidden={true}
+                                                                            focusable="false"
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <path
+                                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                            />
+                                                                          </svg>
+                                                                        </Icon>
+                                                                      </ForwardRef(ArrowRight20)>
+                                                                    </a>
+                                                                  </Link>
+                                                                </div>
+                                                              </LinkWithIcon>
+                                                            </TextCTA>
+                                                          </div>
+                                                        </CTA>
+                                                      </li>
+                                                      <li
+                                                        className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                        key="2"
+                                                      >
+                                                        <CTA
+                                                          copy="View all products"
+                                                          cta={
+                                                            Object {
+                                                              "href": "https://ibm.com",
+                                                            }
+                                                          }
+                                                          disableImage={true}
+                                                          href=""
+                                                          style="text"
+                                                          type="local"
+                                                        >
+                                                          <div>
+                                                            <TextCTA
+                                                              copy="View all products"
+                                                              cta={
+                                                                Object {
+                                                                  "href": "https://ibm.com",
+                                                                }
+                                                              }
+                                                              disableImage={true}
+                                                              formatCTAcopy={[Function]}
+                                                              href=""
+                                                              openLightBox={[Function]}
+                                                              renderLightBox={false}
+                                                              style="text"
+                                                              type="local"
+                                                              videoTitle={
+                                                                Array [
+                                                                  Object {
+                                                                    "duration": "",
+                                                                    "key": 0,
+                                                                    "title": "",
+                                                                  },
+                                                                ]
+                                                              }
+                                                            >
+                                                              <LinkWithIcon
+                                                                href="https://ibm.com"
+                                                                onClick={[Function]}
+                                                                target={null}
+                                                              >
+                                                                <div
+                                                                  className="bx--link-with-icon__container"
+                                                                  data-autoid="dds--link-with-icon"
+                                                                >
+                                                                  <Link
+                                                                    className="bx--link-with-icon"
+                                                                    href="https://ibm.com"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <a
+                                                                      className="bx--link bx--link-with-icon"
+                                                                      href="https://ibm.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <span>
+                                                                        View all products
+                                                                      </span>
+                                                                      <ForwardRef(ArrowRight20)>
+                                                                        <Icon
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          viewBox="0 0 20 20"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <svg
+                                                                            aria-hidden={true}
+                                                                            focusable="false"
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <path
+                                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                            />
+                                                                          </svg>
+                                                                        </Icon>
+                                                                      </ForwardRef(ArrowRight20)>
+                                                                    </a>
+                                                                  </Link>
+                                                                </div>
+                                                              </LinkWithIcon>
+                                                            </TextCTA>
+                                                          </div>
+                                                        </CTA>
+                                                      </li>
+                                                    </ul>
+                                                  </div>
+                                                </LinkList>
+                                                <CTA
+                                                  buttons={
+                                                    Array [
+                                                      Object {
+                                                        "copy": "Excepteur sint occaecat",
+                                                        "href": "https://example.com/",
+                                                        "iconDescription": "right arrow icon",
+                                                        "onClick": [Function],
+                                                        "renderIcon": Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        },
+                                                        "target": null,
+                                                        "type": "local",
+                                                      },
+                                                    ]
+                                                  }
+                                                  copy=""
+                                                  customClassName="bx--leadspace-block__cta bx--leadspace-block__cta-col"
+                                                  href=""
+                                                  style="button"
+                                                  type="local"
+                                                >
+                                                  <div
+                                                    className="bx--leadspace-block__cta bx--leadspace-block__cta-col"
+                                                  >
+                                                    <ButtonCTA
                                                       buttons={
                                                         Array [
                                                           Object {
@@ -2898,673 +2865,691 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           },
                                                         ]
                                                       }
-                                                      enableSizeByContent={true}
+                                                      copy=""
+                                                      formatCTAcopy={[Function]}
+                                                      href=""
+                                                      openLightBox={[Function]}
+                                                      renderLightBox={false}
+                                                      style="button"
+                                                      type="local"
+                                                      videoTitle={
+                                                        Array [
+                                                          Object {
+                                                            "duration": "",
+                                                            "key": 0,
+                                                            "title": "",
+                                                          },
+                                                        ]
+                                                      }
                                                     >
-                                                      <ol
-                                                        className="bx--buttongroup"
-                                                        data-autoid="dds--button-group"
-                                                      >
-                                                        <li
-                                                          className="bx--buttongroup-item"
-                                                          key="0"
-                                                        >
-                                                          <ForwardRef(Button)
-                                                            copy="Excepteur sint occaecat"
-                                                            data-autoid="dds--button-group-0"
-                                                            disabled={false}
-                                                            href="https://example.com/"
-                                                            iconDescription="right arrow icon"
-                                                            kind="primary"
-                                                            onClick={[Function]}
-                                                            renderIcon={
-                                                              Object {
+                                                      <ButtonGroup
+                                                        buttons={
+                                                          Array [
+                                                            Object {
+                                                              "copy": "Excepteur sint occaecat",
+                                                              "href": "https://example.com/",
+                                                              "iconDescription": "right arrow icon",
+                                                              "onClick": [Function],
+                                                              "renderIcon": Object {
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "render": [Function],
-                                                              }
-                                                            }
-                                                            tabIndex={2}
-                                                            target={null}
-                                                            type="button"
+                                                              },
+                                                              "target": null,
+                                                              "type": "local",
+                                                            },
+                                                          ]
+                                                        }
+                                                        enableSizeByContent={true}
+                                                      >
+                                                        <ol
+                                                          className="bx--buttongroup"
+                                                          data-autoid="dds--button-group"
+                                                        >
+                                                          <li
+                                                            className="bx--buttongroup-item"
+                                                            key="0"
                                                           >
-                                                            <a
-                                                              className="bx--btn bx--btn--primary"
+                                                            <ForwardRef(Button)
                                                               copy="Excepteur sint occaecat"
                                                               data-autoid="dds--button-group-0"
+                                                              disabled={false}
                                                               href="https://example.com/"
+                                                              iconDescription="right arrow icon"
+                                                              kind="primary"
                                                               onClick={[Function]}
+                                                              renderIcon={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
                                                               tabIndex={2}
                                                               target={null}
+                                                              type="button"
                                                             >
-                                                              Excepteur sint occaecat
-                                                              <ForwardRef(ArrowRight20)
-                                                                aria-hidden="true"
-                                                                aria-label="right arrow icon"
-                                                                className="bx--btn__icon"
+                                                              <a
+                                                                className="bx--btn bx--btn--primary"
+                                                                copy="Excepteur sint occaecat"
+                                                                data-autoid="dds--button-group-0"
+                                                                href="https://example.com/"
+                                                                onClick={[Function]}
+                                                                tabIndex={2}
+                                                                target={null}
                                                               >
-                                                                <Icon
+                                                                Excepteur sint occaecat
+                                                                <ForwardRef(ArrowRight20)
                                                                   aria-hidden="true"
                                                                   aria-label="right arrow icon"
                                                                   className="bx--btn__icon"
+                                                                >
+                                                                  <Icon
+                                                                    aria-hidden="true"
+                                                                    aria-label="right arrow icon"
+                                                                    className="bx--btn__icon"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden="true"
+                                                                      aria-label="right arrow icon"
+                                                                      className="bx--btn__icon"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      role="img"
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </a>
+                                                            </ForwardRef(Button)>
+                                                          </li>
+                                                        </ol>
+                                                      </ButtonGroup>
+                                                    </ButtonCTA>
+                                                  </div>
+                                                </CTA>
+                                              </div>
+                                            </div>
+                                          </ContentBlock>
+                                          <HorizontalRule>
+                                            <hr
+                                              className="bx--hr"
+                                              data-autoid="dds--hr"
+                                            />
+                                          </HorizontalRule>
+                                        </div>
+                                      </LeadSpaceBlock>
+                                    </div>
+                                  </div>
+                                </section>
+                              </Layout>
+                              <a
+                                data-title="Pharetra pharetra massa massa ultricies mi quis."
+                                name="section-2"
+                              />
+                              <ContentBlockSegmented
+                                heading="Pharetra pharetra massa massa ultricies mi quis."
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                      "cta": Object {
+                                        "copy": "Lorem Ipsum dolor sit",
+                                        "href": "https://example.com",
+                                        "type": "local",
+                                      },
+                                      "heading": "A scelerisque purus semper eget duis at tellus.",
+                                    },
+                                    Object {
+                                      "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                      "heading": "A scelerisque purus semper eget duis at tellus.",
+                                    },
+                                    Object {
+                                      "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                      "cta": Object {
+                                        "copy": "Lorem Ipsum dolor sit",
+                                        "href": "https://example.com",
+                                        "type": "local",
+                                      },
+                                      "heading": "A scelerisque purus semper eget duis at tellus.",
+                                    },
+                                    Object {
+                                      "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                      "heading": "A scelerisque purus semper eget duis at tellus.",
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="bx--content-block-segmented"
+                                  data-autoid="dds--content-block-segmented"
+                                >
+                                  <ContentBlock
+                                    border={false}
+                                    heading="Pharetra pharetra massa massa ultricies mi quis."
+                                  >
+                                    <div
+                                      className="bx--content-block"
+                                      data-autoid="dds--content-block"
+                                    >
+                                      <div>
+                                        <h2
+                                          className="bx--content-block__heading"
+                                          data-autoid="dds--content-block__heading"
+                                        >
+                                          Pharetra pharetra massa massa ultricies mi quis.
+                                        </h2>
+                                      </div>
+                                      <div
+                                        className="bx--content-block__children"
+                                        data-autoid="dds--content-block__children"
+                                      >
+                                        <ContentGroup
+                                          cta={
+                                            Object {
+                                              "copy": "Lorem Ipsum dolor sit",
+                                              "href": "https://example.com",
+                                              "style": "text",
+                                              "type": "local",
+                                            }
+                                          }
+                                          heading="A scelerisque purus semper eget duis at tellus."
+                                          key="0"
+                                        >
+                                          <div
+                                            className="bx--content-group"
+                                            data-autoid="dds--content-group"
+                                          >
+                                            <h3
+                                              className="bx--content-group__title"
+                                              data-autoid="dds--content-group__title"
+                                            >
+                                              A scelerisque purus semper eget duis at tellus.
+                                            </h3>
+                                            <div
+                                              className="bx--content-group__col bx--content-group__children"
+                                              data-autoid="dds--content-group__children"
+                                            >
+                                              <div
+                                                data-autoid="dds--content-block-segmented__content-group"
+                                              >
+                                                <ContentItem
+                                                  copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                  key="0"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="bx--content-group__cta-row"
+                                              data-autoid="dds--content-group__cta"
+                                            >
+                                              <CTA
+                                                copy="Lorem Ipsum dolor sit"
+                                                customClassName="bx--content-group__cta"
+                                                href="https://example.com"
+                                                style="text"
+                                                type="local"
+                                              >
+                                                <div
+                                                  className="bx--content-group__cta"
+                                                >
+                                                  <TextCTA
+                                                    copy="Lorem Ipsum dolor sit"
+                                                    formatCTAcopy={[Function]}
+                                                    href="https://example.com"
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "duration": "",
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
+                                                  >
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
+                                                      >
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target={null}
+                                                        >
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <span>
+                                                              Lorem Ipsum dolor sit
+                                                            </span>
+                                                            <ForwardRef(ArrowRight20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
                                                                   width={20}
                                                                   xmlns="http://www.w3.org/2000/svg"
                                                                 >
-                                                                  <svg
-                                                                    aria-hidden="true"
-                                                                    aria-label="right arrow icon"
-                                                                    className="bx--btn__icon"
-                                                                    focusable="false"
-                                                                    height={20}
-                                                                    preserveAspectRatio="xMidYMid meet"
-                                                                    role="img"
-                                                                    viewBox="0 0 20 20"
-                                                                    width={20}
-                                                                    xmlns="http://www.w3.org/2000/svg"
-                                                                  >
-                                                                    <path
-                                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                    />
-                                                                  </svg>
-                                                                </Icon>
-                                                              </ForwardRef(ArrowRight20)>
-                                                            </a>
-                                                          </ForwardRef(Button)>
-                                                        </li>
-                                                      </ol>
-                                                    </ButtonGroup>
-                                                  </ButtonCTA>
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
                                                 </div>
                                               </CTA>
                                             </div>
                                           </div>
-                                        </ContentBlock>
-                                        <HorizontalRule>
-                                          <hr
-                                            className="bx--hr"
-                                            data-autoid="dds--hr"
-                                          />
-                                        </HorizontalRule>
+                                        </ContentGroup>
+                                        <ContentGroup
+                                          cta={false}
+                                          heading="A scelerisque purus semper eget duis at tellus."
+                                          key="1"
+                                        >
+                                          <div
+                                            className="bx--content-group"
+                                            data-autoid="dds--content-group"
+                                          >
+                                            <h3
+                                              className="bx--content-group__title"
+                                              data-autoid="dds--content-group__title"
+                                            >
+                                              A scelerisque purus semper eget duis at tellus.
+                                            </h3>
+                                            <div
+                                              className="bx--content-group__col bx--content-group__children"
+                                              data-autoid="dds--content-group__children"
+                                            >
+                                              <div
+                                                data-autoid="dds--content-block-segmented__content-group"
+                                              >
+                                                <ContentItem
+                                                  copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                  key="1"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </ContentGroup>
+                                        <ContentGroup
+                                          cta={
+                                            Object {
+                                              "copy": "Lorem Ipsum dolor sit",
+                                              "href": "https://example.com",
+                                              "style": "text",
+                                              "type": "local",
+                                            }
+                                          }
+                                          heading="A scelerisque purus semper eget duis at tellus."
+                                          key="2"
+                                        >
+                                          <div
+                                            className="bx--content-group"
+                                            data-autoid="dds--content-group"
+                                          >
+                                            <h3
+                                              className="bx--content-group__title"
+                                              data-autoid="dds--content-group__title"
+                                            >
+                                              A scelerisque purus semper eget duis at tellus.
+                                            </h3>
+                                            <div
+                                              className="bx--content-group__col bx--content-group__children"
+                                              data-autoid="dds--content-group__children"
+                                            >
+                                              <div
+                                                data-autoid="dds--content-block-segmented__content-group"
+                                              >
+                                                <ContentItem
+                                                  copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                  key="2"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="bx--content-group__cta-row"
+                                              data-autoid="dds--content-group__cta"
+                                            >
+                                              <CTA
+                                                copy="Lorem Ipsum dolor sit"
+                                                customClassName="bx--content-group__cta"
+                                                href="https://example.com"
+                                                style="text"
+                                                type="local"
+                                              >
+                                                <div
+                                                  className="bx--content-group__cta"
+                                                >
+                                                  <TextCTA
+                                                    copy="Lorem Ipsum dolor sit"
+                                                    formatCTAcopy={[Function]}
+                                                    href="https://example.com"
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "duration": "",
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
+                                                  >
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
+                                                      >
+                                                        <Link
+                                                          className="bx--link-with-icon"
+                                                          href="https://example.com"
+                                                          onClick={[Function]}
+                                                          target={null}
+                                                        >
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <span>
+                                                              Lorem Ipsum dolor sit
+                                                            </span>
+                                                            <ForwardRef(ArrowRight20)>
+                                                              <Icon
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
+                                                </div>
+                                              </CTA>
+                                            </div>
+                                          </div>
+                                        </ContentGroup>
+                                        <ContentGroup
+                                          cta={false}
+                                          heading="A scelerisque purus semper eget duis at tellus."
+                                          key="3"
+                                        >
+                                          <div
+                                            className="bx--content-group"
+                                            data-autoid="dds--content-group"
+                                          >
+                                            <h3
+                                              className="bx--content-group__title"
+                                              data-autoid="dds--content-group__title"
+                                            >
+                                              A scelerisque purus semper eget duis at tellus.
+                                            </h3>
+                                            <div
+                                              className="bx--content-group__col bx--content-group__children"
+                                              data-autoid="dds--content-group__children"
+                                            >
+                                              <div
+                                                data-autoid="dds--content-block-segmented__content-group"
+                                              >
+                                                <ContentItem
+                                                  copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                  key="3"
+                                                >
+                                                  <div
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </ContentGroup>
                                       </div>
-                                    </LeadSpaceBlock>
-                                  </div>
+                                    </div>
+                                  </ContentBlock>
                                 </div>
-                              </section>
-                            </Layout>
-                            <a
-                              data-title="Pharetra pharetra massa massa ultricies mi quis."
-                              name="section-2"
-                            />
-                            <ContentBlockSegmented
-                              heading="Pharetra pharetra massa massa ultricies mi quis."
-                              items={
-                                Array [
+                              </ContentBlockSegmented>
+                              <FeatureCardBlockLarge
+                                copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
+                                cta={
                                   Object {
-                                    "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
-                                    "cta": Object {
-                                      "copy": "Lorem Ipsum dolor sit",
-                                      "href": "https://example.com",
-                                      "type": "local",
-                                    },
-                                    "heading": "A scelerisque purus semper eget duis at tellus.",
-                                  },
-                                  Object {
-                                    "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
-                                    "heading": "A scelerisque purus semper eget duis at tellus.",
-                                  },
-                                  Object {
-                                    "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
-                                    "cta": Object {
-                                      "copy": "Lorem Ipsum dolor sit",
-                                      "href": "https://example.com",
-                                      "type": "local",
-                                    },
-                                    "heading": "A scelerisque purus semper eget duis at tellus.",
-                                  },
-                                  Object {
-                                    "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
-                                    "heading": "A scelerisque purus semper eget duis at tellus.",
-                                  },
-                                ]
-                              }
-                            >
-                              <div
-                                className="bx--content-block-segmented"
-                                data-autoid="dds--content-block-segmented"
-                              >
-                                <ContentBlock
-                                  border={false}
-                                  heading="Pharetra pharetra massa massa ultricies mi quis."
-                                >
-                                  <div
-                                    className="bx--content-block"
-                                    data-autoid="dds--content-block"
-                                  >
-                                    <div>
-                                      <h2
-                                        className="bx--content-block__heading"
-                                        data-autoid="dds--content-block__heading"
-                                      >
-                                        Pharetra pharetra massa massa ultricies mi quis.
-                                      </h2>
-                                    </div>
-                                    <div
-                                      className="bx--content-block__children"
-                                      data-autoid="dds--content-block__children"
-                                    >
-                                      <ContentGroup
-                                        cta={
-                                          Object {
-                                            "copy": "Lorem Ipsum dolor sit",
-                                            "href": "https://example.com",
-                                            "style": "text",
-                                            "type": "local",
-                                          }
-                                        }
-                                        heading="A scelerisque purus semper eget duis at tellus."
-                                        key="0"
-                                      >
-                                        <div
-                                          className="bx--content-group"
-                                          data-autoid="dds--content-group"
-                                        >
-                                          <h3
-                                            className="bx--content-group__title"
-                                            data-autoid="dds--content-group__title"
-                                          >
-                                            A scelerisque purus semper eget duis at tellus.
-                                          </h3>
-                                          <div
-                                            className="bx--content-group__col bx--content-group__children"
-                                            data-autoid="dds--content-group__children"
-                                          >
-                                            <div
-                                              data-autoid="dds--content-block-segmented__content-group"
-                                            >
-                                              <ContentItem
-                                                copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
-                                                key="0"
-                                              >
-                                                <div
-                                                  className="bx--content-item"
-                                                  data-autoid="dds--content-item"
-                                                >
-                                                  <div
-                                                    className="bx--content-item__copy"
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
-                                                      }
-                                                    }
-                                                    data-autoid="dds--content-item__copy"
-                                                  />
-                                                </div>
-                                              </ContentItem>
-                                            </div>
-                                          </div>
-                                          <div
-                                            className="bx--content-group__cta-row"
-                                            data-autoid="dds--content-group__cta"
-                                          >
-                                            <CTA
-                                              copy="Lorem Ipsum dolor sit"
-                                              customClassName="bx--content-group__cta"
-                                              href="https://example.com"
-                                              style="text"
-                                              type="local"
-                                            >
-                                              <div
-                                                className="bx--content-group__cta"
-                                              >
-                                                <TextCTA
-                                                  copy="Lorem Ipsum dolor sit"
-                                                  formatCTAcopy={[Function]}
-                                                  href="https://example.com"
-                                                  openLightBox={[Function]}
-                                                  renderLightBox={false}
-                                                  style="text"
-                                                  type="local"
-                                                  videoTitle={
-                                                    Array [
-                                                      Object {
-                                                        "duration": "",
-                                                        "key": 0,
-                                                        "title": "",
-                                                      },
-                                                    ]
-                                                  }
-                                                >
-                                                  <LinkWithIcon
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target={null}
-                                                  >
-                                                    <div
-                                                      className="bx--link-with-icon__container"
-                                                      data-autoid="dds--link-with-icon"
-                                                    >
-                                                      <Link
-                                                        className="bx--link-with-icon"
-                                                        href="https://example.com"
-                                                        onClick={[Function]}
-                                                        target={null}
-                                                      >
-                                                        <a
-                                                          className="bx--link bx--link-with-icon"
-                                                          href="https://example.com"
-                                                          onClick={[Function]}
-                                                          target={null}
-                                                        >
-                                                          <span>
-                                                            Lorem Ipsum dolor sit
-                                                          </span>
-                                                          <ForwardRef(ArrowRight20)>
-                                                            <Icon
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <svg
-                                                                aria-hidden={true}
-                                                                focusable="false"
-                                                                height={20}
-                                                                preserveAspectRatio="xMidYMid meet"
-                                                                viewBox="0 0 20 20"
-                                                                width={20}
-                                                                xmlns="http://www.w3.org/2000/svg"
-                                                              >
-                                                                <path
-                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                />
-                                                              </svg>
-                                                            </Icon>
-                                                          </ForwardRef(ArrowRight20)>
-                                                        </a>
-                                                      </Link>
-                                                    </div>
-                                                  </LinkWithIcon>
-                                                </TextCTA>
-                                              </div>
-                                            </CTA>
-                                          </div>
-                                        </div>
-                                      </ContentGroup>
-                                      <ContentGroup
-                                        cta={false}
-                                        heading="A scelerisque purus semper eget duis at tellus."
-                                        key="1"
-                                      >
-                                        <div
-                                          className="bx--content-group"
-                                          data-autoid="dds--content-group"
-                                        >
-                                          <h3
-                                            className="bx--content-group__title"
-                                            data-autoid="dds--content-group__title"
-                                          >
-                                            A scelerisque purus semper eget duis at tellus.
-                                          </h3>
-                                          <div
-                                            className="bx--content-group__col bx--content-group__children"
-                                            data-autoid="dds--content-group__children"
-                                          >
-                                            <div
-                                              data-autoid="dds--content-block-segmented__content-group"
-                                            >
-                                              <ContentItem
-                                                copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
-                                                key="1"
-                                              >
-                                                <div
-                                                  className="bx--content-item"
-                                                  data-autoid="dds--content-item"
-                                                >
-                                                  <div
-                                                    className="bx--content-item__copy"
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
-                                                      }
-                                                    }
-                                                    data-autoid="dds--content-item__copy"
-                                                  />
-                                                </div>
-                                              </ContentItem>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </ContentGroup>
-                                      <ContentGroup
-                                        cta={
-                                          Object {
-                                            "copy": "Lorem Ipsum dolor sit",
-                                            "href": "https://example.com",
-                                            "style": "text",
-                                            "type": "local",
-                                          }
-                                        }
-                                        heading="A scelerisque purus semper eget duis at tellus."
-                                        key="2"
-                                      >
-                                        <div
-                                          className="bx--content-group"
-                                          data-autoid="dds--content-group"
-                                        >
-                                          <h3
-                                            className="bx--content-group__title"
-                                            data-autoid="dds--content-group__title"
-                                          >
-                                            A scelerisque purus semper eget duis at tellus.
-                                          </h3>
-                                          <div
-                                            className="bx--content-group__col bx--content-group__children"
-                                            data-autoid="dds--content-group__children"
-                                          >
-                                            <div
-                                              data-autoid="dds--content-block-segmented__content-group"
-                                            >
-                                              <ContentItem
-                                                copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
-                                                key="2"
-                                              >
-                                                <div
-                                                  className="bx--content-item"
-                                                  data-autoid="dds--content-item"
-                                                >
-                                                  <div
-                                                    className="bx--content-item__copy"
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
-                                                      }
-                                                    }
-                                                    data-autoid="dds--content-item__copy"
-                                                  />
-                                                </div>
-                                              </ContentItem>
-                                            </div>
-                                          </div>
-                                          <div
-                                            className="bx--content-group__cta-row"
-                                            data-autoid="dds--content-group__cta"
-                                          >
-                                            <CTA
-                                              copy="Lorem Ipsum dolor sit"
-                                              customClassName="bx--content-group__cta"
-                                              href="https://example.com"
-                                              style="text"
-                                              type="local"
-                                            >
-                                              <div
-                                                className="bx--content-group__cta"
-                                              >
-                                                <TextCTA
-                                                  copy="Lorem Ipsum dolor sit"
-                                                  formatCTAcopy={[Function]}
-                                                  href="https://example.com"
-                                                  openLightBox={[Function]}
-                                                  renderLightBox={false}
-                                                  style="text"
-                                                  type="local"
-                                                  videoTitle={
-                                                    Array [
-                                                      Object {
-                                                        "duration": "",
-                                                        "key": 0,
-                                                        "title": "",
-                                                      },
-                                                    ]
-                                                  }
-                                                >
-                                                  <LinkWithIcon
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target={null}
-                                                  >
-                                                    <div
-                                                      className="bx--link-with-icon__container"
-                                                      data-autoid="dds--link-with-icon"
-                                                    >
-                                                      <Link
-                                                        className="bx--link-with-icon"
-                                                        href="https://example.com"
-                                                        onClick={[Function]}
-                                                        target={null}
-                                                      >
-                                                        <a
-                                                          className="bx--link bx--link-with-icon"
-                                                          href="https://example.com"
-                                                          onClick={[Function]}
-                                                          target={null}
-                                                        >
-                                                          <span>
-                                                            Lorem Ipsum dolor sit
-                                                          </span>
-                                                          <ForwardRef(ArrowRight20)>
-                                                            <Icon
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <svg
-                                                                aria-hidden={true}
-                                                                focusable="false"
-                                                                height={20}
-                                                                preserveAspectRatio="xMidYMid meet"
-                                                                viewBox="0 0 20 20"
-                                                                width={20}
-                                                                xmlns="http://www.w3.org/2000/svg"
-                                                              >
-                                                                <path
-                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                />
-                                                              </svg>
-                                                            </Icon>
-                                                          </ForwardRef(ArrowRight20)>
-                                                        </a>
-                                                      </Link>
-                                                    </div>
-                                                  </LinkWithIcon>
-                                                </TextCTA>
-                                              </div>
-                                            </CTA>
-                                          </div>
-                                        </div>
-                                      </ContentGroup>
-                                      <ContentGroup
-                                        cta={false}
-                                        heading="A scelerisque purus semper eget duis at tellus."
-                                        key="3"
-                                      >
-                                        <div
-                                          className="bx--content-group"
-                                          data-autoid="dds--content-group"
-                                        >
-                                          <h3
-                                            className="bx--content-group__title"
-                                            data-autoid="dds--content-group__title"
-                                          >
-                                            A scelerisque purus semper eget duis at tellus.
-                                          </h3>
-                                          <div
-                                            className="bx--content-group__col bx--content-group__children"
-                                            data-autoid="dds--content-group__children"
-                                          >
-                                            <div
-                                              data-autoid="dds--content-block-segmented__content-group"
-                                            >
-                                              <ContentItem
-                                                copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
-                                                key="3"
-                                              >
-                                                <div
-                                                  className="bx--content-item"
-                                                  data-autoid="dds--content-item"
-                                                >
-                                                  <div
-                                                    className="bx--content-item__copy"
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
-                                                      }
-                                                    }
-                                                    data-autoid="dds--content-item__copy"
-                                                  />
-                                                </div>
-                                              </ContentItem>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </ContentGroup>
-                                    </div>
-                                  </div>
-                                </ContentBlock>
-                              </div>
-                            </ContentBlockSegmented>
-                            <FeatureCardBlockLarge
-                              copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
-                              cta={
-                                Object {
-                                  "href": "https://example.com",
-                                  "icon": Object {
-                                    "src": Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "render": [Function],
-                                    },
-                                  },
-                                }
-                              }
-                              eyebrow="scelerisque purus"
-                              heading="Elementum nibh tellus molestie nunc?"
-                              image={
-                                Object {
-                                  "alt": "Image alt text",
-                                  "defaultSrc": "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
-                                }
-                              }
-                            >
-                              <section
-                                className="bx--feature-card-block-large"
-                                data-autoid="dds--feature-card-block-large"
-                              >
-                                <Card
-                                  copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
-                                  cta={
-                                    Object {
-                                      "href": "https://example.com",
-                                      "icon": Object {
-                                        "src": Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "render": [Function],
-                                        },
+                                    "href": "https://example.com",
+                                    "icon": Object {
+                                      "src": Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "render": [Function],
                                       },
-                                    }
+                                    },
                                   }
-                                  customClassName="bx--feature-card-block-large__card"
-                                  eyebrow="scelerisque purus"
-                                  heading="Elementum nibh tellus molestie nunc?"
-                                  image={
-                                    Object {
-                                      "alt": "Image alt text",
-                                      "defaultSrc": "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
-                                    }
+                                }
+                                eyebrow="scelerisque purus"
+                                heading="Elementum nibh tellus molestie nunc?"
+                                image={
+                                  Object {
+                                    "alt": "Image alt text",
+                                    "defaultSrc": "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
                                   }
-                                  inverse={true}
-                                  type="link"
+                                }
+                              >
+                                <section
+                                  className="bx--feature-card-block-large"
+                                  data-autoid="dds--feature-card-block-large"
                                 >
-                                  <ClickableTile
-                                    className="bx--card bx--card--inverse bx--card--link bx--feature-card-block-large__card"
-                                    clicked={false}
-                                    data-autoid="dds--card"
-                                    handleClick={[Function]}
-                                    handleKeyDown={[Function]}
-                                    href="https://example.com"
-                                    light={false}
-                                    onClick={[Function]}
-                                    target={null}
+                                  <Card
+                                    copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
+                                    cta={
+                                      Object {
+                                        "href": "https://example.com",
+                                        "icon": Object {
+                                          "src": Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "render": [Function],
+                                          },
+                                        },
+                                      }
+                                    }
+                                    customClassName="bx--feature-card-block-large__card"
+                                    eyebrow="scelerisque purus"
+                                    heading="Elementum nibh tellus molestie nunc?"
+                                    image={
+                                      Object {
+                                        "alt": "Image alt text",
+                                        "defaultSrc": "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
+                                      }
+                                    }
+                                    inverse={true}
+                                    type="link"
                                   >
-                                    <a
-                                      className="bx--tile bx--tile--clickable bx--card bx--card--inverse bx--card--link bx--feature-card-block-large__card"
+                                    <ClickableTile
+                                      className="bx--card bx--card--inverse bx--card--link bx--feature-card-block-large__card"
+                                      clicked={false}
                                       data-autoid="dds--card"
+                                      handleClick={[Function]}
+                                      handleKeyDown={[Function]}
                                       href="https://example.com"
+                                      light={false}
                                       onClick={[Function]}
-                                      onKeyDown={[Function]}
                                       target={null}
                                     >
-                                      <Image
-                                        alt="Image alt text"
-                                        classname="bx--card__img"
-                                        defaultSrc="https://dummyimage.com/600x600/ee5396/161616&text=1:1"
+                                      <a
+                                        className="bx--tile bx--tile--clickable bx--card bx--card--inverse bx--card--link bx--feature-card-block-large__card"
+                                        data-autoid="dds--card"
+                                        href="https://example.com"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        target={null}
                                       >
+                                        <Image
+                                          alt="Image alt text"
+                                          classname="bx--card__img"
+                                          defaultSrc="https://dummyimage.com/600x600/ee5396/161616&text=1:1"
+                                        >
+                                          <div
+                                            className="bx--image"
+                                            data-autoid="dds--image__longdescription-"
+                                          >
+                                            <picture>
+                                              <img
+                                                alt="Image alt text"
+                                                className="bx--image__img bx--card__img"
+                                                src="https://dummyimage.com/600x600/ee5396/161616&text=1:1"
+                                              />
+                                            </picture>
+                                          </div>
+                                        </Image>
                                         <div
-                                          className="bx--image"
-                                          data-autoid="dds--image__longdescription-"
+                                          className="bx--card__wrapper"
                                         >
-                                          <picture>
-                                            <img
-                                              alt="Image alt text"
-                                              className="bx--image__img bx--card__img"
-                                              src="https://dummyimage.com/600x600/ee5396/161616&text=1:1"
-                                            />
-                                          </picture>
-                                        </div>
-                                      </Image>
-                                      <div
-                                        className="bx--card__wrapper"
-                                      >
-                                        <p
-                                          className="bx--card__eyebrow"
-                                        >
-                                          scelerisque purus
-                                        </p>
-                                        <h3
-                                          className="bx--card__heading"
-                                        >
-                                          Elementum nibh tellus molestie nunc?
-                                        </h3>
-                                        <div
-                                          className="bx--card__copy"
-                                          dangerouslySetInnerHTML={
-                                            Object {
-                                              "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p>",
-                                            }
-                                          }
-                                        />
-                                        <div
-                                          className="bx--card__footer"
-                                        >
-                                          <ForwardRef(ArrowRight20)
-                                            className="bx--card__cta"
-                                            src={
+                                          <p
+                                            className="bx--card__eyebrow"
+                                          >
+                                            scelerisque purus
+                                          </p>
+                                          <h3
+                                            className="bx--card__heading"
+                                          >
+                                            Elementum nibh tellus molestie nunc?
+                                          </h3>
+                                          <div
+                                            className="bx--card__copy"
+                                            dangerouslySetInnerHTML={
                                               Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "render": [Function],
+                                                "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p>",
                                               }
                                             }
+                                          />
+                                          <div
+                                            className="bx--card__footer"
                                           >
-                                            <Icon
+                                            <ForwardRef(ArrowRight20)
                                               className="bx--card__cta"
-                                              height={20}
-                                              preserveAspectRatio="xMidYMid meet"
                                               src={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
                                                   "render": [Function],
                                                 }
                                               }
-                                              viewBox="0 0 20 20"
-                                              width={20}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <svg
-                                                aria-hidden={true}
+                                              <Icon
                                                 className="bx--card__cta"
-                                                focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
                                                 src={
@@ -3577,219 +3562,208 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                 width={20}
                                                 xmlns="http://www.w3.org/2000/svg"
                                               >
-                                                <path
-                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                />
-                                              </svg>
-                                            </Icon>
-                                          </ForwardRef(ArrowRight20)>
-                                          <span />
-                                        </div>
-                                      </div>
-                                    </a>
-                                  </ClickableTile>
-                                </Card>
-                              </section>
-                            </FeatureCardBlockLarge>
-                            <a
-                              data-title="Elementum nibh tellus molestie nunc non"
-                              name="section-3"
-                            />
-                            <ContentBlockSegmented
-                              cta={
-                                Object {
-                                  "disableImage": true,
-                                  "media": Object {
-                                    "src": "0_uka1msg4",
-                                    "type": "video",
-                                  },
-                                  "style": "card",
-                                  "type": "video",
-                                }
-                              }
-                              heading="Elementum nibh tellus molestie nunc non."
-                              items={
-                                Array [
-                                  Object {
-                                    "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
-                                    "cta": Object {
-                                      "copy": "Lorem Ipsum dolor sit",
-                                      "href": "https://example.com",
-                                      "type": "local",
-                                    },
-                                    "heading": "A scelerisque purus semper eget duis at tellus.",
-                                    "image": Object {
-                                      "heading": "Mauris iaculis eget dolor nec hendrerit.",
-                                      "image": Object {
-                                        "alt": "Image alt text",
-                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                        "sources": Array [
-                                          Object {
-                                            "breakpoint": 320,
-                                            "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
-                                          },
-                                          Object {
-                                            "breakpoint": 400,
-                                            "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
-                                          },
-                                          Object {
-                                            "breakpoint": 672,
-                                            "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  },
-                                  Object {
-                                    "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
-                                    "heading": "A scelerisque purus semper eget duis at tellus.",
-                                    "image": Object {
-                                      "heading": "Mauris iaculis eget dolor nec hendrerit.",
-                                      "image": Object {
-                                        "alt": "Image alt text",
-                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                        "sources": Array [
-                                          Object {
-                                            "breakpoint": 320,
-                                            "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
-                                          },
-                                          Object {
-                                            "breakpoint": 400,
-                                            "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
-                                          },
-                                          Object {
-                                            "breakpoint": 672,
-                                            "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                  },
-                                ]
-                              }
-                              mediaType="image"
-                            >
-                              <div
-                                className="bx--content-block-segmented"
-                                data-autoid="dds--content-block-segmented"
-                              >
-                                <ContentBlock
-                                  border={false}
-                                  cta={
-                                    Object {
-                                      "disableImage": true,
-                                      "media": Object {
-                                        "src": "0_uka1msg4",
-                                        "type": "video",
-                                      },
-                                      "style": "card",
-                                      "type": "video",
-                                    }
-                                  }
-                                  heading="Elementum nibh tellus molestie nunc non."
-                                >
-                                  <div
-                                    className="bx--content-block"
-                                    data-autoid="dds--content-block"
-                                  >
-                                    <div>
-                                      <h2
-                                        className="bx--content-block__heading"
-                                        data-autoid="dds--content-block__heading"
-                                      >
-                                        Elementum nibh tellus molestie nunc non.
-                                      </h2>
-                                    </div>
-                                    <div
-                                      className="bx--content-block__children"
-                                      data-autoid="dds--content-block__children"
-                                    >
-                                      <ContentGroup
-                                        cta={
-                                          Object {
-                                            "copy": "Lorem Ipsum dolor sit",
-                                            "href": "https://example.com",
-                                            "style": "text",
-                                            "type": "local",
-                                          }
-                                        }
-                                        heading="A scelerisque purus semper eget duis at tellus."
-                                        key="0"
-                                      >
-                                        <div
-                                          className="bx--content-group"
-                                          data-autoid="dds--content-group"
-                                        >
-                                          <h3
-                                            className="bx--content-group__title"
-                                            data-autoid="dds--content-group__title"
-                                          >
-                                            A scelerisque purus semper eget duis at tellus.
-                                          </h3>
-                                          <div
-                                            className="bx--content-group__col bx--content-group__children"
-                                            data-autoid="dds--content-group__children"
-                                          >
-                                            <div
-                                              data-autoid="dds--content-block-segmented__content-group"
-                                            >
-                                              <ContentItem
-                                                copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
-                                                key="0"
-                                              >
-                                                <div
-                                                  className="bx--content-item"
-                                                  data-autoid="dds--content-item"
-                                                >
-                                                  <div
-                                                    className="bx--content-item__copy"
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
-                                                      }
-                                                    }
-                                                    data-autoid="dds--content-item__copy"
-                                                  />
-                                                </div>
-                                              </ContentItem>
-                                              <div
-                                                data-autoid="dds--content-block-segmented__media"
-                                              >
-                                                <ImageWithCaption
-                                                  copy=""
-                                                  heading="Mauris iaculis eget dolor nec hendrerit."
-                                                  image={
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="bx--card__cta"
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  src={
                                                     Object {
-                                                      "alt": "Image alt text",
-                                                      "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                                      "sources": Array [
-                                                        Object {
-                                                          "breakpoint": 320,
-                                                          "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
-                                                        },
-                                                        Object {
-                                                          "breakpoint": 400,
-                                                          "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
-                                                        },
-                                                        Object {
-                                                          "breakpoint": 672,
-                                                          "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                                        },
-                                                      ],
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
                                                     }
                                                   }
-                                                  inverse={false}
-                                                  lightbox={false}
+                                                  viewBox="0 0 20 20"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(ArrowRight20)>
+                                            <span />
+                                          </div>
+                                        </div>
+                                      </a>
+                                    </ClickableTile>
+                                  </Card>
+                                </section>
+                              </FeatureCardBlockLarge>
+                              <a
+                                data-title="Elementum nibh tellus molestie nunc non"
+                                name="section-3"
+                              />
+                              <ContentBlockSegmented
+                                cta={
+                                  Object {
+                                    "disableImage": true,
+                                    "media": Object {
+                                      "src": "0_uka1msg4",
+                                      "type": "video",
+                                    },
+                                    "style": "card",
+                                    "type": "video",
+                                  }
+                                }
+                                heading="Elementum nibh tellus molestie nunc non."
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                      "cta": Object {
+                                        "copy": "Lorem Ipsum dolor sit",
+                                        "href": "https://example.com",
+                                        "type": "local",
+                                      },
+                                      "heading": "A scelerisque purus semper eget duis at tellus.",
+                                      "image": Object {
+                                        "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                                        "image": Object {
+                                          "alt": "Image alt text",
+                                          "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                          "sources": Array [
+                                            Object {
+                                              "breakpoint": 320,
+                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                            },
+                                            Object {
+                                              "breakpoint": 400,
+                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                            },
+                                            Object {
+                                              "breakpoint": 672,
+                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                    Object {
+                                      "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                      "heading": "A scelerisque purus semper eget duis at tellus.",
+                                      "image": Object {
+                                        "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                                        "image": Object {
+                                          "alt": "Image alt text",
+                                          "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                          "sources": Array [
+                                            Object {
+                                              "breakpoint": 320,
+                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                            },
+                                            Object {
+                                              "breakpoint": 400,
+                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                            },
+                                            Object {
+                                              "breakpoint": 672,
+                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  ]
+                                }
+                                mediaType="image"
+                              >
+                                <div
+                                  className="bx--content-block-segmented"
+                                  data-autoid="dds--content-block-segmented"
+                                >
+                                  <ContentBlock
+                                    border={false}
+                                    cta={
+                                      Object {
+                                        "disableImage": true,
+                                        "media": Object {
+                                          "src": "0_uka1msg4",
+                                          "type": "video",
+                                        },
+                                        "style": "card",
+                                        "type": "video",
+                                      }
+                                    }
+                                    heading="Elementum nibh tellus molestie nunc non."
+                                  >
+                                    <div
+                                      className="bx--content-block"
+                                      data-autoid="dds--content-block"
+                                    >
+                                      <div>
+                                        <h2
+                                          className="bx--content-block__heading"
+                                          data-autoid="dds--content-block__heading"
+                                        >
+                                          Elementum nibh tellus molestie nunc non.
+                                        </h2>
+                                      </div>
+                                      <div
+                                        className="bx--content-block__children"
+                                        data-autoid="dds--content-block__children"
+                                      >
+                                        <ContentGroup
+                                          cta={
+                                            Object {
+                                              "copy": "Lorem Ipsum dolor sit",
+                                              "href": "https://example.com",
+                                              "style": "text",
+                                              "type": "local",
+                                            }
+                                          }
+                                          heading="A scelerisque purus semper eget duis at tellus."
+                                          key="0"
+                                        >
+                                          <div
+                                            className="bx--content-group"
+                                            data-autoid="dds--content-group"
+                                          >
+                                            <h3
+                                              className="bx--content-group__title"
+                                              data-autoid="dds--content-group__title"
+                                            >
+                                              A scelerisque purus semper eget duis at tellus.
+                                            </h3>
+                                            <div
+                                              className="bx--content-group__col bx--content-group__children"
+                                              data-autoid="dds--content-group__children"
+                                            >
+                                              <div
+                                                data-autoid="dds--content-block-segmented__content-group"
+                                              >
+                                                <ContentItem
+                                                  copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                  key="0"
                                                 >
                                                   <div
-                                                    className="bx--image-with-caption"
-                                                    data-autoid="dds--image-with-caption"
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
                                                   >
-                                                    <Image
-                                                      alt="Image alt text"
-                                                      defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
-                                                      sources={
-                                                        Array [
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__media"
+                                                >
+                                                  <ImageWithCaption
+                                                    copy=""
+                                                    heading="Mauris iaculis eget dolor nec hendrerit."
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                        "sources": Array [
                                                           Object {
                                                             "breakpoint": 320,
                                                             "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
@@ -3802,216 +3776,216 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             "breakpoint": 672,
                                                             "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
                                                           },
-                                                        ]
+                                                        ],
                                                       }
-                                                    >
-                                                      <div
-                                                        className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
-                                                      >
-                                                        <picture>
-                                                          <source
-                                                            key="0"
-                                                            media="(min-width: 672px )"
-                                                            srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
-                                                          />
-                                                          <source
-                                                            key="1"
-                                                            media="(min-width: 400px )"
-                                                            srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
-                                                          />
-                                                          <source
-                                                            key="2"
-                                                            media="(min-width: 320px )"
-                                                            srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
-                                                          />
-                                                          <img
-                                                            alt="Image alt text"
-                                                            className="bx--image__img"
-                                                            src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
-                                                          />
-                                                        </picture>
-                                                      </div>
-                                                    </Image>
-                                                    <p
-                                                      className="bx--image__caption--inverse"
-                                                      data-autoid="dds--image__caption"
-                                                    >
-                                                      Mauris iaculis eget dolor nec hendrerit.
-                                                    </p>
-                                                  </div>
-                                                </ImageWithCaption>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div
-                                            className="bx--content-group__cta-row"
-                                            data-autoid="dds--content-group__cta"
-                                          >
-                                            <CTA
-                                              copy="Lorem Ipsum dolor sit"
-                                              customClassName="bx--content-group__cta"
-                                              href="https://example.com"
-                                              style="text"
-                                              type="local"
-                                            >
-                                              <div
-                                                className="bx--content-group__cta"
-                                              >
-                                                <TextCTA
-                                                  copy="Lorem Ipsum dolor sit"
-                                                  formatCTAcopy={[Function]}
-                                                  href="https://example.com"
-                                                  openLightBox={[Function]}
-                                                  renderLightBox={false}
-                                                  style="text"
-                                                  type="local"
-                                                  videoTitle={
-                                                    Array [
-                                                      Object {
-                                                        "duration": "",
-                                                        "key": 0,
-                                                        "title": "",
-                                                      },
-                                                    ]
-                                                  }
-                                                >
-                                                  <LinkWithIcon
-                                                    href="https://example.com"
-                                                    onClick={[Function]}
-                                                    target={null}
+                                                    }
+                                                    inverse={false}
+                                                    lightbox={false}
                                                   >
                                                     <div
-                                                      className="bx--link-with-icon__container"
-                                                      data-autoid="dds--link-with-icon"
+                                                      className="bx--image-with-caption"
+                                                      data-autoid="dds--image-with-caption"
                                                     >
-                                                      <Link
-                                                        className="bx--link-with-icon"
-                                                        href="https://example.com"
-                                                        onClick={[Function]}
-                                                        target={null}
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        sources={
+                                                          Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ]
+                                                        }
                                                       >
-                                                        <a
-                                                          className="bx--link bx--link-with-icon"
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <picture>
+                                                            <source
+                                                              key="0"
+                                                              media="(min-width: 672px )"
+                                                              srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                            />
+                                                            <source
+                                                              key="1"
+                                                              media="(min-width: 400px )"
+                                                              srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                            />
+                                                            <source
+                                                              key="2"
+                                                              media="(min-width: 320px )"
+                                                              srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                            />
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img"
+                                                              src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                      <p
+                                                        className="bx--image__caption--inverse"
+                                                        data-autoid="dds--image__caption"
+                                                      >
+                                                        Mauris iaculis eget dolor nec hendrerit.
+                                                      </p>
+                                                    </div>
+                                                  </ImageWithCaption>
+                                                </div>
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="bx--content-group__cta-row"
+                                              data-autoid="dds--content-group__cta"
+                                            >
+                                              <CTA
+                                                copy="Lorem Ipsum dolor sit"
+                                                customClassName="bx--content-group__cta"
+                                                href="https://example.com"
+                                                style="text"
+                                                type="local"
+                                              >
+                                                <div
+                                                  className="bx--content-group__cta"
+                                                >
+                                                  <TextCTA
+                                                    copy="Lorem Ipsum dolor sit"
+                                                    formatCTAcopy={[Function]}
+                                                    href="https://example.com"
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="text"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "duration": "",
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
+                                                  >
+                                                    <LinkWithIcon
+                                                      href="https://example.com"
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <div
+                                                        className="bx--link-with-icon__container"
+                                                        data-autoid="dds--link-with-icon"
+                                                      >
+                                                        <Link
+                                                          className="bx--link-with-icon"
                                                           href="https://example.com"
                                                           onClick={[Function]}
                                                           target={null}
                                                         >
-                                                          <span>
-                                                            Lorem Ipsum dolor sit
-                                                          </span>
-                                                          <ForwardRef(ArrowRight20)>
-                                                            <Icon
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <svg
-                                                                aria-hidden={true}
-                                                                focusable="false"
+                                                          <a
+                                                            className="bx--link bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <span>
+                                                              Lorem Ipsum dolor sit
+                                                            </span>
+                                                            <ForwardRef(ArrowRight20)>
+                                                              <Icon
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 viewBox="0 0 20 20"
                                                                 width={20}
                                                                 xmlns="http://www.w3.org/2000/svg"
                                                               >
-                                                                <path
-                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                />
-                                                              </svg>
-                                                            </Icon>
-                                                          </ForwardRef(ArrowRight20)>
-                                                        </a>
-                                                      </Link>
-                                                    </div>
-                                                  </LinkWithIcon>
-                                                </TextCTA>
-                                              </div>
-                                            </CTA>
-                                          </div>
-                                        </div>
-                                      </ContentGroup>
-                                      <ContentGroup
-                                        cta={false}
-                                        heading="A scelerisque purus semper eget duis at tellus."
-                                        key="1"
-                                      >
-                                        <div
-                                          className="bx--content-group"
-                                          data-autoid="dds--content-group"
-                                        >
-                                          <h3
-                                            className="bx--content-group__title"
-                                            data-autoid="dds--content-group__title"
-                                          >
-                                            A scelerisque purus semper eget duis at tellus.
-                                          </h3>
-                                          <div
-                                            className="bx--content-group__col bx--content-group__children"
-                                            data-autoid="dds--content-group__children"
-                                          >
-                                            <div
-                                              data-autoid="dds--content-block-segmented__content-group"
-                                            >
-                                              <ContentItem
-                                                copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
-                                                key="1"
-                                              >
-                                                <div
-                                                  className="bx--content-item"
-                                                  data-autoid="dds--content-item"
-                                                >
-                                                  <div
-                                                    className="bx--content-item__copy"
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
-                                                      }
-                                                    }
-                                                    data-autoid="dds--content-item__copy"
-                                                  />
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(ArrowRight20)>
+                                                          </a>
+                                                        </Link>
+                                                      </div>
+                                                    </LinkWithIcon>
+                                                  </TextCTA>
                                                 </div>
-                                              </ContentItem>
+                                              </CTA>
+                                            </div>
+                                          </div>
+                                        </ContentGroup>
+                                        <ContentGroup
+                                          cta={false}
+                                          heading="A scelerisque purus semper eget duis at tellus."
+                                          key="1"
+                                        >
+                                          <div
+                                            className="bx--content-group"
+                                            data-autoid="dds--content-group"
+                                          >
+                                            <h3
+                                              className="bx--content-group__title"
+                                              data-autoid="dds--content-group__title"
+                                            >
+                                              A scelerisque purus semper eget duis at tellus.
+                                            </h3>
+                                            <div
+                                              className="bx--content-group__col bx--content-group__children"
+                                              data-autoid="dds--content-group__children"
+                                            >
                                               <div
-                                                data-autoid="dds--content-block-segmented__media"
+                                                data-autoid="dds--content-block-segmented__content-group"
                                               >
-                                                <ImageWithCaption
-                                                  copy=""
-                                                  heading="Mauris iaculis eget dolor nec hendrerit."
-                                                  image={
-                                                    Object {
-                                                      "alt": "Image alt text",
-                                                      "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                                      "sources": Array [
-                                                        Object {
-                                                          "breakpoint": 320,
-                                                          "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
-                                                        },
-                                                        Object {
-                                                          "breakpoint": 400,
-                                                          "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
-                                                        },
-                                                        Object {
-                                                          "breakpoint": 672,
-                                                          "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
-                                                        },
-                                                      ],
-                                                    }
-                                                  }
-                                                  inverse={false}
-                                                  lightbox={false}
+                                                <ContentItem
+                                                  copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                  key="1"
                                                 >
                                                   <div
-                                                    className="bx--image-with-caption"
-                                                    data-autoid="dds--image-with-caption"
+                                                    className="bx--content-item"
+                                                    data-autoid="dds--content-item"
                                                   >
-                                                    <Image
-                                                      alt="Image alt text"
-                                                      defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
-                                                      sources={
-                                                        Array [
+                                                    <div
+                                                      className="bx--content-item__copy"
+                                                      dangerouslySetInnerHTML={
+                                                        Object {
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                        }
+                                                      }
+                                                      data-autoid="dds--content-item__copy"
+                                                    />
+                                                  </div>
+                                                </ContentItem>
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__media"
+                                                >
+                                                  <ImageWithCaption
+                                                    copy=""
+                                                    heading="Mauris iaculis eget dolor nec hendrerit."
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                        "sources": Array [
                                                           Object {
                                                             "breakpoint": 320,
                                                             "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
@@ -4024,174 +3998,187 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             "breakpoint": 672,
                                                             "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
                                                           },
-                                                        ]
+                                                        ],
                                                       }
+                                                    }
+                                                    inverse={false}
+                                                    lightbox={false}
+                                                  >
+                                                    <div
+                                                      className="bx--image-with-caption"
+                                                      data-autoid="dds--image-with-caption"
                                                     >
-                                                      <div
-                                                        className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                        sources={
+                                                          Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ]
+                                                        }
                                                       >
-                                                        <picture>
-                                                          <source
-                                                            key="0"
-                                                            media="(min-width: 672px )"
-                                                            srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
-                                                          />
-                                                          <source
-                                                            key="1"
-                                                            media="(min-width: 400px )"
-                                                            srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
-                                                          />
-                                                          <source
-                                                            key="2"
-                                                            media="(min-width: 320px )"
-                                                            srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
-                                                          />
-                                                          <img
-                                                            alt="Image alt text"
-                                                            className="bx--image__img"
-                                                            src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
-                                                          />
-                                                        </picture>
-                                                      </div>
-                                                    </Image>
-                                                    <p
-                                                      className="bx--image__caption--inverse"
-                                                      data-autoid="dds--image__caption"
-                                                    >
-                                                      Mauris iaculis eget dolor nec hendrerit.
-                                                    </p>
-                                                  </div>
-                                                </ImageWithCaption>
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <picture>
+                                                            <source
+                                                              key="0"
+                                                              media="(min-width: 672px )"
+                                                              srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                            />
+                                                            <source
+                                                              key="1"
+                                                              media="(min-width: 400px )"
+                                                              srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                            />
+                                                            <source
+                                                              key="2"
+                                                              media="(min-width: 320px )"
+                                                              srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                            />
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img"
+                                                              src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                      <p
+                                                        className="bx--image__caption--inverse"
+                                                        data-autoid="dds--image__caption"
+                                                      >
+                                                        Mauris iaculis eget dolor nec hendrerit.
+                                                      </p>
+                                                    </div>
+                                                  </ImageWithCaption>
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
-                                        </div>
-                                      </ContentGroup>
-                                    </div>
-                                    <div
-                                      className="bx--content-block__cta-row"
-                                      data-autoid="dds--content-block__cta"
-                                    >
-                                      <CTA
-                                        copy=""
-                                        customClassName="bx--content-block__cta bx--content-block__cta-col"
-                                        disableImage={true}
-                                        href=""
-                                        media={
-                                          Object {
-                                            "src": "0_uka1msg4",
-                                            "type": "video",
-                                          }
-                                        }
-                                        style="card"
-                                        type="video"
+                                        </ContentGroup>
+                                      </div>
+                                      <div
+                                        className="bx--content-block__cta-row"
+                                        data-autoid="dds--content-block__cta"
                                       >
-                                        <div
-                                          aria-label=""
-                                          className="bx--content-block__cta bx--content-block__cta-col"
-                                          role="region"
+                                        <CTA
+                                          copy=""
+                                          customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                          disableImage={true}
+                                          href=""
+                                          media={
+                                            Object {
+                                              "src": "0_uka1msg4",
+                                              "type": "video",
+                                            }
+                                          }
+                                          style="card"
+                                          type="video"
                                         >
-                                          <CardCTA
-                                            copy=""
-                                            cta={null}
-                                            disableImage={true}
-                                            href=""
-                                            media={
-                                              Object {
-                                                "src": "0_uka1msg4",
-                                                "type": "video",
-                                              }
-                                            }
-                                            openLightBox={[Function]}
-                                            renderLightBox={false}
-                                            style="card"
-                                            type="video"
-                                            videoTitle={
-                                              Array [
-                                                Object {
-                                                  "duration": "",
-                                                  "key": 0,
-                                                  "title": "",
-                                                },
-                                              ]
-                                            }
+                                          <div
+                                            aria-label=""
+                                            className="bx--content-block__cta bx--content-block__cta-col"
+                                            role="region"
                                           >
-                                            <CardLink
-                                              card={
+                                            <CardCTA
+                                              copy=""
+                                              cta={null}
+                                              disableImage={true}
+                                              href=""
+                                              media={
                                                 Object {
-                                                  "copy": "",
-                                                  "cta": Object {
-                                                    "copy": "",
-                                                    "href": "#",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
-                                                      },
-                                                    },
-                                                  },
-                                                  "handleClick": [Function],
-                                                  "href": "",
-                                                  "image": undefined,
-                                                  "media": Object {
-                                                    "src": "0_uka1msg4",
-                                                    "type": "video",
-                                                  },
+                                                  "src": "0_uka1msg4",
+                                                  "type": "video",
                                                 }
                                               }
-                                              customClassName="bx--card__video"
-                                              disabled={false}
+                                              openLightBox={[Function]}
+                                              renderLightBox={false}
+                                              style="card"
+                                              type="video"
+                                              videoTitle={
+                                                Array [
+                                                  Object {
+                                                    "duration": "",
+                                                    "key": 0,
+                                                    "title": "",
+                                                  },
+                                                ]
+                                              }
                                             >
-                                              <Card
-                                                copy=""
-                                                cta={
+                                              <CardLink
+                                                card={
                                                   Object {
                                                     "copy": "",
-                                                    "href": "#",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
+                                                    "cta": Object {
+                                                      "copy": "",
+                                                      "href": "#",
+                                                      "icon": Object {
+                                                        "src": Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        },
                                                       },
+                                                    },
+                                                    "handleClick": [Function],
+                                                    "href": "",
+                                                    "image": undefined,
+                                                    "media": Object {
+                                                      "src": "0_uka1msg4",
+                                                      "type": "video",
                                                     },
                                                   }
                                                 }
-                                                customClassName="bx--card__CTA bx--card__video"
+                                                customClassName="bx--card__video"
                                                 disabled={false}
-                                                handleClick={[Function]}
-                                                href=""
-                                                media={
-                                                  Object {
-                                                    "src": "0_uka1msg4",
-                                                    "type": "video",
-                                                  }
-                                                }
-                                                type="link"
                                               >
-                                                <ClickableTile
-                                                  className="bx--card bx--card--link bx--card__CTA bx--card__video"
-                                                  clicked={false}
-                                                  data-autoid="dds--card"
+                                                <Card
+                                                  copy=""
+                                                  cta={
+                                                    Object {
+                                                      "copy": "",
+                                                      "href": "#",
+                                                      "icon": Object {
+                                                        "src": Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        },
+                                                      },
+                                                    }
+                                                  }
+                                                  customClassName="bx--card__CTA bx--card__video"
                                                   disabled={false}
                                                   handleClick={[Function]}
-                                                  handleKeyDown={[Function]}
                                                   href=""
-                                                  light={false}
                                                   media={
                                                     Object {
                                                       "src": "0_uka1msg4",
                                                       "type": "video",
                                                     }
                                                   }
-                                                  onClick={[Function]}
-                                                  target={null}
+                                                  type="link"
                                                 >
-                                                  <a
-                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA bx--card__video"
+                                                  <ClickableTile
+                                                    className="bx--card bx--card--link bx--card__CTA bx--card__video"
+                                                    clicked={false}
                                                     data-autoid="dds--card"
                                                     disabled={false}
+                                                    handleClick={[Function]}
+                                                    handleKeyDown={[Function]}
                                                     href=""
+                                                    light={false}
                                                     media={
                                                       Object {
                                                         "src": "0_uka1msg4",
@@ -4199,42 +4186,40 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       }
                                                     }
                                                     onClick={[Function]}
-                                                    onKeyDown={[Function]}
                                                     target={null}
                                                   >
-                                                    <div
-                                                      className="bx--card__wrapper"
+                                                    <a
+                                                      className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA bx--card__video"
+                                                      data-autoid="dds--card"
+                                                      disabled={false}
+                                                      href=""
+                                                      media={
+                                                        Object {
+                                                          "src": "0_uka1msg4",
+                                                          "type": "video",
+                                                        }
+                                                      }
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      target={null}
                                                     >
                                                       <div
-                                                        className="bx--card__footer"
+                                                        className="bx--card__wrapper"
                                                       >
-                                                        <ForwardRef(PlayOutline20)
-                                                          className="bx--card__cta"
-                                                          src={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "render": [Function],
-                                                            }
-                                                          }
+                                                        <div
+                                                          className="bx--card__footer"
                                                         >
-                                                          <Icon
+                                                          <ForwardRef(PlayOutline20)
                                                             className="bx--card__cta"
-                                                            height={20}
-                                                            preserveAspectRatio="xMidYMid meet"
                                                             src={
                                                               Object {
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "render": [Function],
                                                               }
                                                             }
-                                                            viewBox="0 0 32 32"
-                                                            width={20}
-                                                            xmlns="http://www.w3.org/2000/svg"
                                                           >
-                                                            <svg
-                                                              aria-hidden={true}
+                                                            <Icon
                                                               className="bx--card__cta"
-                                                              focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
                                                               src={
@@ -4247,1217 +4232,10 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               width={20}
                                                               xmlns="http://www.w3.org/2000/svg"
                                                             >
-                                                              <path
-                                                                d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
-                                                              />
-                                                              <path
-                                                                d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
-                                                              />
-                                                            </svg>
-                                                          </Icon>
-                                                        </ForwardRef(PlayOutline20)>
-                                                        <span />
-                                                      </div>
-                                                    </div>
-                                                  </a>
-                                                </ClickableTile>
-                                              </Card>
-                                            </CardLink>
-                                          </CardCTA>
-                                        </div>
-                                      </CTA>
-                                    </div>
-                                  </div>
-                                </ContentBlock>
-                              </div>
-                            </ContentBlockSegmented>
-                            <CalloutWithMedia
-                              copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
-                              heading="Mauris ultrices eros in cursus"
-                              mediaData={
-                                Object {
-                                  "src": "0_uka1msg4",
-                                  "type": "video",
-                                }
-                              }
-                              mediaType="video"
-                            >
-                              <div
-                                className="bx--callout-with-media"
-                                data-autoid="dds--callout-with-media"
-                              >
-                                <Callout>
-                                  <section
-                                    className="bx--callout__container"
-                                    data-autoid="dds--callout__container"
-                                  >
-                                    <div
-                                      className="bx--callout__column"
-                                      data-autoid="dds--callout__column"
-                                    >
-                                      <div
-                                        className="bx--callout__content"
-                                        data-autoid="dds--callout__content"
-                                      >
-                                        <ContentBlockSimple
-                                          copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
-                                          heading="Mauris ultrices eros in cursus"
-                                          inverse={true}
-                                          mediaData={
-                                            Object {
-                                              "src": "0_uka1msg4",
-                                              "type": "video",
-                                            }
-                                          }
-                                          mediaType="video"
-                                        >
-                                          <div
-                                            className="bx--content-block-simple"
-                                            data-autoid="dds--content-block-simple"
-                                          >
-                                            <ContentBlock
-                                              border={false}
-                                              heading="Mauris ultrices eros in cursus"
-                                              inverse={true}
-                                            >
-                                              <div
-                                                className="bx--content-block bx--content-block--inverse"
-                                                data-autoid="dds--content-block"
-                                              >
-                                                <div>
-                                                  <h2
-                                                    className="bx--content-block__heading"
-                                                    data-autoid="dds--content-block__heading"
-                                                  >
-                                                    Mauris ultrices eros in cursus
-                                                  </h2>
-                                                </div>
-                                                <div
-                                                  className="bx--content-block__children"
-                                                  data-autoid="dds--content-block__children"
-                                                >
-                                                  <div
-                                                    className="bx--content-block-simple__content"
-                                                  >
-                                                    <ContentItem
-                                                      copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
-                                                      inverse={true}
-                                                    >
-                                                      <div
-                                                        className="bx--content-item bx--content-item--inverse"
-                                                        data-autoid="dds--content-item"
-                                                      >
-                                                        <div
-                                                          className="bx--content-item__copy"
-                                                          dangerouslySetInnerHTML={
-                                                            Object {
-                                                              "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p>",
-                                                            }
-                                                          }
-                                                          data-autoid="dds--content-item__copy"
-                                                        />
-                                                      </div>
-                                                    </ContentItem>
-                                                    <div
-                                                      data-autoid="dds--content-block-simple__media"
-                                                    >
-                                                      <VideoPlayer
-                                                        autoPlay={false}
-                                                        inverse={true}
-                                                        src="0_uka1msg4"
-                                                        type="video"
-                                                      >
-                                                        <div
-                                                          aria-label=" (1:00)"
-                                                          className="bx--video-player bx--video-player--inverse"
-                                                        >
-                                                          <div
-                                                            className="bx--video-player__video-container"
-                                                            data-autoid="dds--video-player__video-undefined"
-                                                          >
-                                                            <div
-                                                              className="bx--video-player__video"
-                                                              id="bx--video-player__video-undefined"
-                                                            >
-                                                              <VideoImageOverlay
-                                                                embedVideo={[Function]}
-                                                                videoData={
-                                                                  Object {
-                                                                    "description": "",
-                                                                    "name": "",
-                                                                  }
-                                                                }
-                                                              >
-                                                                <button
-                                                                  className="bx--video-player__image-overlay"
-                                                                  data-autoid="dds--video-player__image-overlay"
-                                                                  onClick={[Function]}
-                                                                >
-                                                                  <Image
-                                                                    alt=""
-                                                                    defaultSrc="https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320"
-                                                                    icon={[Function]}
-                                                                  />
-                                                                </button>
-                                                              </VideoImageOverlay>
-                                                            </div>
-                                                          </div>
-                                                        </div>
-                                                      </VideoPlayer>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </div>
-                                            </ContentBlock>
-                                          </div>
-                                        </ContentBlockSimple>
-                                      </div>
-                                    </div>
-                                  </section>
-                                </Callout>
-                              </div>
-                            </CalloutWithMedia>
-                            <a
-                              data-title="Tincidunt ornare massa"
-                              name="section-4"
-                            />
-                            <ContentGroupHorizontal
-                              heading="Tincidunt ornare massa"
-                              items={
-                                Array [
-                                  Object {
-                                    "copy": "Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin.",
-                                    "cta": Object {
-                                      "items": Array [
-                                        Object {
-                                          "copy": "Link text",
-                                          "href": "https://example.com",
-                                          "type": "local",
-                                        },
-                                        Object {
-                                          "copy": "External link text",
-                                          "href": "https://example.com",
-                                          "type": "external",
-                                        },
-                                      ],
-                                    },
-                                    "eyebrow": "Lorem ipsum",
-                                    "heading": "Aliquam condimentum",
-                                  },
-                                  Object {
-                                    "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
-                                    "cta": Object {
-                                      "items": Array [
-                                        Object {
-                                          "copy": "Link text",
-                                          "href": "https://example.com",
-                                          "type": "local",
-                                        },
-                                        Object {
-                                          "copy": "External link text",
-                                          "href": "https://example.com",
-                                          "type": "external",
-                                        },
-                                      ],
-                                    },
-                                    "eyebrow": "Lorem ipsum",
-                                    "heading": "Aliquam condimentum",
-                                  },
-                                ]
-                              }
-                            >
-                              <div
-                                className="bx--content-group-horizontal"
-                                data-autoid="dds--content-group-horizontal"
-                              >
-                                <ContentBlock
-                                  border={true}
-                                  heading="Tincidunt ornare massa"
-                                >
-                                  <div
-                                    className="bx--content-block"
-                                    data-autoid="dds--content-block"
-                                  >
-                                    <div>
-                                      <h2
-                                        className="bx--content-block__heading"
-                                        data-autoid="dds--content-block__heading"
-                                      >
-                                        Tincidunt ornare massa
-                                      </h2>
-                                    </div>
-                                    <div
-                                      className="bx--content-block__children"
-                                      data-autoid="dds--content-block__children"
-                                    >
-                                      <ContentItemHorizontal
-                                        copy="Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin."
-                                        cta={
-                                          Object {
-                                            "items": Array [
-                                              Object {
-                                                "copy": "Link text",
-                                                "href": "https://example.com",
-                                                "type": "local",
-                                              },
-                                              Object {
-                                                "copy": "External link text",
-                                                "href": "https://example.com",
-                                                "type": "external",
-                                              },
-                                            ],
-                                          }
-                                        }
-                                        eyebrow="Lorem ipsum"
-                                        heading="Aliquam condimentum"
-                                        key="0"
-                                      >
-                                        <div
-                                          className="bx--content-item-horizontal__item bx"
-                                          data-autoid="dds--content-item-horizontal__item"
-                                        >
-                                          <div
-                                            className="bx--content-item-horizontal__row"
-                                          >
-                                            <div
-                                              className="bx--content-item-horizontal__col"
-                                            >
-                                              <p
-                                                className="bx--content-item-horizontal__item--eyebrow"
-                                                data-autoid="dds--content-item-horizontal__item--eyebrow"
-                                              >
-                                                Lorem ipsum
-                                              </p>
-                                              <h3
-                                                className="bx--content-item-horizontal__item--heading"
-                                                data-autoid="dds--content-item-horizontal__item--heading"
-                                              >
-                                                Aliquam condimentum
-                                              </h3>
-                                            </div>
-                                            <div
-                                              className="bx--content-item-horizontal__col"
-                                            >
-                                              <div
-                                                className="bx--content-item-horizontal__item--copy"
-                                                dangerouslySetInnerHTML={
-                                                  Object {
-                                                    "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> sellus at elit sollicitudin.</p>",
-                                                  }
-                                                }
-                                                data-autoid="dds--content-item-horizontal__item--copy"
-                                              />
-                                              <div
-                                                className="bx--content-item-horizontal__item--cta"
-                                                data-autoid="dds--content-item-horizontal__item--cta"
-                                              >
-                                                <LinkList
-                                                  items={
-                                                    Array [
-                                                      Object {
-                                                        "copy": "Link text",
-                                                        "href": "https://example.com",
-                                                        "type": "local",
-                                                      },
-                                                      Object {
-                                                        "copy": "External link text",
-                                                        "href": "https://example.com",
-                                                        "type": "external",
-                                                      },
-                                                    ]
-                                                  }
-                                                  style="vertical"
-                                                >
-                                                  <div
-                                                    className="bx--link-list"
-                                                    data-autoid="dds--link-list"
-                                                  >
-                                                    <ul
-                                                      className="bx--link-list__list bx--link-list__list--vertical"
-                                                    >
-                                                      <li
-                                                        className="bx--link-list__list__CTA bx--link-list__list--local"
-                                                        key="0"
-                                                      >
-                                                        <CTA
-                                                          copy="Link text"
-                                                          disableImage={true}
-                                                          href="https://example.com"
-                                                          style="text"
-                                                          type="local"
-                                                        >
-                                                          <div>
-                                                            <TextCTA
-                                                              copy="Link text"
-                                                              disableImage={true}
-                                                              formatCTAcopy={[Function]}
-                                                              href="https://example.com"
-                                                              openLightBox={[Function]}
-                                                              renderLightBox={false}
-                                                              style="text"
-                                                              type="local"
-                                                              videoTitle={
-                                                                Array [
-                                                                  Object {
-                                                                    "duration": "",
-                                                                    "key": 0,
-                                                                    "title": "",
-                                                                  },
-                                                                ]
-                                                              }
-                                                            >
-                                                              <LinkWithIcon
-                                                                href="https://example.com"
-                                                                onClick={[Function]}
-                                                                target={null}
-                                                              >
-                                                                <div
-                                                                  className="bx--link-with-icon__container"
-                                                                  data-autoid="dds--link-with-icon"
-                                                                >
-                                                                  <Link
-                                                                    className="bx--link-with-icon"
-                                                                    href="https://example.com"
-                                                                    onClick={[Function]}
-                                                                    target={null}
-                                                                  >
-                                                                    <a
-                                                                      className="bx--link bx--link-with-icon"
-                                                                      href="https://example.com"
-                                                                      onClick={[Function]}
-                                                                      target={null}
-                                                                    >
-                                                                      <span>
-                                                                        Link text
-                                                                      </span>
-                                                                      <ForwardRef(ArrowRight20)>
-                                                                        <Icon
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 20 20"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden={true}
-                                                                            focusable="false"
-                                                                            height={20}
-                                                                            preserveAspectRatio="xMidYMid meet"
-                                                                            viewBox="0 0 20 20"
-                                                                            width={20}
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                            />
-                                                                          </svg>
-                                                                        </Icon>
-                                                                      </ForwardRef(ArrowRight20)>
-                                                                    </a>
-                                                                  </Link>
-                                                                </div>
-                                                              </LinkWithIcon>
-                                                            </TextCTA>
-                                                          </div>
-                                                        </CTA>
-                                                      </li>
-                                                      <li
-                                                        className="bx--link-list__list__CTA bx--link-list__list--external"
-                                                        key="1"
-                                                      >
-                                                        <CTA
-                                                          copy="External link text"
-                                                          disableImage={true}
-                                                          href="https://example.com"
-                                                          style="text"
-                                                          type="external"
-                                                        >
-                                                          <div>
-                                                            <TextCTA
-                                                              copy="External link text"
-                                                              disableImage={true}
-                                                              formatCTAcopy={[Function]}
-                                                              href="https://example.com"
-                                                              openLightBox={[Function]}
-                                                              renderLightBox={false}
-                                                              style="text"
-                                                              type="external"
-                                                              videoTitle={
-                                                                Array [
-                                                                  Object {
-                                                                    "duration": "",
-                                                                    "key": 0,
-                                                                    "title": "",
-                                                                  },
-                                                                ]
-                                                              }
-                                                            >
-                                                              <LinkWithIcon
-                                                                href="https://example.com"
-                                                                onClick={[Function]}
-                                                                target="_blank"
-                                                              >
-                                                                <div
-                                                                  className="bx--link-with-icon__container"
-                                                                  data-autoid="dds--link-with-icon"
-                                                                >
-                                                                  <Link
-                                                                    className="bx--link-with-icon"
-                                                                    href="https://example.com"
-                                                                    onClick={[Function]}
-                                                                    target="_blank"
-                                                                  >
-                                                                    <a
-                                                                      className="bx--link bx--link-with-icon"
-                                                                      href="https://example.com"
-                                                                      onClick={[Function]}
-                                                                      target="_blank"
-                                                                    >
-                                                                      <span>
-                                                                        External link text
-                                                                      </span>
-                                                                      <ForwardRef(Launch20)>
-                                                                        <Icon
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 32 32"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden={true}
-                                                                            focusable="false"
-                                                                            height={20}
-                                                                            preserveAspectRatio="xMidYMid meet"
-                                                                            viewBox="0 0 32 32"
-                                                                            width={20}
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                                            />
-                                                                            <path
-                                                                              d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
-                                                                            />
-                                                                          </svg>
-                                                                        </Icon>
-                                                                      </ForwardRef(Launch20)>
-                                                                    </a>
-                                                                  </Link>
-                                                                </div>
-                                                              </LinkWithIcon>
-                                                            </TextCTA>
-                                                          </div>
-                                                        </CTA>
-                                                      </li>
-                                                    </ul>
-                                                  </div>
-                                                </LinkList>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </ContentItemHorizontal>
-                                      <ContentItemHorizontal
-                                        copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
-                                        cta={
-                                          Object {
-                                            "items": Array [
-                                              Object {
-                                                "copy": "Link text",
-                                                "href": "https://example.com",
-                                                "type": "local",
-                                              },
-                                              Object {
-                                                "copy": "External link text",
-                                                "href": "https://example.com",
-                                                "type": "external",
-                                              },
-                                            ],
-                                          }
-                                        }
-                                        eyebrow="Lorem ipsum"
-                                        heading="Aliquam condimentum"
-                                        key="1"
-                                      >
-                                        <div
-                                          className="bx--content-item-horizontal__item bx"
-                                          data-autoid="dds--content-item-horizontal__item"
-                                        >
-                                          <div
-                                            className="bx--content-item-horizontal__row"
-                                          >
-                                            <div
-                                              className="bx--content-item-horizontal__col"
-                                            >
-                                              <p
-                                                className="bx--content-item-horizontal__item--eyebrow"
-                                                data-autoid="dds--content-item-horizontal__item--eyebrow"
-                                              >
-                                                Lorem ipsum
-                                              </p>
-                                              <h3
-                                                className="bx--content-item-horizontal__item--heading"
-                                                data-autoid="dds--content-item-horizontal__item--heading"
-                                              >
-                                                Aliquam condimentum
-                                              </h3>
-                                            </div>
-                                            <div
-                                              className="bx--content-item-horizontal__col"
-                                            >
-                                              <div
-                                                className="bx--content-item-horizontal__item--copy"
-                                                dangerouslySetInnerHTML={
-                                                  Object {
-                                                    "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
-                                                  }
-                                                }
-                                                data-autoid="dds--content-item-horizontal__item--copy"
-                                              />
-                                              <div
-                                                className="bx--content-item-horizontal__item--cta"
-                                                data-autoid="dds--content-item-horizontal__item--cta"
-                                              >
-                                                <LinkList
-                                                  items={
-                                                    Array [
-                                                      Object {
-                                                        "copy": "Link text",
-                                                        "href": "https://example.com",
-                                                        "type": "local",
-                                                      },
-                                                      Object {
-                                                        "copy": "External link text",
-                                                        "href": "https://example.com",
-                                                        "type": "external",
-                                                      },
-                                                    ]
-                                                  }
-                                                  style="vertical"
-                                                >
-                                                  <div
-                                                    className="bx--link-list"
-                                                    data-autoid="dds--link-list"
-                                                  >
-                                                    <ul
-                                                      className="bx--link-list__list bx--link-list__list--vertical"
-                                                    >
-                                                      <li
-                                                        className="bx--link-list__list__CTA bx--link-list__list--local"
-                                                        key="0"
-                                                      >
-                                                        <CTA
-                                                          copy="Link text"
-                                                          disableImage={true}
-                                                          href="https://example.com"
-                                                          style="text"
-                                                          type="local"
-                                                        >
-                                                          <div>
-                                                            <TextCTA
-                                                              copy="Link text"
-                                                              disableImage={true}
-                                                              formatCTAcopy={[Function]}
-                                                              href="https://example.com"
-                                                              openLightBox={[Function]}
-                                                              renderLightBox={false}
-                                                              style="text"
-                                                              type="local"
-                                                              videoTitle={
-                                                                Array [
-                                                                  Object {
-                                                                    "duration": "",
-                                                                    "key": 0,
-                                                                    "title": "",
-                                                                  },
-                                                                ]
-                                                              }
-                                                            >
-                                                              <LinkWithIcon
-                                                                href="https://example.com"
-                                                                onClick={[Function]}
-                                                                target={null}
-                                                              >
-                                                                <div
-                                                                  className="bx--link-with-icon__container"
-                                                                  data-autoid="dds--link-with-icon"
-                                                                >
-                                                                  <Link
-                                                                    className="bx--link-with-icon"
-                                                                    href="https://example.com"
-                                                                    onClick={[Function]}
-                                                                    target={null}
-                                                                  >
-                                                                    <a
-                                                                      className="bx--link bx--link-with-icon"
-                                                                      href="https://example.com"
-                                                                      onClick={[Function]}
-                                                                      target={null}
-                                                                    >
-                                                                      <span>
-                                                                        Link text
-                                                                      </span>
-                                                                      <ForwardRef(ArrowRight20)>
-                                                                        <Icon
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 20 20"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden={true}
-                                                                            focusable="false"
-                                                                            height={20}
-                                                                            preserveAspectRatio="xMidYMid meet"
-                                                                            viewBox="0 0 20 20"
-                                                                            width={20}
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                            />
-                                                                          </svg>
-                                                                        </Icon>
-                                                                      </ForwardRef(ArrowRight20)>
-                                                                    </a>
-                                                                  </Link>
-                                                                </div>
-                                                              </LinkWithIcon>
-                                                            </TextCTA>
-                                                          </div>
-                                                        </CTA>
-                                                      </li>
-                                                      <li
-                                                        className="bx--link-list__list__CTA bx--link-list__list--external"
-                                                        key="1"
-                                                      >
-                                                        <CTA
-                                                          copy="External link text"
-                                                          disableImage={true}
-                                                          href="https://example.com"
-                                                          style="text"
-                                                          type="external"
-                                                        >
-                                                          <div>
-                                                            <TextCTA
-                                                              copy="External link text"
-                                                              disableImage={true}
-                                                              formatCTAcopy={[Function]}
-                                                              href="https://example.com"
-                                                              openLightBox={[Function]}
-                                                              renderLightBox={false}
-                                                              style="text"
-                                                              type="external"
-                                                              videoTitle={
-                                                                Array [
-                                                                  Object {
-                                                                    "duration": "",
-                                                                    "key": 0,
-                                                                    "title": "",
-                                                                  },
-                                                                ]
-                                                              }
-                                                            >
-                                                              <LinkWithIcon
-                                                                href="https://example.com"
-                                                                onClick={[Function]}
-                                                                target="_blank"
-                                                              >
-                                                                <div
-                                                                  className="bx--link-with-icon__container"
-                                                                  data-autoid="dds--link-with-icon"
-                                                                >
-                                                                  <Link
-                                                                    className="bx--link-with-icon"
-                                                                    href="https://example.com"
-                                                                    onClick={[Function]}
-                                                                    target="_blank"
-                                                                  >
-                                                                    <a
-                                                                      className="bx--link bx--link-with-icon"
-                                                                      href="https://example.com"
-                                                                      onClick={[Function]}
-                                                                      target="_blank"
-                                                                    >
-                                                                      <span>
-                                                                        External link text
-                                                                      </span>
-                                                                      <ForwardRef(Launch20)>
-                                                                        <Icon
-                                                                          height={20}
-                                                                          preserveAspectRatio="xMidYMid meet"
-                                                                          viewBox="0 0 32 32"
-                                                                          width={20}
-                                                                          xmlns="http://www.w3.org/2000/svg"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden={true}
-                                                                            focusable="false"
-                                                                            height={20}
-                                                                            preserveAspectRatio="xMidYMid meet"
-                                                                            viewBox="0 0 32 32"
-                                                                            width={20}
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
-                                                                            />
-                                                                            <path
-                                                                              d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
-                                                                            />
-                                                                          </svg>
-                                                                        </Icon>
-                                                                      </ForwardRef(Launch20)>
-                                                                    </a>
-                                                                  </Link>
-                                                                </div>
-                                                              </LinkWithIcon>
-                                                            </TextCTA>
-                                                          </div>
-                                                        </CTA>
-                                                      </li>
-                                                    </ul>
-                                                  </div>
-                                                </LinkList>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </ContentItemHorizontal>
-                                    </div>
-                                    <HorizontalRule>
-                                      <hr
-                                        className="bx--hr"
-                                        data-autoid="dds--hr"
-                                      />
-                                    </HorizontalRule>
-                                  </div>
-                                </ContentBlock>
-                              </div>
-                            </ContentGroupHorizontal>
-                            <a
-                              data-title="Lobortis elementum nibh tellus"
-                              name="section-5"
-                            />
-                            <LogoGrid
-                              ctaCopy="Amet justo donec"
-                              ctaHref="https://www.example.com"
-                              heading="Lobortis elementum nibh tellus"
-                              logosGroup={
-                                Array [
-                                  Object {
-                                    "altText": "Image alt text",
-                                    "href": "http://example.com/",
-                                    "imgSrc": "https://dummyimage.com/140x140",
-                                    "title": "Company A",
-                                  },
-                                  Object {
-                                    "altText": "Image alt text",
-                                    "href": "http://example.com/",
-                                    "imgSrc": "https://dummyimage.com/140x140",
-                                    "title": "Company B",
-                                  },
-                                  Object {
-                                    "altText": "Image alt text",
-                                    "href": "http://example.com/",
-                                    "imgSrc": "https://dummyimage.com/140x140",
-                                    "title": "Company C",
-                                  },
-                                  Object {
-                                    "altText": "Image alt text",
-                                    "href": "http://example.com/",
-                                    "imgSrc": "https://dummyimage.com/140x140",
-                                    "title": "Company D",
-                                  },
-                                  Object {
-                                    "altText": "Image alt text",
-                                    "href": "http://example.com/",
-                                    "imgSrc": "https://dummyimage.com/140x140",
-                                    "title": "Company E",
-                                  },
-                                  Object {
-                                    "altText": "Image alt text",
-                                    "href": "http://example.com/",
-                                    "imgSrc": "https://dummyimage.com/140x140",
-                                    "title": "Company F",
-                                  },
-                                ]
-                              }
-                            >
-                              <section
-                                className="bx--logo-grid"
-                                data-autoid="dds--logo-grid bx--logo-grid"
-                              >
-                                <div
-                                  className="bx--logo-grid__container"
-                                >
-                                  <div
-                                    className="bx--logo-grid__wrapper bx--grid bx--grid--full-width"
-                                  >
-                                    <ContentBlock
-                                      border={false}
-                                      cta={
-                                        Object {
-                                          "copy": "Amet justo donec",
-                                          "cta": Object {
-                                            "href": "https://www.example.com",
-                                          },
-                                          "style": "card",
-                                          "type": "local",
-                                        }
-                                      }
-                                      heading="Lobortis elementum nibh tellus"
-                                    >
-                                      <div
-                                        className="bx--content-block"
-                                        data-autoid="dds--content-block"
-                                      >
-                                        <div>
-                                          <h2
-                                            className="bx--content-block__heading"
-                                            data-autoid="dds--content-block__heading"
-                                          >
-                                            Lobortis elementum nibh tellus
-                                          </h2>
-                                        </div>
-                                        <div
-                                          className="bx--content-block__children"
-                                          data-autoid="dds--content-block__children"
-                                        >
-                                          <div
-                                            className="bx--logo-grid__row"
-                                          >
-                                            <div
-                                              className="bx--logo-grid__col"
-                                              key="0"
-                                            >
-                                              <a
-                                                className="bx--logo-grid__link"
-                                                href="http://example.com/"
-                                              >
-                                                <div
-                                                  className="bx--logo-grid__logo"
-                                                >
-                                                  <Image
-                                                    alt="Image alt text"
-                                                    classname="bx--logo-grid_img"
-                                                    defaultSrc="https://dummyimage.com/140x140"
-                                                  >
-                                                    <div
-                                                      className="bx--image"
-                                                      data-autoid="dds--image__longdescription-"
-                                                    >
-                                                      <picture>
-                                                        <img
-                                                          alt="Image alt text"
-                                                          className="bx--image__img bx--logo-grid_img"
-                                                          src="https://dummyimage.com/140x140"
-                                                        />
-                                                      </picture>
-                                                    </div>
-                                                  </Image>
-                                                </div>
-                                              </a>
-                                            </div>
-                                            <div
-                                              className="bx--logo-grid__col"
-                                              key="1"
-                                            >
-                                              <a
-                                                className="bx--logo-grid__link"
-                                                href="http://example.com/"
-                                              >
-                                                <div
-                                                  className="bx--logo-grid__logo"
-                                                >
-                                                  <Image
-                                                    alt="Image alt text"
-                                                    classname="bx--logo-grid_img"
-                                                    defaultSrc="https://dummyimage.com/140x140"
-                                                  >
-                                                    <div
-                                                      className="bx--image"
-                                                      data-autoid="dds--image__longdescription-"
-                                                    >
-                                                      <picture>
-                                                        <img
-                                                          alt="Image alt text"
-                                                          className="bx--image__img bx--logo-grid_img"
-                                                          src="https://dummyimage.com/140x140"
-                                                        />
-                                                      </picture>
-                                                    </div>
-                                                  </Image>
-                                                </div>
-                                              </a>
-                                            </div>
-                                            <div
-                                              className="bx--logo-grid__col"
-                                              key="2"
-                                            >
-                                              <a
-                                                className="bx--logo-grid__link"
-                                                href="http://example.com/"
-                                              >
-                                                <div
-                                                  className="bx--logo-grid__logo"
-                                                >
-                                                  <Image
-                                                    alt="Image alt text"
-                                                    classname="bx--logo-grid_img"
-                                                    defaultSrc="https://dummyimage.com/140x140"
-                                                  >
-                                                    <div
-                                                      className="bx--image"
-                                                      data-autoid="dds--image__longdescription-"
-                                                    >
-                                                      <picture>
-                                                        <img
-                                                          alt="Image alt text"
-                                                          className="bx--image__img bx--logo-grid_img"
-                                                          src="https://dummyimage.com/140x140"
-                                                        />
-                                                      </picture>
-                                                    </div>
-                                                  </Image>
-                                                </div>
-                                              </a>
-                                            </div>
-                                            <div
-                                              className="bx--logo-grid__col"
-                                              key="3"
-                                            >
-                                              <a
-                                                className="bx--logo-grid__link"
-                                                href="http://example.com/"
-                                              >
-                                                <div
-                                                  className="bx--logo-grid__logo"
-                                                >
-                                                  <Image
-                                                    alt="Image alt text"
-                                                    classname="bx--logo-grid_img"
-                                                    defaultSrc="https://dummyimage.com/140x140"
-                                                  >
-                                                    <div
-                                                      className="bx--image"
-                                                      data-autoid="dds--image__longdescription-"
-                                                    >
-                                                      <picture>
-                                                        <img
-                                                          alt="Image alt text"
-                                                          className="bx--image__img bx--logo-grid_img"
-                                                          src="https://dummyimage.com/140x140"
-                                                        />
-                                                      </picture>
-                                                    </div>
-                                                  </Image>
-                                                </div>
-                                              </a>
-                                            </div>
-                                            <div
-                                              className="bx--logo-grid__col"
-                                              key="4"
-                                            >
-                                              <a
-                                                className="bx--logo-grid__link"
-                                                href="http://example.com/"
-                                              >
-                                                <div
-                                                  className="bx--logo-grid__logo"
-                                                >
-                                                  <Image
-                                                    alt="Image alt text"
-                                                    classname="bx--logo-grid_img"
-                                                    defaultSrc="https://dummyimage.com/140x140"
-                                                  >
-                                                    <div
-                                                      className="bx--image"
-                                                      data-autoid="dds--image__longdescription-"
-                                                    >
-                                                      <picture>
-                                                        <img
-                                                          alt="Image alt text"
-                                                          className="bx--image__img bx--logo-grid_img"
-                                                          src="https://dummyimage.com/140x140"
-                                                        />
-                                                      </picture>
-                                                    </div>
-                                                  </Image>
-                                                </div>
-                                              </a>
-                                            </div>
-                                            <div
-                                              className="bx--logo-grid__col"
-                                              key="5"
-                                            >
-                                              <a
-                                                className="bx--logo-grid__link"
-                                                href="http://example.com/"
-                                              >
-                                                <div
-                                                  className="bx--logo-grid__logo"
-                                                >
-                                                  <Image
-                                                    alt="Image alt text"
-                                                    classname="bx--logo-grid_img"
-                                                    defaultSrc="https://dummyimage.com/140x140"
-                                                  >
-                                                    <div
-                                                      className="bx--image"
-                                                      data-autoid="dds--image__longdescription-"
-                                                    >
-                                                      <picture>
-                                                        <img
-                                                          alt="Image alt text"
-                                                          className="bx--image__img bx--logo-grid_img"
-                                                          src="https://dummyimage.com/140x140"
-                                                        />
-                                                      </picture>
-                                                    </div>
-                                                  </Image>
-                                                </div>
-                                              </a>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          className="bx--content-block__cta-row"
-                                          data-autoid="dds--content-block__cta"
-                                        >
-                                          <CTA
-                                            copy="Amet justo donec"
-                                            cta={
-                                              Object {
-                                                "href": "https://www.example.com",
-                                              }
-                                            }
-                                            customClassName="bx--content-block__cta bx--content-block__cta-col"
-                                            href=""
-                                            style="card"
-                                            type="local"
-                                          >
-                                            <div
-                                              aria-label="Amet justo donec"
-                                              className="bx--content-block__cta bx--content-block__cta-col"
-                                              role="region"
-                                            >
-                                              <CardCTA
-                                                copy="Amet justo donec"
-                                                cta={
-                                                  Object {
-                                                    "href": "https://www.example.com",
-                                                  }
-                                                }
-                                                disableImage={false}
-                                                href=""
-                                                media={null}
-                                                openLightBox={[Function]}
-                                                renderLightBox={false}
-                                                style="card"
-                                                type="local"
-                                                videoTitle={
-                                                  Array [
-                                                    Object {
-                                                      "duration": "",
-                                                      "key": 0,
-                                                      "title": "",
-                                                    },
-                                                  ]
-                                                }
-                                              >
-                                                <CardLink
-                                                  card={
-                                                    Object {
-                                                      "copy": "Amet justo donec",
-                                                      "cta": Object {
-                                                        "href": "https://www.example.com",
-                                                        "icon": Object {
-                                                          "src": Object {
-                                                            "$$typeof": Symbol(react.forward_ref),
-                                                            "render": [Function],
-                                                          },
-                                                        },
-                                                        "type": "local",
-                                                      },
-                                                      "href": "",
-                                                      "media": null,
-                                                      "target": null,
-                                                    }
-                                                  }
-                                                  disabled={false}
-                                                >
-                                                  <Card
-                                                    copy="Amet justo donec"
-                                                    cta={
-                                                      Object {
-                                                        "href": "https://www.example.com",
-                                                        "icon": Object {
-                                                          "src": Object {
-                                                            "$$typeof": Symbol(react.forward_ref),
-                                                            "render": [Function],
-                                                          },
-                                                        },
-                                                        "type": "local",
-                                                      }
-                                                    }
-                                                    customClassName="bx--card__CTA"
-                                                    disabled={false}
-                                                    href=""
-                                                    media={null}
-                                                    target={null}
-                                                    type="link"
-                                                  >
-                                                    <ClickableTile
-                                                      className="bx--card bx--card--link bx--card__CTA"
-                                                      clicked={false}
-                                                      data-autoid="dds--card"
-                                                      disabled={false}
-                                                      handleClick={[Function]}
-                                                      handleKeyDown={[Function]}
-                                                      href=""
-                                                      light={false}
-                                                      media={null}
-                                                      onClick={[Function]}
-                                                      target={null}
-                                                    >
-                                                      <a
-                                                        className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
-                                                        data-autoid="dds--card"
-                                                        disabled={false}
-                                                        href=""
-                                                        media={null}
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        target={null}
-                                                      >
-                                                        <div
-                                                          className="bx--card__wrapper"
-                                                        >
-                                                          <div
-                                                            className="bx--card__copy"
-                                                            dangerouslySetInnerHTML={
-                                                              Object {
-                                                                "__html": "<p>Amet justo donec</p>",
-                                                              }
-                                                            }
-                                                          />
-                                                          <div
-                                                            className="bx--card__footer"
-                                                          >
-                                                            <ForwardRef(ArrowRight20)
-                                                              className="bx--card__cta"
-                                                              src={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "render": [Function],
-                                                                }
-                                                              }
-                                                            >
-                                                              <Icon
+                                                              <svg
+                                                                aria-hidden={true}
                                                                 className="bx--card__cta"
+                                                                focusable="false"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 src={
@@ -5466,14 +4244,1221 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                     "render": [Function],
                                                                   }
                                                                 }
-                                                                viewBox="0 0 20 20"
+                                                                viewBox="0 0 32 32"
                                                                 width={20}
                                                                 xmlns="http://www.w3.org/2000/svg"
                                                               >
-                                                                <svg
-                                                                  aria-hidden={true}
+                                                                <path
+                                                                  d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
+                                                                />
+                                                                <path
+                                                                  d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(PlayOutline20)>
+                                                          <span />
+                                                        </div>
+                                                      </div>
+                                                    </a>
+                                                  </ClickableTile>
+                                                </Card>
+                                              </CardLink>
+                                            </CardCTA>
+                                          </div>
+                                        </CTA>
+                                      </div>
+                                    </div>
+                                  </ContentBlock>
+                                </div>
+                              </ContentBlockSegmented>
+                              <CalloutWithMedia
+                                copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
+                                heading="Mauris ultrices eros in cursus"
+                                mediaData={
+                                  Object {
+                                    "src": "0_uka1msg4",
+                                    "type": "video",
+                                  }
+                                }
+                                mediaType="video"
+                              >
+                                <div
+                                  className="bx--callout-with-media"
+                                  data-autoid="dds--callout-with-media"
+                                >
+                                  <Callout>
+                                    <section
+                                      className="bx--callout__container"
+                                      data-autoid="dds--callout__container"
+                                    >
+                                      <div
+                                        className="bx--callout__column"
+                                        data-autoid="dds--callout__column"
+                                      >
+                                        <div
+                                          className="bx--callout__content"
+                                          data-autoid="dds--callout__content"
+                                        >
+                                          <ContentBlockSimple
+                                            copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
+                                            heading="Mauris ultrices eros in cursus"
+                                            inverse={true}
+                                            mediaData={
+                                              Object {
+                                                "src": "0_uka1msg4",
+                                                "type": "video",
+                                              }
+                                            }
+                                            mediaType="video"
+                                          >
+                                            <div
+                                              className="bx--content-block-simple"
+                                              data-autoid="dds--content-block-simple"
+                                            >
+                                              <ContentBlock
+                                                border={false}
+                                                heading="Mauris ultrices eros in cursus"
+                                                inverse={true}
+                                              >
+                                                <div
+                                                  className="bx--content-block bx--content-block--inverse"
+                                                  data-autoid="dds--content-block"
+                                                >
+                                                  <div>
+                                                    <h2
+                                                      className="bx--content-block__heading"
+                                                      data-autoid="dds--content-block__heading"
+                                                    >
+                                                      Mauris ultrices eros in cursus
+                                                    </h2>
+                                                  </div>
+                                                  <div
+                                                    className="bx--content-block__children"
+                                                    data-autoid="dds--content-block__children"
+                                                  >
+                                                    <div
+                                                      className="bx--content-block-simple__content"
+                                                    >
+                                                      <ContentItem
+                                                        copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
+                                                        inverse={true}
+                                                      >
+                                                        <div
+                                                          className="bx--content-item bx--content-item--inverse"
+                                                          data-autoid="dds--content-item"
+                                                        >
+                                                          <div
+                                                            className="bx--content-item__copy"
+                                                            dangerouslySetInnerHTML={
+                                                              Object {
+                                                                "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p>",
+                                                              }
+                                                            }
+                                                            data-autoid="dds--content-item__copy"
+                                                          />
+                                                        </div>
+                                                      </ContentItem>
+                                                      <div
+                                                        data-autoid="dds--content-block-simple__media"
+                                                      >
+                                                        <VideoPlayer
+                                                          autoPlay={false}
+                                                          inverse={true}
+                                                          src="0_uka1msg4"
+                                                          type="video"
+                                                        >
+                                                          <div
+                                                            aria-label=" (1:00)"
+                                                            className="bx--video-player bx--video-player--inverse"
+                                                          >
+                                                            <div
+                                                              className="bx--video-player__video-container"
+                                                              data-autoid="dds--video-player__video-undefined"
+                                                            >
+                                                              <div
+                                                                className="bx--video-player__video"
+                                                                id="bx--video-player__video-undefined"
+                                                              >
+                                                                <VideoImageOverlay
+                                                                  embedVideo={[Function]}
+                                                                  videoData={
+                                                                    Object {
+                                                                      "description": "",
+                                                                      "name": "",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <button
+                                                                    className="bx--video-player__image-overlay"
+                                                                    data-autoid="dds--video-player__image-overlay"
+                                                                    onClick={[Function]}
+                                                                  >
+                                                                    <Image
+                                                                      alt=""
+                                                                      defaultSrc="https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320"
+                                                                      icon={[Function]}
+                                                                    />
+                                                                  </button>
+                                                                </VideoImageOverlay>
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                        </VideoPlayer>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </ContentBlock>
+                                            </div>
+                                          </ContentBlockSimple>
+                                        </div>
+                                      </div>
+                                    </section>
+                                  </Callout>
+                                </div>
+                              </CalloutWithMedia>
+                              <a
+                                data-title="Tincidunt ornare massa"
+                                name="section-4"
+                              />
+                              <ContentGroupHorizontal
+                                heading="Tincidunt ornare massa"
+                                items={
+                                  Array [
+                                    Object {
+                                      "copy": "Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin.",
+                                      "cta": Object {
+                                        "items": Array [
+                                          Object {
+                                            "copy": "Link text",
+                                            "href": "https://example.com",
+                                            "type": "local",
+                                          },
+                                          Object {
+                                            "copy": "External link text",
+                                            "href": "https://example.com",
+                                            "type": "external",
+                                          },
+                                        ],
+                                      },
+                                      "eyebrow": "Lorem ipsum",
+                                      "heading": "Aliquam condimentum",
+                                    },
+                                    Object {
+                                      "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
+                                      "cta": Object {
+                                        "items": Array [
+                                          Object {
+                                            "copy": "Link text",
+                                            "href": "https://example.com",
+                                            "type": "local",
+                                          },
+                                          Object {
+                                            "copy": "External link text",
+                                            "href": "https://example.com",
+                                            "type": "external",
+                                          },
+                                        ],
+                                      },
+                                      "eyebrow": "Lorem ipsum",
+                                      "heading": "Aliquam condimentum",
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="bx--content-group-horizontal"
+                                  data-autoid="dds--content-group-horizontal"
+                                >
+                                  <ContentBlock
+                                    border={true}
+                                    heading="Tincidunt ornare massa"
+                                  >
+                                    <div
+                                      className="bx--content-block"
+                                      data-autoid="dds--content-block"
+                                    >
+                                      <div>
+                                        <h2
+                                          className="bx--content-block__heading"
+                                          data-autoid="dds--content-block__heading"
+                                        >
+                                          Tincidunt ornare massa
+                                        </h2>
+                                      </div>
+                                      <div
+                                        className="bx--content-block__children"
+                                        data-autoid="dds--content-block__children"
+                                      >
+                                        <ContentItemHorizontal
+                                          copy="Lorem ipsum dolor sit amet, _consectetur_ sellus at elit sollicitudin."
+                                          cta={
+                                            Object {
+                                              "items": Array [
+                                                Object {
+                                                  "copy": "Link text",
+                                                  "href": "https://example.com",
+                                                  "type": "local",
+                                                },
+                                                Object {
+                                                  "copy": "External link text",
+                                                  "href": "https://example.com",
+                                                  "type": "external",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          eyebrow="Lorem ipsum"
+                                          heading="Aliquam condimentum"
+                                          key="0"
+                                        >
+                                          <div
+                                            className="bx--content-item-horizontal__item bx"
+                                            data-autoid="dds--content-item-horizontal__item"
+                                          >
+                                            <div
+                                              className="bx--content-item-horizontal__row"
+                                            >
+                                              <div
+                                                className="bx--content-item-horizontal__col"
+                                              >
+                                                <p
+                                                  className="bx--content-item-horizontal__item--eyebrow"
+                                                  data-autoid="dds--content-item-horizontal__item--eyebrow"
+                                                >
+                                                  Lorem ipsum
+                                                </p>
+                                                <h3
+                                                  className="bx--content-item-horizontal__item--heading"
+                                                  data-autoid="dds--content-item-horizontal__item--heading"
+                                                >
+                                                  Aliquam condimentum
+                                                </h3>
+                                              </div>
+                                              <div
+                                                className="bx--content-item-horizontal__col"
+                                              >
+                                                <div
+                                                  className="bx--content-item-horizontal__item--copy"
+                                                  dangerouslySetInnerHTML={
+                                                    Object {
+                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> sellus at elit sollicitudin.</p>",
+                                                    }
+                                                  }
+                                                  data-autoid="dds--content-item-horizontal__item--copy"
+                                                />
+                                                <div
+                                                  className="bx--content-item-horizontal__item--cta"
+                                                  data-autoid="dds--content-item-horizontal__item--cta"
+                                                >
+                                                  <LinkList
+                                                    items={
+                                                      Array [
+                                                        Object {
+                                                          "copy": "Link text",
+                                                          "href": "https://example.com",
+                                                          "type": "local",
+                                                        },
+                                                        Object {
+                                                          "copy": "External link text",
+                                                          "href": "https://example.com",
+                                                          "type": "external",
+                                                        },
+                                                      ]
+                                                    }
+                                                    style="vertical"
+                                                  >
+                                                    <div
+                                                      className="bx--link-list"
+                                                      data-autoid="dds--link-list"
+                                                    >
+                                                      <ul
+                                                        className="bx--link-list__list bx--link-list__list--vertical"
+                                                      >
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                          key="0"
+                                                        >
+                                                          <CTA
+                                                            copy="Link text"
+                                                            disableImage={true}
+                                                            href="https://example.com"
+                                                            style="text"
+                                                            type="local"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="Link text"
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href="https://example.com"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="local"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://example.com"
+                                                                  onClick={[Function]}
+                                                                  target={null}
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://example.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <span>
+                                                                          Link text
+                                                                        </span>
+                                                                        <ForwardRef(ArrowRight20)>
+                                                                          <Icon
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(ArrowRight20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--external"
+                                                          key="1"
+                                                        >
+                                                          <CTA
+                                                            copy="External link text"
+                                                            disableImage={true}
+                                                            href="https://example.com"
+                                                            style="text"
+                                                            type="external"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="External link text"
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href="https://example.com"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="external"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://example.com"
+                                                                  onClick={[Function]}
+                                                                  target="_blank"
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://example.com"
+                                                                      onClick={[Function]}
+                                                                      target="_blank"
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target="_blank"
+                                                                      >
+                                                                        <span>
+                                                                          External link text
+                                                                        </span>
+                                                                        <ForwardRef(Launch20)>
+                                                                          <Icon
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 32 32"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 32 32"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                              />
+                                                                              <path
+                                                                                d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(Launch20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                      </ul>
+                                                    </div>
+                                                  </LinkList>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </ContentItemHorizontal>
+                                        <ContentItemHorizontal
+                                          copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
+                                          cta={
+                                            Object {
+                                              "items": Array [
+                                                Object {
+                                                  "copy": "Link text",
+                                                  "href": "https://example.com",
+                                                  "type": "local",
+                                                },
+                                                Object {
+                                                  "copy": "External link text",
+                                                  "href": "https://example.com",
+                                                  "type": "external",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          eyebrow="Lorem ipsum"
+                                          heading="Aliquam condimentum"
+                                          key="1"
+                                        >
+                                          <div
+                                            className="bx--content-item-horizontal__item bx"
+                                            data-autoid="dds--content-item-horizontal__item"
+                                          >
+                                            <div
+                                              className="bx--content-item-horizontal__row"
+                                            >
+                                              <div
+                                                className="bx--content-item-horizontal__col"
+                                              >
+                                                <p
+                                                  className="bx--content-item-horizontal__item--eyebrow"
+                                                  data-autoid="dds--content-item-horizontal__item--eyebrow"
+                                                >
+                                                  Lorem ipsum
+                                                </p>
+                                                <h3
+                                                  className="bx--content-item-horizontal__item--heading"
+                                                  data-autoid="dds--content-item-horizontal__item--heading"
+                                                >
+                                                  Aliquam condimentum
+                                                </h3>
+                                              </div>
+                                              <div
+                                                className="bx--content-item-horizontal__col"
+                                              >
+                                                <div
+                                                  className="bx--content-item-horizontal__item--copy"
+                                                  dangerouslySetInnerHTML={
+                                                    Object {
+                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
+                                                    }
+                                                  }
+                                                  data-autoid="dds--content-item-horizontal__item--copy"
+                                                />
+                                                <div
+                                                  className="bx--content-item-horizontal__item--cta"
+                                                  data-autoid="dds--content-item-horizontal__item--cta"
+                                                >
+                                                  <LinkList
+                                                    items={
+                                                      Array [
+                                                        Object {
+                                                          "copy": "Link text",
+                                                          "href": "https://example.com",
+                                                          "type": "local",
+                                                        },
+                                                        Object {
+                                                          "copy": "External link text",
+                                                          "href": "https://example.com",
+                                                          "type": "external",
+                                                        },
+                                                      ]
+                                                    }
+                                                    style="vertical"
+                                                  >
+                                                    <div
+                                                      className="bx--link-list"
+                                                      data-autoid="dds--link-list"
+                                                    >
+                                                      <ul
+                                                        className="bx--link-list__list bx--link-list__list--vertical"
+                                                      >
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                          key="0"
+                                                        >
+                                                          <CTA
+                                                            copy="Link text"
+                                                            disableImage={true}
+                                                            href="https://example.com"
+                                                            style="text"
+                                                            type="local"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="Link text"
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href="https://example.com"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="local"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://example.com"
+                                                                  onClick={[Function]}
+                                                                  target={null}
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://example.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <span>
+                                                                          Link text
+                                                                        </span>
+                                                                        <ForwardRef(ArrowRight20)>
+                                                                          <Icon
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(ArrowRight20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--external"
+                                                          key="1"
+                                                        >
+                                                          <CTA
+                                                            copy="External link text"
+                                                            disableImage={true}
+                                                            href="https://example.com"
+                                                            style="text"
+                                                            type="external"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="External link text"
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href="https://example.com"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="external"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://example.com"
+                                                                  onClick={[Function]}
+                                                                  target="_blank"
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://example.com"
+                                                                      onClick={[Function]}
+                                                                      target="_blank"
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target="_blank"
+                                                                      >
+                                                                        <span>
+                                                                          External link text
+                                                                        </span>
+                                                                        <ForwardRef(Launch20)>
+                                                                          <Icon
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 32 32"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 32 32"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                              />
+                                                                              <path
+                                                                                d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(Launch20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                      </ul>
+                                                    </div>
+                                                  </LinkList>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </ContentItemHorizontal>
+                                      </div>
+                                      <HorizontalRule>
+                                        <hr
+                                          className="bx--hr"
+                                          data-autoid="dds--hr"
+                                        />
+                                      </HorizontalRule>
+                                    </div>
+                                  </ContentBlock>
+                                </div>
+                              </ContentGroupHorizontal>
+                              <a
+                                data-title="Lobortis elementum nibh tellus"
+                                name="section-5"
+                              />
+                              <LogoGrid
+                                ctaCopy="Amet justo donec"
+                                ctaHref="https://www.example.com"
+                                heading="Lobortis elementum nibh tellus"
+                                logosGroup={
+                                  Array [
+                                    Object {
+                                      "altText": "Image alt text",
+                                      "href": "http://example.com/",
+                                      "imgSrc": "https://dummyimage.com/140x140",
+                                      "title": "Company A",
+                                    },
+                                    Object {
+                                      "altText": "Image alt text",
+                                      "href": "http://example.com/",
+                                      "imgSrc": "https://dummyimage.com/140x140",
+                                      "title": "Company B",
+                                    },
+                                    Object {
+                                      "altText": "Image alt text",
+                                      "href": "http://example.com/",
+                                      "imgSrc": "https://dummyimage.com/140x140",
+                                      "title": "Company C",
+                                    },
+                                    Object {
+                                      "altText": "Image alt text",
+                                      "href": "http://example.com/",
+                                      "imgSrc": "https://dummyimage.com/140x140",
+                                      "title": "Company D",
+                                    },
+                                    Object {
+                                      "altText": "Image alt text",
+                                      "href": "http://example.com/",
+                                      "imgSrc": "https://dummyimage.com/140x140",
+                                      "title": "Company E",
+                                    },
+                                    Object {
+                                      "altText": "Image alt text",
+                                      "href": "http://example.com/",
+                                      "imgSrc": "https://dummyimage.com/140x140",
+                                      "title": "Company F",
+                                    },
+                                  ]
+                                }
+                              >
+                                <section
+                                  className="bx--logo-grid"
+                                  data-autoid="dds--logo-grid bx--logo-grid"
+                                >
+                                  <div
+                                    className="bx--logo-grid__container"
+                                  >
+                                    <div
+                                      className="bx--logo-grid__wrapper bx--grid bx--grid--full-width"
+                                    >
+                                      <ContentBlock
+                                        border={false}
+                                        cta={
+                                          Object {
+                                            "copy": "Amet justo donec",
+                                            "cta": Object {
+                                              "href": "https://www.example.com",
+                                            },
+                                            "style": "card",
+                                            "type": "local",
+                                          }
+                                        }
+                                        heading="Lobortis elementum nibh tellus"
+                                      >
+                                        <div
+                                          className="bx--content-block"
+                                          data-autoid="dds--content-block"
+                                        >
+                                          <div>
+                                            <h2
+                                              className="bx--content-block__heading"
+                                              data-autoid="dds--content-block__heading"
+                                            >
+                                              Lobortis elementum nibh tellus
+                                            </h2>
+                                          </div>
+                                          <div
+                                            className="bx--content-block__children"
+                                            data-autoid="dds--content-block__children"
+                                          >
+                                            <div
+                                              className="bx--logo-grid__row"
+                                            >
+                                              <div
+                                                className="bx--logo-grid__col"
+                                                key="0"
+                                              >
+                                                <a
+                                                  className="bx--logo-grid__link"
+                                                  href="http://example.com/"
+                                                >
+                                                  <div
+                                                    className="bx--logo-grid__logo"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      classname="bx--logo-grid_img"
+                                                      defaultSrc="https://dummyimage.com/140x140"
+                                                    >
+                                                      <div
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <picture>
+                                                          <img
+                                                            alt="Image alt text"
+                                                            className="bx--image__img bx--logo-grid_img"
+                                                            src="https://dummyimage.com/140x140"
+                                                          />
+                                                        </picture>
+                                                      </div>
+                                                    </Image>
+                                                  </div>
+                                                </a>
+                                              </div>
+                                              <div
+                                                className="bx--logo-grid__col"
+                                                key="1"
+                                              >
+                                                <a
+                                                  className="bx--logo-grid__link"
+                                                  href="http://example.com/"
+                                                >
+                                                  <div
+                                                    className="bx--logo-grid__logo"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      classname="bx--logo-grid_img"
+                                                      defaultSrc="https://dummyimage.com/140x140"
+                                                    >
+                                                      <div
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <picture>
+                                                          <img
+                                                            alt="Image alt text"
+                                                            className="bx--image__img bx--logo-grid_img"
+                                                            src="https://dummyimage.com/140x140"
+                                                          />
+                                                        </picture>
+                                                      </div>
+                                                    </Image>
+                                                  </div>
+                                                </a>
+                                              </div>
+                                              <div
+                                                className="bx--logo-grid__col"
+                                                key="2"
+                                              >
+                                                <a
+                                                  className="bx--logo-grid__link"
+                                                  href="http://example.com/"
+                                                >
+                                                  <div
+                                                    className="bx--logo-grid__logo"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      classname="bx--logo-grid_img"
+                                                      defaultSrc="https://dummyimage.com/140x140"
+                                                    >
+                                                      <div
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <picture>
+                                                          <img
+                                                            alt="Image alt text"
+                                                            className="bx--image__img bx--logo-grid_img"
+                                                            src="https://dummyimage.com/140x140"
+                                                          />
+                                                        </picture>
+                                                      </div>
+                                                    </Image>
+                                                  </div>
+                                                </a>
+                                              </div>
+                                              <div
+                                                className="bx--logo-grid__col"
+                                                key="3"
+                                              >
+                                                <a
+                                                  className="bx--logo-grid__link"
+                                                  href="http://example.com/"
+                                                >
+                                                  <div
+                                                    className="bx--logo-grid__logo"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      classname="bx--logo-grid_img"
+                                                      defaultSrc="https://dummyimage.com/140x140"
+                                                    >
+                                                      <div
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <picture>
+                                                          <img
+                                                            alt="Image alt text"
+                                                            className="bx--image__img bx--logo-grid_img"
+                                                            src="https://dummyimage.com/140x140"
+                                                          />
+                                                        </picture>
+                                                      </div>
+                                                    </Image>
+                                                  </div>
+                                                </a>
+                                              </div>
+                                              <div
+                                                className="bx--logo-grid__col"
+                                                key="4"
+                                              >
+                                                <a
+                                                  className="bx--logo-grid__link"
+                                                  href="http://example.com/"
+                                                >
+                                                  <div
+                                                    className="bx--logo-grid__logo"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      classname="bx--logo-grid_img"
+                                                      defaultSrc="https://dummyimage.com/140x140"
+                                                    >
+                                                      <div
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <picture>
+                                                          <img
+                                                            alt="Image alt text"
+                                                            className="bx--image__img bx--logo-grid_img"
+                                                            src="https://dummyimage.com/140x140"
+                                                          />
+                                                        </picture>
+                                                      </div>
+                                                    </Image>
+                                                  </div>
+                                                </a>
+                                              </div>
+                                              <div
+                                                className="bx--logo-grid__col"
+                                                key="5"
+                                              >
+                                                <a
+                                                  className="bx--logo-grid__link"
+                                                  href="http://example.com/"
+                                                >
+                                                  <div
+                                                    className="bx--logo-grid__logo"
+                                                  >
+                                                    <Image
+                                                      alt="Image alt text"
+                                                      classname="bx--logo-grid_img"
+                                                      defaultSrc="https://dummyimage.com/140x140"
+                                                    >
+                                                      <div
+                                                        className="bx--image"
+                                                        data-autoid="dds--image__longdescription-"
+                                                      >
+                                                        <picture>
+                                                          <img
+                                                            alt="Image alt text"
+                                                            className="bx--image__img bx--logo-grid_img"
+                                                            src="https://dummyimage.com/140x140"
+                                                          />
+                                                        </picture>
+                                                      </div>
+                                                    </Image>
+                                                  </div>
+                                                </a>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            className="bx--content-block__cta-row"
+                                            data-autoid="dds--content-block__cta"
+                                          >
+                                            <CTA
+                                              copy="Amet justo donec"
+                                              cta={
+                                                Object {
+                                                  "href": "https://www.example.com",
+                                                }
+                                              }
+                                              customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                              href=""
+                                              style="card"
+                                              type="local"
+                                            >
+                                              <div
+                                                aria-label="Amet justo donec"
+                                                className="bx--content-block__cta bx--content-block__cta-col"
+                                                role="region"
+                                              >
+                                                <CardCTA
+                                                  copy="Amet justo donec"
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://www.example.com",
+                                                    }
+                                                  }
+                                                  disableImage={false}
+                                                  href=""
+                                                  media={null}
+                                                  openLightBox={[Function]}
+                                                  renderLightBox={false}
+                                                  style="card"
+                                                  type="local"
+                                                  videoTitle={
+                                                    Array [
+                                                      Object {
+                                                        "duration": "",
+                                                        "key": 0,
+                                                        "title": "",
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <CardLink
+                                                    card={
+                                                      Object {
+                                                        "copy": "Amet justo donec",
+                                                        "cta": Object {
+                                                          "href": "https://www.example.com",
+                                                          "icon": Object {
+                                                            "src": Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            },
+                                                          },
+                                                          "type": "local",
+                                                        },
+                                                        "href": "",
+                                                        "media": null,
+                                                        "target": null,
+                                                      }
+                                                    }
+                                                    disabled={false}
+                                                  >
+                                                    <Card
+                                                      copy="Amet justo donec"
+                                                      cta={
+                                                        Object {
+                                                          "href": "https://www.example.com",
+                                                          "icon": Object {
+                                                            "src": Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "render": [Function],
+                                                            },
+                                                          },
+                                                          "type": "local",
+                                                        }
+                                                      }
+                                                      customClassName="bx--card__CTA"
+                                                      disabled={false}
+                                                      href=""
+                                                      media={null}
+                                                      target={null}
+                                                      type="link"
+                                                    >
+                                                      <ClickableTile
+                                                        className="bx--card bx--card--link bx--card__CTA"
+                                                        clicked={false}
+                                                        data-autoid="dds--card"
+                                                        disabled={false}
+                                                        handleClick={[Function]}
+                                                        handleKeyDown={[Function]}
+                                                        href=""
+                                                        light={false}
+                                                        media={null}
+                                                        onClick={[Function]}
+                                                        target={null}
+                                                      >
+                                                        <a
+                                                          className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card__CTA"
+                                                          data-autoid="dds--card"
+                                                          disabled={false}
+                                                          href=""
+                                                          media={null}
+                                                          onClick={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          target={null}
+                                                        >
+                                                          <div
+                                                            className="bx--card__wrapper"
+                                                          >
+                                                            <div
+                                                              className="bx--card__copy"
+                                                              dangerouslySetInnerHTML={
+                                                                Object {
+                                                                  "__html": "<p>Amet justo donec</p>",
+                                                                }
+                                                              }
+                                                            />
+                                                            <div
+                                                              className="bx--card__footer"
+                                                            >
+                                                              <ForwardRef(ArrowRight20)
+                                                                className="bx--card__cta"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                              >
+                                                                <Icon
                                                                   className="bx--card__cta"
-                                                                  focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   src={
@@ -5486,903 +5471,884 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                   width={20}
                                                                   xmlns="http://www.w3.org/2000/svg"
                                                                 >
-                                                                  <path
-                                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                                  />
-                                                                </svg>
-                                                              </Icon>
-                                                            </ForwardRef(ArrowRight20)>
-                                                            <span />
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="bx--card__cta"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowRight20)>
+                                                              <span />
+                                                            </div>
                                                           </div>
-                                                        </div>
-                                                      </a>
-                                                    </ClickableTile>
-                                                  </Card>
-                                                </CardLink>
-                                              </CardCTA>
-                                            </div>
-                                          </CTA>
+                                                        </a>
+                                                      </ClickableTile>
+                                                    </Card>
+                                                  </CardLink>
+                                                </CardCTA>
+                                              </div>
+                                            </CTA>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </ContentBlock>
-                                  </div>
-                                </div>
-                              </section>
-                            </LogoGrid>
-                            <a
-                              data-title="Aliquam condimentum interdum"
-                              name="section-6"
-                            />
-                            <ContentBlockCards
-                              cards={
-                                Array [
-                                  Object {
-                                    "cta": Object {
-                                      "href": "https://www.example.com",
-                                    },
-                                    "eyebrow": "Topic",
-                                    "heading": "Natural language processing.",
-                                    "image": Object {
-                                      "alt": "Image alt text",
-                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                    },
-                                  },
-                                  Object {
-                                    "cta": Object {
-                                      "href": "https://www.example.com",
-                                    },
-                                    "eyebrow": "Topic",
-                                    "heading": "Natural language processing.",
-                                    "image": Object {
-                                      "alt": "Image alt text",
-                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                    },
-                                  },
-                                  Object {
-                                    "cta": Object {
-                                      "href": "https://www.example.com",
-                                    },
-                                    "eyebrow": "Topic",
-                                    "heading": "Natural language processing.",
-                                    "image": Object {
-                                      "alt": "Image alt text",
-                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                    },
-                                  },
-                                ]
-                              }
-                              heading="Aliquam condimentum interdum"
-                            >
-                              <div
-                                className="bx--content-block-cards"
-                                data-autoid="dds--content-block-cards"
-                              >
-                                <ContentBlock
-                                  border={false}
-                                  heading="Aliquam condimentum interdum"
-                                >
-                                  <div
-                                    className="bx--content-block"
-                                    data-autoid="dds--content-block"
-                                  >
-                                    <div>
-                                      <h2
-                                        className="bx--content-block__heading"
-                                        data-autoid="dds--content-block__heading"
-                                      >
-                                        Aliquam condimentum interdum
-                                      </h2>
-                                    </div>
-                                    <div
-                                      className="bx--content-block__children"
-                                      data-autoid="dds--content-block__children"
-                                    >
-                                      <div
-                                        className="bx--content-block-cards__content"
-                                      >
-                                        <CardGroup
-                                          cards={
-                                            Array [
-                                              Object {
-                                                "cta": Object {
-                                                  "href": "https://www.example.com",
-                                                },
-                                                "eyebrow": "Topic",
-                                                "heading": "Natural language processing.",
-                                                "image": Object {
-                                                  "alt": "Image alt text",
-                                                  "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                                },
-                                              },
-                                              Object {
-                                                "cta": Object {
-                                                  "href": "https://www.example.com",
-                                                },
-                                                "eyebrow": "Topic",
-                                                "heading": "Natural language processing.",
-                                                "image": Object {
-                                                  "alt": "Image alt text",
-                                                  "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                                },
-                                              },
-                                              Object {
-                                                "cta": Object {
-                                                  "href": "https://www.example.com",
-                                                },
-                                                "eyebrow": "Topic",
-                                                "heading": "Natural language processing.",
-                                                "image": Object {
-                                                  "alt": "Image alt text",
-                                                  "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                                },
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <div
-                                            className="bx--card-group__cards__row bx--row--condensed"
-                                            data-autoid="dds--card-group"
-                                          >
-                                            <div
-                                              aria-label="Natural language processing."
-                                              className="bx--card-group__cards__col"
-                                              key="0"
-                                              role="region"
-                                            >
-                                              <Card
-                                                cta={
-                                                  Object {
-                                                    "href": "https://www.example.com",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
-                                                      },
-                                                    },
-                                                  }
-                                                }
-                                                customClassName="bx--card-group__card"
-                                                eyebrow="Topic"
-                                                heading="Natural language processing."
-                                                image={
-                                                  Object {
-                                                    "alt": "Image alt text",
-                                                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                                  }
-                                                }
-                                                key="0"
-                                                type="link"
-                                              >
-                                                <ClickableTile
-                                                  className="bx--card bx--card--link bx--card-group__card"
-                                                  clicked={false}
-                                                  data-autoid="dds--card"
-                                                  handleClick={[Function]}
-                                                  handleKeyDown={[Function]}
-                                                  href="https://www.example.com"
-                                                  light={false}
-                                                  onClick={[Function]}
-                                                  target={null}
-                                                >
-                                                  <a
-                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
-                                                    data-autoid="dds--card"
-                                                    href="https://www.example.com"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    target={null}
-                                                  >
-                                                    <Image
-                                                      alt="Image alt text"
-                                                      classname="bx--card__img"
-                                                      defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
-                                                    >
-                                                      <div
-                                                        className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
-                                                      >
-                                                        <picture>
-                                                          <img
-                                                            alt="Image alt text"
-                                                            className="bx--image__img bx--card__img"
-                                                            src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
-                                                          />
-                                                        </picture>
-                                                      </div>
-                                                    </Image>
-                                                    <div
-                                                      className="bx--card__wrapper"
-                                                    >
-                                                      <p
-                                                        className="bx--card__eyebrow"
-                                                      >
-                                                        Topic
-                                                      </p>
-                                                      <h3
-                                                        className="bx--card__heading"
-                                                      >
-                                                        Natural language processing.
-                                                      </h3>
-                                                      <div
-                                                        className="bx--card__footer"
-                                                      >
-                                                        <ForwardRef(ArrowRight20)
-                                                          className="bx--card__cta"
-                                                          src={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "render": [Function],
-                                                            }
-                                                          }
-                                                        >
-                                                          <Icon
-                                                            className="bx--card__cta"
-                                                            height={20}
-                                                            preserveAspectRatio="xMidYMid meet"
-                                                            src={
-                                                              Object {
-                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                "render": [Function],
-                                                              }
-                                                            }
-                                                            viewBox="0 0 20 20"
-                                                            width={20}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="bx--card__cta"
-                                                              focusable="false"
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              src={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "render": [Function],
-                                                                }
-                                                              }
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <path
-                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                              />
-                                                            </svg>
-                                                          </Icon>
-                                                        </ForwardRef(ArrowRight20)>
-                                                        <span />
-                                                      </div>
-                                                    </div>
-                                                  </a>
-                                                </ClickableTile>
-                                              </Card>
-                                            </div>
-                                            <div
-                                              aria-label="Natural language processing."
-                                              className="bx--card-group__cards__col"
-                                              key="1"
-                                              role="region"
-                                            >
-                                              <Card
-                                                cta={
-                                                  Object {
-                                                    "href": "https://www.example.com",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
-                                                      },
-                                                    },
-                                                  }
-                                                }
-                                                customClassName="bx--card-group__card"
-                                                eyebrow="Topic"
-                                                heading="Natural language processing."
-                                                image={
-                                                  Object {
-                                                    "alt": "Image alt text",
-                                                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                                  }
-                                                }
-                                                key="1"
-                                                type="link"
-                                              >
-                                                <ClickableTile
-                                                  className="bx--card bx--card--link bx--card-group__card"
-                                                  clicked={false}
-                                                  data-autoid="dds--card"
-                                                  handleClick={[Function]}
-                                                  handleKeyDown={[Function]}
-                                                  href="https://www.example.com"
-                                                  light={false}
-                                                  onClick={[Function]}
-                                                  target={null}
-                                                >
-                                                  <a
-                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
-                                                    data-autoid="dds--card"
-                                                    href="https://www.example.com"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    target={null}
-                                                  >
-                                                    <Image
-                                                      alt="Image alt text"
-                                                      classname="bx--card__img"
-                                                      defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
-                                                    >
-                                                      <div
-                                                        className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
-                                                      >
-                                                        <picture>
-                                                          <img
-                                                            alt="Image alt text"
-                                                            className="bx--image__img bx--card__img"
-                                                            src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
-                                                          />
-                                                        </picture>
-                                                      </div>
-                                                    </Image>
-                                                    <div
-                                                      className="bx--card__wrapper"
-                                                    >
-                                                      <p
-                                                        className="bx--card__eyebrow"
-                                                      >
-                                                        Topic
-                                                      </p>
-                                                      <h3
-                                                        className="bx--card__heading"
-                                                      >
-                                                        Natural language processing.
-                                                      </h3>
-                                                      <div
-                                                        className="bx--card__footer"
-                                                      >
-                                                        <ForwardRef(ArrowRight20)
-                                                          className="bx--card__cta"
-                                                          src={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "render": [Function],
-                                                            }
-                                                          }
-                                                        >
-                                                          <Icon
-                                                            className="bx--card__cta"
-                                                            height={20}
-                                                            preserveAspectRatio="xMidYMid meet"
-                                                            src={
-                                                              Object {
-                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                "render": [Function],
-                                                              }
-                                                            }
-                                                            viewBox="0 0 20 20"
-                                                            width={20}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="bx--card__cta"
-                                                              focusable="false"
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              src={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "render": [Function],
-                                                                }
-                                                              }
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <path
-                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                              />
-                                                            </svg>
-                                                          </Icon>
-                                                        </ForwardRef(ArrowRight20)>
-                                                        <span />
-                                                      </div>
-                                                    </div>
-                                                  </a>
-                                                </ClickableTile>
-                                              </Card>
-                                            </div>
-                                            <div
-                                              aria-label="Natural language processing."
-                                              className="bx--card-group__cards__col"
-                                              key="2"
-                                              role="region"
-                                            >
-                                              <Card
-                                                cta={
-                                                  Object {
-                                                    "href": "https://www.example.com",
-                                                    "icon": Object {
-                                                      "src": Object {
-                                                        "$$typeof": Symbol(react.forward_ref),
-                                                        "render": [Function],
-                                                      },
-                                                    },
-                                                  }
-                                                }
-                                                customClassName="bx--card-group__card"
-                                                eyebrow="Topic"
-                                                heading="Natural language processing."
-                                                image={
-                                                  Object {
-                                                    "alt": "Image alt text",
-                                                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
-                                                  }
-                                                }
-                                                key="2"
-                                                type="link"
-                                              >
-                                                <ClickableTile
-                                                  className="bx--card bx--card--link bx--card-group__card"
-                                                  clicked={false}
-                                                  data-autoid="dds--card"
-                                                  handleClick={[Function]}
-                                                  handleKeyDown={[Function]}
-                                                  href="https://www.example.com"
-                                                  light={false}
-                                                  onClick={[Function]}
-                                                  target={null}
-                                                >
-                                                  <a
-                                                    className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
-                                                    data-autoid="dds--card"
-                                                    href="https://www.example.com"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    target={null}
-                                                  >
-                                                    <Image
-                                                      alt="Image alt text"
-                                                      classname="bx--card__img"
-                                                      defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
-                                                    >
-                                                      <div
-                                                        className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
-                                                      >
-                                                        <picture>
-                                                          <img
-                                                            alt="Image alt text"
-                                                            className="bx--image__img bx--card__img"
-                                                            src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
-                                                          />
-                                                        </picture>
-                                                      </div>
-                                                    </Image>
-                                                    <div
-                                                      className="bx--card__wrapper"
-                                                    >
-                                                      <p
-                                                        className="bx--card__eyebrow"
-                                                      >
-                                                        Topic
-                                                      </p>
-                                                      <h3
-                                                        className="bx--card__heading"
-                                                      >
-                                                        Natural language processing.
-                                                      </h3>
-                                                      <div
-                                                        className="bx--card__footer"
-                                                      >
-                                                        <ForwardRef(ArrowRight20)
-                                                          className="bx--card__cta"
-                                                          src={
-                                                            Object {
-                                                              "$$typeof": Symbol(react.forward_ref),
-                                                              "render": [Function],
-                                                            }
-                                                          }
-                                                        >
-                                                          <Icon
-                                                            className="bx--card__cta"
-                                                            height={20}
-                                                            preserveAspectRatio="xMidYMid meet"
-                                                            src={
-                                                              Object {
-                                                                "$$typeof": Symbol(react.forward_ref),
-                                                                "render": [Function],
-                                                              }
-                                                            }
-                                                            viewBox="0 0 20 20"
-                                                            width={20}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="bx--card__cta"
-                                                              focusable="false"
-                                                              height={20}
-                                                              preserveAspectRatio="xMidYMid meet"
-                                                              src={
-                                                                Object {
-                                                                  "$$typeof": Symbol(react.forward_ref),
-                                                                  "render": [Function],
-                                                                }
-                                                              }
-                                                              viewBox="0 0 20 20"
-                                                              width={20}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <path
-                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                              />
-                                                            </svg>
-                                                          </Icon>
-                                                        </ForwardRef(ArrowRight20)>
-                                                        <span />
-                                                      </div>
-                                                    </div>
-                                                  </a>
-                                                </ClickableTile>
-                                              </Card>
-                                            </div>
-                                          </div>
-                                        </CardGroup>
-                                      </div>
+                                      </ContentBlock>
                                     </div>
                                   </div>
-                                </ContentBlock>
-                              </div>
-                            </ContentBlockCards>
-                            <a
-                              data-title="Duis aute irure dolor in reprehenderit"
-                              name="section-7"
-                            />
-                            <CalloutQuote
-                              quote={
-                                Object {
-                                  "copy": "Duis aute irure dolor in reprehenderit",
-                                  "cta": Object {
-                                    "copy": "Link with Icon",
-                                    "href": "https://example.com",
-                                    "type": "local",
-                                  },
-                                  "source": Object {
-                                    "copy": "dolor sit amet",
-                                    "heading": "Lorem ipsum",
-                                  },
-                                }
-                              }
-                            >
-                              <div
-                                className="bx--callout-quote"
-                                data-autoid="dds--callout-quote"
-                              >
-                                <Callout>
-                                  <section
-                                    className="bx--callout__container"
-                                    data-autoid="dds--callout__container"
-                                  >
-                                    <div
-                                      className="bx--callout__column"
-                                      data-autoid="dds--callout__column"
-                                    >
-                                      <div
-                                        className="bx--callout__content"
-                                        data-autoid="dds--callout__content"
-                                      >
-                                        <Quote
-                                          copy="Duis aute irure dolor in reprehenderit"
-                                          cta={
-                                            Object {
-                                              "copy": "Link with Icon",
-                                              "href": "https://example.com",
-                                              "type": "local",
-                                            }
-                                          }
-                                          inverse={true}
-                                          source={
-                                            Object {
-                                              "copy": "dolor sit amet",
-                                              "heading": "Lorem ipsum",
-                                            }
-                                          }
-                                        >
-                                          <div
-                                            className="bx--quote bx--quote__inverse"
-                                            data-autoid="dds--quote"
-                                          >
-                                            <div
-                                              className="bx--quote__container"
-                                            >
-                                              <div
-                                                className="bx--quote__wrapper"
-                                                data-autoid="dds--quote__copy"
-                                              >
-                                                <span
-                                                  className="bx--quote__mark"
-                                                >
-                                                  “
-                                                </span>
-                                                <blockquote
-                                                  className="bx--quote__copy"
-                                                >
-                                                  Duis aute irure dolor in reprehenderit
-                                                  ”
-                                                </blockquote>
-                                              </div>
-                                              <div
-                                                className="bx--quote__source"
-                                                data-autoid="dds--quote__source"
-                                              >
-                                                <p
-                                                  className="bx--quote__source-heading"
-                                                >
-                                                  Lorem ipsum
-                                                </p>
-                                                <p
-                                                  className="bx--quote__source-body"
-                                                >
-                                                  dolor sit amet
-                                                </p>
-                                              </div>
-                                            </div>
-                                            <div
-                                              className="bx--quote__footer"
-                                            >
-                                              <HorizontalRule>
-                                                <hr
-                                                  className="bx--hr"
-                                                  data-autoid="dds--hr"
-                                                />
-                                              </HorizontalRule>
-                                              <LinkWithIcon
-                                                href="https://example.com"
-                                              >
-                                                <div
-                                                  className="bx--link-with-icon__container"
-                                                  data-autoid="dds--link-with-icon"
-                                                >
-                                                  <Link
-                                                    className="bx--link-with-icon"
-                                                    href="https://example.com"
-                                                  >
-                                                    <a
-                                                      className="bx--link bx--link-with-icon"
-                                                      href="https://example.com"
-                                                    >
-                                                      Link with Icon
-                                                      <ForwardRef(ArrowRight20)>
-                                                        <Icon
-                                                          height={20}
-                                                          preserveAspectRatio="xMidYMid meet"
-                                                          viewBox="0 0 20 20"
-                                                          width={20}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            focusable="false"
-                                                            height={20}
-                                                            preserveAspectRatio="xMidYMid meet"
-                                                            viewBox="0 0 20 20"
-                                                            width={20}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                            />
-                                                          </svg>
-                                                        </Icon>
-                                                      </ForwardRef(ArrowRight20)>
-                                                    </a>
-                                                  </Link>
-                                                </div>
-                                              </LinkWithIcon>
-                                            </div>
-                                          </div>
-                                        </Quote>
-                                      </div>
-                                    </div>
-                                  </section>
-                                </Callout>
-                              </div>
-                            </CalloutQuote>
-                          </div>
-                        </div>
-                      </div>
-                    </section>
-                  </Layout>
-                </section>
-              </TableOfContents>
-              <div
-                className="bx--grid"
-                style={
-                  Object {
-                    "backgroundColor": "#f4f4f4",
-                  }
-                }
-              >
-                <div
-                  className="bx--row"
-                >
-                  <div
-                    className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
-                  >
-                    <CTASection
-                      copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
-                      cta={
-                        Object {
-                          "buttons": Array [
-                            Object {
-                              "copy": Array [
-                                "Contact sales",
-                              ],
-                              "iconDescription": "right arrow icon",
-                              "onClick": [Function],
-                              "renderIcon": Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "render": [Function],
-                              },
-                              "target": null,
-                              "type": "local",
-                            },
-                          ],
-                          "style": "button",
-                          "type": "local",
-                        }
-                      }
-                      heading="Take the next step"
-                      items={
-                        Array [
-                          Object {
-                            "copy": "
-            IBM DevOps partners have a wide range of expertise.
-            Find one to build the right solution for you.
-            ",
-                            "cta": Object {
-                              "copy": "Find a partner",
-                              "href": "https://example.com/",
-                              "type": "local",
-                            },
-                            "heading": "Get connected",
-                          },
-                          Object {
-                            "copy": "Dig into more self-directed learning about DevOps methodologies.",
-                            "cta": Object {
-                              "copy": "Browse tutorials",
-                              "href": "https://example.com/",
-                              "type": "local",
-                            },
-                            "heading": "Learn how",
-                          },
-                        ]
-                      }
-                      theme="g10"
-                    >
-                      <section
-                        className="bx--cta-section bx--cta-section--g10 bx--cta-section__has-items"
-                        data-autoid="dds--cta-section"
-                      >
-                        <ContentBlock
-                          border={false}
-                          copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
-                          cta={
-                            Object {
-                              "buttons": Array [
-                                Object {
-                                  "copy": Array [
-                                    "Contact sales",
-                                  ],
-                                  "iconDescription": "right arrow icon",
-                                  "onClick": [Function],
-                                  "renderIcon": Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "render": [Function],
-                                  },
-                                  "target": null,
-                                  "type": "local",
-                                },
-                              ],
-                              "style": "button",
-                              "type": "local",
-                            }
-                          }
-                          heading="Take the next step"
-                        >
-                          <div
-                            className="bx--content-block"
-                            data-autoid="dds--content-block"
-                          >
-                            <div>
-                              <h2
-                                className="bx--content-block__heading"
-                                data-autoid="dds--content-block__heading"
-                              >
-                                Take the next step
-                              </h2>
-                            </div>
-                            <div
-                              className="bx--content-block__copy"
-                              dangerouslySetInnerHTML={
-                                Object {
-                                  "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
-                                }
-                              }
-                            />
-                            <div
-                              className="bx--content-block__children"
-                              data-autoid="dds--content-block__children"
-                            />
-                            <div
-                              className="bx--content-block__cta-row"
-                              data-autoid="dds--content-block__cta"
-                            >
-                              <CTA
-                                buttons={
+                                </section>
+                              </LogoGrid>
+                              <a
+                                data-title="Aliquam condimentum interdum"
+                                name="section-6"
+                              />
+                              <ContentBlockCards
+                                cards={
                                   Array [
                                     Object {
-                                      "copy": Array [
-                                        "Contact sales",
-                                      ],
-                                      "iconDescription": "right arrow icon",
-                                      "onClick": [Function],
-                                      "renderIcon": Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "render": [Function],
+                                      "cta": Object {
+                                        "href": "https://www.example.com",
                                       },
-                                      "target": null,
-                                      "type": "local",
+                                      "eyebrow": "Topic",
+                                      "heading": "Natural language processing.",
+                                      "image": Object {
+                                        "alt": "Image alt text",
+                                        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                      },
+                                    },
+                                    Object {
+                                      "cta": Object {
+                                        "href": "https://www.example.com",
+                                      },
+                                      "eyebrow": "Topic",
+                                      "heading": "Natural language processing.",
+                                      "image": Object {
+                                        "alt": "Image alt text",
+                                        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                      },
+                                    },
+                                    Object {
+                                      "cta": Object {
+                                        "href": "https://www.example.com",
+                                      },
+                                      "eyebrow": "Topic",
+                                      "heading": "Natural language processing.",
+                                      "image": Object {
+                                        "alt": "Image alt text",
+                                        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                      },
                                     },
                                   ]
                                 }
-                                copy=""
-                                customClassName="bx--content-block__cta bx--content-block__cta-col"
-                                href=""
-                                style="button"
-                                type="local"
+                                heading="Aliquam condimentum interdum"
                               >
                                 <div
-                                  className="bx--content-block__cta bx--content-block__cta-col"
+                                  className="bx--content-block-cards"
+                                  data-autoid="dds--content-block-cards"
                                 >
-                                  <ButtonCTA
-                                    buttons={
-                                      Array [
-                                        Object {
-                                          "copy": Array [
-                                            "Contact sales",
-                                          ],
-                                          "iconDescription": "right arrow icon",
-                                          "onClick": [Function],
-                                          "renderIcon": Object {
-                                            "$$typeof": Symbol(react.forward_ref),
-                                            "render": [Function],
-                                          },
-                                          "target": null,
-                                          "type": "local",
-                                        },
-                                      ]
-                                    }
-                                    copy=""
-                                    formatCTAcopy={[Function]}
-                                    href=""
-                                    openLightBox={[Function]}
-                                    renderLightBox={false}
-                                    style="button"
-                                    type="local"
-                                    videoTitle={
-                                      Array [
-                                        Object {
-                                          "duration": "",
-                                          "key": 0,
-                                          "title": "",
-                                        },
-                                      ]
-                                    }
+                                  <ContentBlock
+                                    border={false}
+                                    heading="Aliquam condimentum interdum"
                                   >
-                                    <ButtonGroup
+                                    <div
+                                      className="bx--content-block"
+                                      data-autoid="dds--content-block"
+                                    >
+                                      <div>
+                                        <h2
+                                          className="bx--content-block__heading"
+                                          data-autoid="dds--content-block__heading"
+                                        >
+                                          Aliquam condimentum interdum
+                                        </h2>
+                                      </div>
+                                      <div
+                                        className="bx--content-block__children"
+                                        data-autoid="dds--content-block__children"
+                                      >
+                                        <div
+                                          className="bx--content-block-cards__content"
+                                        >
+                                          <CardGroup
+                                            cards={
+                                              Array [
+                                                Object {
+                                                  "cta": Object {
+                                                    "href": "https://www.example.com",
+                                                  },
+                                                  "eyebrow": "Topic",
+                                                  "heading": "Natural language processing.",
+                                                  "image": Object {
+                                                    "alt": "Image alt text",
+                                                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                  },
+                                                },
+                                                Object {
+                                                  "cta": Object {
+                                                    "href": "https://www.example.com",
+                                                  },
+                                                  "eyebrow": "Topic",
+                                                  "heading": "Natural language processing.",
+                                                  "image": Object {
+                                                    "alt": "Image alt text",
+                                                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                  },
+                                                },
+                                                Object {
+                                                  "cta": Object {
+                                                    "href": "https://www.example.com",
+                                                  },
+                                                  "eyebrow": "Topic",
+                                                  "heading": "Natural language processing.",
+                                                  "image": Object {
+                                                    "alt": "Image alt text",
+                                                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                  },
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <div
+                                              className="bx--card-group__cards__row bx--row--condensed"
+                                              data-autoid="dds--card-group"
+                                            >
+                                              <div
+                                                aria-label="Natural language processing."
+                                                className="bx--card-group__cards__col"
+                                                key="0"
+                                                role="region"
+                                              >
+                                                <Card
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://www.example.com",
+                                                      "icon": Object {
+                                                        "src": Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        },
+                                                      },
+                                                    }
+                                                  }
+                                                  customClassName="bx--card-group__card"
+                                                  eyebrow="Topic"
+                                                  heading="Natural language processing."
+                                                  image={
+                                                    Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                    }
+                                                  }
+                                                  key="0"
+                                                  type="link"
+                                                >
+                                                  <ClickableTile
+                                                    className="bx--card bx--card--link bx--card-group__card"
+                                                    clicked={false}
+                                                    data-autoid="dds--card"
+                                                    handleClick={[Function]}
+                                                    handleKeyDown={[Function]}
+                                                    href="https://www.example.com"
+                                                    light={false}
+                                                    onClick={[Function]}
+                                                    target={null}
+                                                  >
+                                                    <a
+                                                      className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                                      data-autoid="dds--card"
+                                                      href="https://www.example.com"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--card__img"
+                                                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--card__img"
+                                                              src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                      <div
+                                                        className="bx--card__wrapper"
+                                                      >
+                                                        <p
+                                                          className="bx--card__eyebrow"
+                                                        >
+                                                          Topic
+                                                        </p>
+                                                        <h3
+                                                          className="bx--card__heading"
+                                                        >
+                                                          Natural language processing.
+                                                        </h3>
+                                                        <div
+                                                          className="bx--card__footer"
+                                                        >
+                                                          <ForwardRef(ArrowRight20)
+                                                            className="bx--card__cta"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
+                                                          >
+                                                            <Icon
+                                                              className="bx--card__cta"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                              viewBox="0 0 20 20"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="bx--card__cta"
+                                                                focusable="false"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowRight20)>
+                                                          <span />
+                                                        </div>
+                                                      </div>
+                                                    </a>
+                                                  </ClickableTile>
+                                                </Card>
+                                              </div>
+                                              <div
+                                                aria-label="Natural language processing."
+                                                className="bx--card-group__cards__col"
+                                                key="1"
+                                                role="region"
+                                              >
+                                                <Card
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://www.example.com",
+                                                      "icon": Object {
+                                                        "src": Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        },
+                                                      },
+                                                    }
+                                                  }
+                                                  customClassName="bx--card-group__card"
+                                                  eyebrow="Topic"
+                                                  heading="Natural language processing."
+                                                  image={
+                                                    Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                    }
+                                                  }
+                                                  key="1"
+                                                  type="link"
+                                                >
+                                                  <ClickableTile
+                                                    className="bx--card bx--card--link bx--card-group__card"
+                                                    clicked={false}
+                                                    data-autoid="dds--card"
+                                                    handleClick={[Function]}
+                                                    handleKeyDown={[Function]}
+                                                    href="https://www.example.com"
+                                                    light={false}
+                                                    onClick={[Function]}
+                                                    target={null}
+                                                  >
+                                                    <a
+                                                      className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                                      data-autoid="dds--card"
+                                                      href="https://www.example.com"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--card__img"
+                                                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--card__img"
+                                                              src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                      <div
+                                                        className="bx--card__wrapper"
+                                                      >
+                                                        <p
+                                                          className="bx--card__eyebrow"
+                                                        >
+                                                          Topic
+                                                        </p>
+                                                        <h3
+                                                          className="bx--card__heading"
+                                                        >
+                                                          Natural language processing.
+                                                        </h3>
+                                                        <div
+                                                          className="bx--card__footer"
+                                                        >
+                                                          <ForwardRef(ArrowRight20)
+                                                            className="bx--card__cta"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
+                                                          >
+                                                            <Icon
+                                                              className="bx--card__cta"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                              viewBox="0 0 20 20"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="bx--card__cta"
+                                                                focusable="false"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowRight20)>
+                                                          <span />
+                                                        </div>
+                                                      </div>
+                                                    </a>
+                                                  </ClickableTile>
+                                                </Card>
+                                              </div>
+                                              <div
+                                                aria-label="Natural language processing."
+                                                className="bx--card-group__cards__col"
+                                                key="2"
+                                                role="region"
+                                              >
+                                                <Card
+                                                  cta={
+                                                    Object {
+                                                      "href": "https://www.example.com",
+                                                      "icon": Object {
+                                                        "src": Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        },
+                                                      },
+                                                    }
+                                                  }
+                                                  customClassName="bx--card-group__card"
+                                                  eyebrow="Topic"
+                                                  heading="Natural language processing."
+                                                  image={
+                                                    Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                    }
+                                                  }
+                                                  key="2"
+                                                  type="link"
+                                                >
+                                                  <ClickableTile
+                                                    className="bx--card bx--card--link bx--card-group__card"
+                                                    clicked={false}
+                                                    data-autoid="dds--card"
+                                                    handleClick={[Function]}
+                                                    handleKeyDown={[Function]}
+                                                    href="https://www.example.com"
+                                                    light={false}
+                                                    onClick={[Function]}
+                                                    target={null}
+                                                  >
+                                                    <a
+                                                      className="bx--tile bx--tile--clickable bx--card bx--card--link bx--card-group__card"
+                                                      data-autoid="dds--card"
+                                                      href="https://www.example.com"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--card__img"
+                                                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription-"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--card__img"
+                                                              src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                      <div
+                                                        className="bx--card__wrapper"
+                                                      >
+                                                        <p
+                                                          className="bx--card__eyebrow"
+                                                        >
+                                                          Topic
+                                                        </p>
+                                                        <h3
+                                                          className="bx--card__heading"
+                                                        >
+                                                          Natural language processing.
+                                                        </h3>
+                                                        <div
+                                                          className="bx--card__footer"
+                                                        >
+                                                          <ForwardRef(ArrowRight20)
+                                                            className="bx--card__cta"
+                                                            src={
+                                                              Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              }
+                                                            }
+                                                          >
+                                                            <Icon
+                                                              className="bx--card__cta"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                              viewBox="0 0 20 20"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="bx--card__cta"
+                                                                focusable="false"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowRight20)>
+                                                          <span />
+                                                        </div>
+                                                      </div>
+                                                    </a>
+                                                  </ClickableTile>
+                                                </Card>
+                                              </div>
+                                            </div>
+                                          </CardGroup>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </ContentBlock>
+                                </div>
+                              </ContentBlockCards>
+                              <a
+                                data-title="Duis aute irure dolor in reprehenderit"
+                                name="section-7"
+                              />
+                              <CalloutQuote
+                                quote={
+                                  Object {
+                                    "copy": "Duis aute irure dolor in reprehenderit",
+                                    "cta": Object {
+                                      "copy": "Link with Icon",
+                                      "href": "https://example.com",
+                                      "type": "local",
+                                    },
+                                    "source": Object {
+                                      "copy": "dolor sit amet",
+                                      "heading": "Lorem ipsum",
+                                    },
+                                  }
+                                }
+                              >
+                                <div
+                                  className="bx--callout-quote"
+                                  data-autoid="dds--callout-quote"
+                                >
+                                  <Callout>
+                                    <section
+                                      className="bx--callout__container"
+                                      data-autoid="dds--callout__container"
+                                    >
+                                      <div
+                                        className="bx--callout__column"
+                                        data-autoid="dds--callout__column"
+                                      >
+                                        <div
+                                          className="bx--callout__content"
+                                          data-autoid="dds--callout__content"
+                                        >
+                                          <Quote
+                                            copy="Duis aute irure dolor in reprehenderit"
+                                            cta={
+                                              Object {
+                                                "copy": "Link with Icon",
+                                                "href": "https://example.com",
+                                                "type": "local",
+                                              }
+                                            }
+                                            inverse={true}
+                                            source={
+                                              Object {
+                                                "copy": "dolor sit amet",
+                                                "heading": "Lorem ipsum",
+                                              }
+                                            }
+                                          >
+                                            <div
+                                              className="bx--quote bx--quote__inverse"
+                                              data-autoid="dds--quote"
+                                            >
+                                              <div
+                                                className="bx--quote__container"
+                                              >
+                                                <div
+                                                  className="bx--quote__wrapper"
+                                                  data-autoid="dds--quote__copy"
+                                                >
+                                                  <span
+                                                    className="bx--quote__mark"
+                                                  >
+                                                    “
+                                                  </span>
+                                                  <blockquote
+                                                    className="bx--quote__copy"
+                                                  >
+                                                    Duis aute irure dolor in reprehenderit
+                                                    ”
+                                                  </blockquote>
+                                                </div>
+                                                <div
+                                                  className="bx--quote__source"
+                                                  data-autoid="dds--quote__source"
+                                                >
+                                                  <p
+                                                    className="bx--quote__source-heading"
+                                                  >
+                                                    Lorem ipsum
+                                                  </p>
+                                                  <p
+                                                    className="bx--quote__source-body"
+                                                  >
+                                                    dolor sit amet
+                                                  </p>
+                                                </div>
+                                              </div>
+                                              <div
+                                                className="bx--quote__footer"
+                                              >
+                                                <HorizontalRule>
+                                                  <hr
+                                                    className="bx--hr"
+                                                    data-autoid="dds--hr"
+                                                  />
+                                                </HorizontalRule>
+                                                <LinkWithIcon
+                                                  href="https://example.com"
+                                                >
+                                                  <div
+                                                    className="bx--link-with-icon__container"
+                                                    data-autoid="dds--link-with-icon"
+                                                  >
+                                                    <Link
+                                                      className="bx--link-with-icon"
+                                                      href="https://example.com"
+                                                    >
+                                                      <a
+                                                        className="bx--link bx--link-with-icon"
+                                                        href="https://example.com"
+                                                      >
+                                                        Link with Icon
+                                                        <ForwardRef(ArrowRight20)>
+                                                          <Icon
+                                                            height={20}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 20 20"
+                                                            width={20}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              focusable="false"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 20 20"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(ArrowRight20)>
+                                                      </a>
+                                                    </Link>
+                                                  </div>
+                                                </LinkWithIcon>
+                                              </div>
+                                            </div>
+                                          </Quote>
+                                        </div>
+                                      </div>
+                                    </section>
+                                  </Callout>
+                                </div>
+                              </CalloutQuote>
+                            </div>
+                          </div>
+                        </div>
+                      </section>
+                    </Layout>
+                  </section>
+                </TableOfContents>
+                <div
+                  className="bx--grid"
+                  style={
+                    Object {
+                      "backgroundColor": "#f4f4f4",
+                    }
+                  }
+                >
+                  <div
+                    className="bx--row"
+                  >
+                    <div
+                      className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                    >
+                      <CTASection
+                        copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
+                        cta={
+                          Object {
+                            "buttons": Array [
+                              Object {
+                                "copy": Array [
+                                  "Contact sales",
+                                ],
+                                "iconDescription": "right arrow icon",
+                                "onClick": [Function],
+                                "renderIcon": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                },
+                                "target": null,
+                                "type": "local",
+                              },
+                            ],
+                            "style": "button",
+                            "type": "local",
+                          }
+                        }
+                        heading="Take the next step"
+                        items={
+                          Array [
+                            Object {
+                              "copy": "
+            IBM DevOps partners have a wide range of expertise.
+            Find one to build the right solution for you.
+            ",
+                              "cta": Object {
+                                "copy": "Find a partner",
+                                "href": "https://example.com/",
+                                "type": "local",
+                              },
+                              "heading": "Get connected",
+                            },
+                            Object {
+                              "copy": "Dig into more self-directed learning about DevOps methodologies.",
+                              "cta": Object {
+                                "copy": "Browse tutorials",
+                                "href": "https://example.com/",
+                                "type": "local",
+                              },
+                              "heading": "Learn how",
+                            },
+                          ]
+                        }
+                        theme="g10"
+                      >
+                        <section
+                          className="bx--cta-section bx--cta-section--g10 bx--cta-section__has-items"
+                          data-autoid="dds--cta-section"
+                        >
+                          <ContentBlock
+                            border={false}
+                            copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
+                            cta={
+                              Object {
+                                "buttons": Array [
+                                  Object {
+                                    "copy": Array [
+                                      "Contact sales",
+                                    ],
+                                    "iconDescription": "right arrow icon",
+                                    "onClick": [Function],
+                                    "renderIcon": Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "render": [Function],
+                                    },
+                                    "target": null,
+                                    "type": "local",
+                                  },
+                                ],
+                                "style": "button",
+                                "type": "local",
+                              }
+                            }
+                            heading="Take the next step"
+                          >
+                            <div
+                              className="bx--content-block"
+                              data-autoid="dds--content-block"
+                            >
+                              <div>
+                                <h2
+                                  className="bx--content-block__heading"
+                                  data-autoid="dds--content-block__heading"
+                                >
+                                  Take the next step
+                                </h2>
+                              </div>
+                              <div
+                                className="bx--content-block__copy"
+                                dangerouslySetInnerHTML={
+                                  Object {
+                                    "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
+                                  }
+                                }
+                              />
+                              <div
+                                className="bx--content-block__children"
+                                data-autoid="dds--content-block__children"
+                              />
+                              <div
+                                className="bx--content-block__cta-row"
+                                data-autoid="dds--content-block__cta"
+                              >
+                                <CTA
+                                  buttons={
+                                    Array [
+                                      Object {
+                                        "copy": Array [
+                                          "Contact sales",
+                                        ],
+                                        "iconDescription": "right arrow icon",
+                                        "onClick": [Function],
+                                        "renderIcon": Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "render": [Function],
+                                        },
+                                        "target": null,
+                                        "type": "local",
+                                      },
+                                    ]
+                                  }
+                                  copy=""
+                                  customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                  href=""
+                                  style="button"
+                                  type="local"
+                                >
+                                  <div
+                                    className="bx--content-block__cta bx--content-block__cta-col"
+                                  >
+                                    <ButtonCTA
                                       buttons={
                                         Array [
                                           Object {
@@ -6400,39 +6366,52 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                           },
                                         ]
                                       }
-                                      enableSizeByContent={true}
+                                      copy=""
+                                      formatCTAcopy={[Function]}
+                                      href=""
+                                      openLightBox={[Function]}
+                                      renderLightBox={false}
+                                      style="button"
+                                      type="local"
+                                      videoTitle={
+                                        Array [
+                                          Object {
+                                            "duration": "",
+                                            "key": 0,
+                                            "title": "",
+                                          },
+                                        ]
+                                      }
                                     >
-                                      <ol
-                                        className="bx--buttongroup"
-                                        data-autoid="dds--button-group"
-                                      >
-                                        <li
-                                          className="bx--buttongroup-item"
-                                          key="0"
-                                        >
-                                          <ForwardRef(Button)
-                                            copy={
-                                              Array [
+                                      <ButtonGroup
+                                        buttons={
+                                          Array [
+                                            Object {
+                                              "copy": Array [
                                                 "Contact sales",
-                                              ]
-                                            }
-                                            data-autoid="dds--button-group-0"
-                                            disabled={false}
-                                            iconDescription="right arrow icon"
-                                            kind="primary"
-                                            onClick={[Function]}
-                                            renderIcon={
-                                              Object {
+                                              ],
+                                              "iconDescription": "right arrow icon",
+                                              "onClick": [Function],
+                                              "renderIcon": Object {
                                                 "$$typeof": Symbol(react.forward_ref),
                                                 "render": [Function],
-                                              }
-                                            }
-                                            tabIndex={2}
-                                            target={null}
-                                            type="button"
+                                              },
+                                              "target": null,
+                                              "type": "local",
+                                            },
+                                          ]
+                                        }
+                                        enableSizeByContent={true}
+                                      >
+                                        <ol
+                                          className="bx--buttongroup"
+                                          data-autoid="dds--button-group"
+                                        >
+                                          <li
+                                            className="bx--buttongroup-item"
+                                            key="0"
                                           >
-                                            <button
-                                              className="bx--btn bx--btn--primary"
+                                            <ForwardRef(Button)
                                               copy={
                                                 Array [
                                                   "Contact sales",
@@ -6440,302 +6419,325 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               }
                                               data-autoid="dds--button-group-0"
                                               disabled={false}
+                                              iconDescription="right arrow icon"
+                                              kind="primary"
                                               onClick={[Function]}
+                                              renderIcon={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "render": [Function],
+                                                }
+                                              }
                                               tabIndex={2}
                                               target={null}
                                               type="button"
                                             >
-                                              Contact sales
-                                              <ForwardRef(ArrowRight20)
-                                                aria-hidden="true"
-                                                aria-label="right arrow icon"
-                                                className="bx--btn__icon"
+                                              <button
+                                                className="bx--btn bx--btn--primary"
+                                                copy={
+                                                  Array [
+                                                    "Contact sales",
+                                                  ]
+                                                }
+                                                data-autoid="dds--button-group-0"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                tabIndex={2}
+                                                target={null}
+                                                type="button"
                                               >
-                                                <Icon
+                                                Contact sales
+                                                <ForwardRef(ArrowRight20)
                                                   aria-hidden="true"
                                                   aria-label="right arrow icon"
                                                   className="bx--btn__icon"
-                                                  height={20}
-                                                  preserveAspectRatio="xMidYMid meet"
-                                                  viewBox="0 0 20 20"
-                                                  width={20}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <svg
+                                                  <Icon
                                                     aria-hidden="true"
                                                     aria-label="right arrow icon"
                                                     className="bx--btn__icon"
-                                                    focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
-                                                    role="img"
                                                     viewBox="0 0 20 20"
                                                     width={20}
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                    />
-                                                  </svg>
-                                                </Icon>
-                                              </ForwardRef(ArrowRight20)>
-                                            </button>
-                                          </ForwardRef(Button)>
-                                        </li>
-                                      </ol>
-                                    </ButtonGroup>
-                                  </ButtonCTA>
-                                </div>
-                              </CTA>
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      aria-label="right arrow icon"
+                                                      className="bx--btn__icon"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      role="img"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </button>
+                                            </ForwardRef(Button)>
+                                          </li>
+                                        </ol>
+                                      </ButtonGroup>
+                                    </ButtonCTA>
+                                  </div>
+                                </CTA>
+                              </div>
                             </div>
-                          </div>
-                        </ContentBlock>
-                        <div
-                          className="bx--helper-wrapper"
-                        >
+                          </ContentBlock>
                           <div
-                            className="bx--content-item-wrapper"
+                            className="bx--helper-wrapper"
                           >
-                            <ContentItem
-                              copy="
+                            <div
+                              className="bx--content-item-wrapper"
+                            >
+                              <ContentItem
+                                copy="
             IBM DevOps partners have a wide range of expertise.
             Find one to build the right solution for you.
             "
-                              cta={
-                                Object {
-                                  "copy": "Find a partner",
-                                  "href": "https://example.com/",
-                                  "type": "local",
-                                }
-                              }
-                              heading="Get connected"
-                              key="0"
-                            >
-                              <div
-                                className="bx--content-item"
-                                data-autoid="dds--content-item"
-                              >
-                                <h4
-                                  className="bx--content-item__heading"
-                                  data-autoid="dds--content-item__heading"
-                                >
-                                  Get connected
-                                </h4>
-                                <div
-                                  className="bx--content-item__copy"
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<p>  IBM DevOps partners have a wide range of expertise.  Find one to build the right solution for you.  </p>",
-                                    }
+                                cta={
+                                  Object {
+                                    "copy": "Find a partner",
+                                    "href": "https://example.com/",
+                                    "type": "local",
                                   }
-                                  data-autoid="dds--content-item__copy"
-                                />
-                                <CTA
-                                  copy="Find a partner"
-                                  customClassName="bx--content-item__cta"
-                                  href="https://example.com/"
-                                  style="text"
-                                  type="local"
+                                }
+                                heading="Get connected"
+                                key="0"
+                              >
+                                <div
+                                  className="bx--content-item"
+                                  data-autoid="dds--content-item"
                                 >
-                                  <div
-                                    className="bx--content-item__cta"
+                                  <h4
+                                    className="bx--content-item__heading"
+                                    data-autoid="dds--content-item__heading"
                                   >
-                                    <TextCTA
-                                      copy="Find a partner"
-                                      formatCTAcopy={[Function]}
-                                      href="https://example.com/"
-                                      openLightBox={[Function]}
-                                      renderLightBox={false}
-                                      style="text"
-                                      type="local"
-                                      videoTitle={
-                                        Array [
-                                          Object {
-                                            "duration": "",
-                                            "key": 0,
-                                            "title": "",
-                                          },
-                                        ]
+                                    Get connected
+                                  </h4>
+                                  <div
+                                    className="bx--content-item__copy"
+                                    dangerouslySetInnerHTML={
+                                      Object {
+                                        "__html": "<p>  IBM DevOps partners have a wide range of expertise.  Find one to build the right solution for you.  </p>",
                                       }
+                                    }
+                                    data-autoid="dds--content-item__copy"
+                                  />
+                                  <CTA
+                                    copy="Find a partner"
+                                    customClassName="bx--content-item__cta"
+                                    href="https://example.com/"
+                                    style="text"
+                                    type="local"
+                                  >
+                                    <div
+                                      className="bx--content-item__cta"
                                     >
-                                      <LinkWithIcon
+                                      <TextCTA
+                                        copy="Find a partner"
+                                        formatCTAcopy={[Function]}
                                         href="https://example.com/"
-                                        onClick={[Function]}
-                                        target={null}
+                                        openLightBox={[Function]}
+                                        renderLightBox={false}
+                                        style="text"
+                                        type="local"
+                                        videoTitle={
+                                          Array [
+                                            Object {
+                                              "duration": "",
+                                              "key": 0,
+                                              "title": "",
+                                            },
+                                          ]
+                                        }
                                       >
-                                        <div
-                                          className="bx--link-with-icon__container"
-                                          data-autoid="dds--link-with-icon"
+                                        <LinkWithIcon
+                                          href="https://example.com/"
+                                          onClick={[Function]}
+                                          target={null}
                                         >
-                                          <Link
-                                            className="bx--link-with-icon"
-                                            href="https://example.com/"
-                                            onClick={[Function]}
-                                            target={null}
+                                          <div
+                                            className="bx--link-with-icon__container"
+                                            data-autoid="dds--link-with-icon"
                                           >
-                                            <a
-                                              className="bx--link bx--link-with-icon"
+                                            <Link
+                                              className="bx--link-with-icon"
                                               href="https://example.com/"
                                               onClick={[Function]}
                                               target={null}
                                             >
-                                              <span>
-                                                Find a partner
-                                              </span>
-                                              <ForwardRef(ArrowRight20)>
-                                                <Icon
-                                                  height={20}
-                                                  preserveAspectRatio="xMidYMid meet"
-                                                  viewBox="0 0 20 20"
-                                                  width={20}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    focusable="false"
+                                              <a
+                                                className="bx--link bx--link-with-icon"
+                                                href="https://example.com/"
+                                                onClick={[Function]}
+                                                target={null}
+                                              >
+                                                <span>
+                                                  Find a partner
+                                                </span>
+                                                <ForwardRef(ArrowRight20)>
+                                                  <Icon
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     viewBox="0 0 20 20"
                                                     width={20}
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                    />
-                                                  </svg>
-                                                </Icon>
-                                              </ForwardRef(ArrowRight20)>
-                                            </a>
-                                          </Link>
-                                        </div>
-                                      </LinkWithIcon>
-                                    </TextCTA>
-                                  </div>
-                                </CTA>
-                              </div>
-                            </ContentItem>
-                            <ContentItem
-                              copy="Dig into more self-directed learning about DevOps methodologies."
-                              cta={
-                                Object {
-                                  "copy": "Browse tutorials",
-                                  "href": "https://example.com/",
-                                  "type": "local",
-                                }
-                              }
-                              heading="Learn how"
-                              key="1"
-                            >
-                              <div
-                                className="bx--content-item"
-                                data-autoid="dds--content-item"
-                              >
-                                <h4
-                                  className="bx--content-item__heading"
-                                  data-autoid="dds--content-item__heading"
-                                >
-                                  Learn how
-                                </h4>
-                                <div
-                                  className="bx--content-item__copy"
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p>",
-                                    }
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </a>
+                                            </Link>
+                                          </div>
+                                        </LinkWithIcon>
+                                      </TextCTA>
+                                    </div>
+                                  </CTA>
+                                </div>
+                              </ContentItem>
+                              <ContentItem
+                                copy="Dig into more self-directed learning about DevOps methodologies."
+                                cta={
+                                  Object {
+                                    "copy": "Browse tutorials",
+                                    "href": "https://example.com/",
+                                    "type": "local",
                                   }
-                                  data-autoid="dds--content-item__copy"
-                                />
-                                <CTA
-                                  copy="Browse tutorials"
-                                  customClassName="bx--content-item__cta"
-                                  href="https://example.com/"
-                                  style="text"
-                                  type="local"
+                                }
+                                heading="Learn how"
+                                key="1"
+                              >
+                                <div
+                                  className="bx--content-item"
+                                  data-autoid="dds--content-item"
                                 >
-                                  <div
-                                    className="bx--content-item__cta"
+                                  <h4
+                                    className="bx--content-item__heading"
+                                    data-autoid="dds--content-item__heading"
                                   >
-                                    <TextCTA
-                                      copy="Browse tutorials"
-                                      formatCTAcopy={[Function]}
-                                      href="https://example.com/"
-                                      openLightBox={[Function]}
-                                      renderLightBox={false}
-                                      style="text"
-                                      type="local"
-                                      videoTitle={
-                                        Array [
-                                          Object {
-                                            "duration": "",
-                                            "key": 0,
-                                            "title": "",
-                                          },
-                                        ]
+                                    Learn how
+                                  </h4>
+                                  <div
+                                    className="bx--content-item__copy"
+                                    dangerouslySetInnerHTML={
+                                      Object {
+                                        "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p>",
                                       }
+                                    }
+                                    data-autoid="dds--content-item__copy"
+                                  />
+                                  <CTA
+                                    copy="Browse tutorials"
+                                    customClassName="bx--content-item__cta"
+                                    href="https://example.com/"
+                                    style="text"
+                                    type="local"
+                                  >
+                                    <div
+                                      className="bx--content-item__cta"
                                     >
-                                      <LinkWithIcon
+                                      <TextCTA
+                                        copy="Browse tutorials"
+                                        formatCTAcopy={[Function]}
                                         href="https://example.com/"
-                                        onClick={[Function]}
-                                        target={null}
+                                        openLightBox={[Function]}
+                                        renderLightBox={false}
+                                        style="text"
+                                        type="local"
+                                        videoTitle={
+                                          Array [
+                                            Object {
+                                              "duration": "",
+                                              "key": 0,
+                                              "title": "",
+                                            },
+                                          ]
+                                        }
                                       >
-                                        <div
-                                          className="bx--link-with-icon__container"
-                                          data-autoid="dds--link-with-icon"
+                                        <LinkWithIcon
+                                          href="https://example.com/"
+                                          onClick={[Function]}
+                                          target={null}
                                         >
-                                          <Link
-                                            className="bx--link-with-icon"
-                                            href="https://example.com/"
-                                            onClick={[Function]}
-                                            target={null}
+                                          <div
+                                            className="bx--link-with-icon__container"
+                                            data-autoid="dds--link-with-icon"
                                           >
-                                            <a
-                                              className="bx--link bx--link-with-icon"
+                                            <Link
+                                              className="bx--link-with-icon"
                                               href="https://example.com/"
                                               onClick={[Function]}
                                               target={null}
                                             >
-                                              <span>
-                                                Browse tutorials
-                                              </span>
-                                              <ForwardRef(ArrowRight20)>
-                                                <Icon
-                                                  height={20}
-                                                  preserveAspectRatio="xMidYMid meet"
-                                                  viewBox="0 0 20 20"
-                                                  width={20}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    focusable="false"
+                                              <a
+                                                className="bx--link bx--link-with-icon"
+                                                href="https://example.com/"
+                                                onClick={[Function]}
+                                                target={null}
+                                              >
+                                                <span>
+                                                  Browse tutorials
+                                                </span>
+                                                <ForwardRef(ArrowRight20)>
+                                                  <Icon
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     viewBox="0 0 20 20"
                                                     width={20}
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
-                                                    />
-                                                  </svg>
-                                                </Icon>
-                                              </ForwardRef(ArrowRight20)>
-                                            </a>
-                                          </Link>
-                                        </div>
-                                      </LinkWithIcon>
-                                    </TextCTA>
-                                  </div>
-                                </CTA>
-                              </div>
-                            </ContentItem>
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </a>
+                                            </Link>
+                                          </div>
+                                        </LinkWithIcon>
+                                      </TextCTA>
+                                    </div>
+                                  </CTA>
+                                </div>
+                              </ContentItem>
+                            </div>
                           </div>
-                        </div>
-                      </section>
-                    </CTASection>
+                        </section>
+                      </CTASection>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </Content>
             </div>
           </main>
         </div>
@@ -14627,153 +14629,155 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
                   <div
                     className="bx--tableofcontents__content-wrapper"
                   >
-                    <div>
-                      <a
-                        data-title="Cras molestie condimentum"
-                        name="8"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                    <DataContent>
+                      <div>
+                        <a
+                          data-title="Cras molestie condimentum"
+                          name="8"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Cras molestie condimentum
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Praesent fermentum sodales"
-                        name="7"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Cras molestie condimentum
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Praesent fermentum sodales"
+                          name="7"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Praesent fermentum sodales
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Nulla tristique lacinia"
-                        name="2"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Praesent fermentum sodales
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Nulla tristique lacinia"
+                          name="2"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Nulla tristique lacinia
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Morbi id nibh metus"
-                        name="3"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Nulla tristique lacinia
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Morbi id nibh metus"
+                          name="3"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Morbi id nibh metus
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Integer non scelerisque"
-                        name="14"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Morbi id nibh metus
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Integer non scelerisque"
+                          name="14"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Integer non scelerisque
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                    </div>
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Integer non scelerisque
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                      </div>
+                    </DataContent>
                   </div>
                 </div>
               </div>
@@ -15131,153 +15135,155 @@ exports[`Storyshots Components|Table of Contents Manually define Menu Items 1`] 
                 <div
                   className="bx--tableofcontents__content-wrapper"
                 >
-                  <div>
-                    <a
-                      data-title="Cras molestie condimentum"
-                      name="8"
-                      style={
-                        Object {
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <h3
+                  <DataContent>
+                    <div>
+                      <a
+                        data-title="Cras molestie condimentum"
+                        name="8"
                         style={
                           Object {
-                            "paddingBottom": "1rem",
-                            "paddingTop": "2rem",
+                            "color": "#000",
                           }
                         }
                       >
-                        Cras molestie condimentum
-                      </h3>
-                    </a>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <a
-                      data-title="Praesent fermentum sodales"
-                      name="7"
-                      style={
-                        Object {
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <h3
+                        <h3
+                          style={
+                            Object {
+                              "paddingBottom": "1rem",
+                              "paddingTop": "2rem",
+                            }
+                          }
+                        >
+                          Cras molestie condimentum
+                        </h3>
+                      </a>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <a
+                        data-title="Praesent fermentum sodales"
+                        name="7"
                         style={
                           Object {
-                            "paddingBottom": "1rem",
-                            "paddingTop": "2rem",
+                            "color": "#000",
                           }
                         }
                       >
-                        Praesent fermentum sodales
-                      </h3>
-                    </a>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <a
-                      data-title="Nulla tristique lacinia"
-                      name="2"
-                      style={
-                        Object {
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <h3
+                        <h3
+                          style={
+                            Object {
+                              "paddingBottom": "1rem",
+                              "paddingTop": "2rem",
+                            }
+                          }
+                        >
+                          Praesent fermentum sodales
+                        </h3>
+                      </a>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <a
+                        data-title="Nulla tristique lacinia"
+                        name="2"
                         style={
                           Object {
-                            "paddingBottom": "1rem",
-                            "paddingTop": "2rem",
+                            "color": "#000",
                           }
                         }
                       >
-                        Nulla tristique lacinia
-                      </h3>
-                    </a>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <a
-                      data-title="Morbi id nibh metus"
-                      name="3"
-                      style={
-                        Object {
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <h3
+                        <h3
+                          style={
+                            Object {
+                              "paddingBottom": "1rem",
+                              "paddingTop": "2rem",
+                            }
+                          }
+                        >
+                          Nulla tristique lacinia
+                        </h3>
+                      </a>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <a
+                        data-title="Morbi id nibh metus"
+                        name="3"
                         style={
                           Object {
-                            "paddingBottom": "1rem",
-                            "paddingTop": "2rem",
+                            "color": "#000",
                           }
                         }
                       >
-                        Morbi id nibh metus
-                      </h3>
-                    </a>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <a
-                      data-title="Integer non scelerisque"
-                      name="14"
-                      style={
-                        Object {
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <h3
+                        <h3
+                          style={
+                            Object {
+                              "paddingBottom": "1rem",
+                              "paddingTop": "2rem",
+                            }
+                          }
+                        >
+                          Morbi id nibh metus
+                        </h3>
+                      </a>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <a
+                        data-title="Integer non scelerisque"
+                        name="14"
                         style={
                           Object {
-                            "paddingBottom": "1rem",
-                            "paddingTop": "2rem",
+                            "color": "#000",
                           }
                         }
                       >
-                        Integer non scelerisque
-                      </h3>
-                    </a>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                    </p>
-                  </div>
+                        <h3
+                          style={
+                            Object {
+                              "paddingBottom": "1rem",
+                              "paddingTop": "2rem",
+                            }
+                          }
+                        >
+                          Integer non scelerisque
+                        </h3>
+                      </a>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                      </p>
+                    </div>
+                  </DataContent>
                 </div>
               </div>
             </div>
@@ -15909,153 +15915,155 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                         </div>
                       </Image>
                     </div>
-                    <div>
-                      <a
-                        data-title="Cras molestie condimentum"
-                        name="8"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                    <DataContent>
+                      <div>
+                        <a
+                          data-title="Cras molestie condimentum"
+                          name="8"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Cras molestie condimentum
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Praesent fermentum sodales"
-                        name="7"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Cras molestie condimentum
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Praesent fermentum sodales"
+                          name="7"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Praesent fermentum sodales
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Nulla tristique lacinia"
-                        name="2"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Praesent fermentum sodales
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Nulla tristique lacinia"
+                          name="2"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Nulla tristique lacinia
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Morbi id nibh metus"
-                        name="3"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Nulla tristique lacinia
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Morbi id nibh metus"
+                          name="3"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Morbi id nibh metus
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <a
-                        data-title="Integer non scelerisque"
-                        name="14"
-                        style={
-                          Object {
-                            "color": "#000",
-                          }
-                        }
-                      >
-                        <h3
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Morbi id nibh metus
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <a
+                          data-title="Integer non scelerisque"
+                          name="14"
                           style={
                             Object {
-                              "paddingBottom": "1rem",
-                              "paddingTop": "2rem",
+                              "color": "#000",
                             }
                           }
                         >
-                          Integer non scelerisque
-                        </h3>
-                      </a>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
-                      </p>
-                    </div>
+                          <h3
+                            style={
+                              Object {
+                                "paddingBottom": "1rem",
+                                "paddingTop": "2rem",
+                              }
+                            }
+                          >
+                            Integer non scelerisque
+                          </h3>
+                        </a>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras molestie condimentum consectetur. Nulla tristique lacinia elit, at elementum dui gravida non. Mauris et nisl semper, elementum quam non, lacinia purus. Vivamus aliquam vitae sapien volutpat efficitur. Curabitur sagittis neque facilisis magna posuere consectetur. Praesent fermentum sodales facilisis. Mauris a efficitur sem. Aliquam vehicula sapien libero, a viverra felis scelerisque vel. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec fringilla dui tellus, a pretium diam vehicula et. Etiam non vulputate augue. Morbi laoreet diam dapibus sapien pellentesque tristique. Morbi id nibh metus. Integer non scelerisque nisl.
+                        </p>
+                      </div>
+                    </DataContent>
                   </div>
                 </div>
               </div>

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import content from './data/content';
+import Content from './data/content';
 import DotcomShell from '../DotcomShell';
 import { Default as footerStory } from '../../Footer/__stories__/Footer.stories.js';
 import { Default as mastheadStory } from '../../Masthead/__stories__/Masthead.stories.js';
@@ -53,7 +53,9 @@ export const Default = ({ parameters }) => {
   return (
     <DotcomShell mastheadProps={mastheadProps} footerProps={footerProps}>
       <main id="main-content">
-        <div style={{ paddingTop: '6rem' }}>{content}</div>
+        <div style={{ paddingTop: '6rem' }}>
+          <Content />
+        </div>
       </main>
     </DotcomShell>
   );

--- a/packages/react/src/components/DotcomShell/__stories__/data/content.js
+++ b/packages/react/src/components/DotcomShell/__stories__/data/content.js
@@ -18,7 +18,7 @@ import {
   LogoGrid,
   FeatureCardBlockLarge,
   TableOfContents,
-} from '../../../../../';
+} from '../../../../index';
 
 import { ArrowRight20 } from '@carbon/icons-react';
 import React from 'react';
@@ -28,7 +28,7 @@ import React from 'react';
  *
  * @returns {*} JSX for Learn template
  */
-const content = (
+const Content = () => (
   <>
     <TableOfContents menuLabel="Jump to" theme="white">
       <a name="section-1" data-title="Lorem ipsum dolor sit amet" />
@@ -433,4 +433,4 @@ const content = (
   </>
 );
 
-export default content;
+export default Content;

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -6,7 +6,7 @@
  */
 
 import { object, text, boolean } from '@storybook/addon-knobs';
-import dataContent from './data/dataContent';
+import DataContent from './data/DataContent';
 import Image from '../../Image/Image';
 import React from 'react';
 import readme from '../README.stories.mdx';
@@ -73,7 +73,7 @@ export const ManuallyDefineMenuItems = ({ parameters }) => {
       menuLabel={menuLabel}
       menuRule={menuRule}
       headingContent={headingContent}>
-      {dataContent}
+      <DataContent />
     </TableOfContents>
   );
 };

--- a/packages/react/src/components/TableOfContents/__stories__/data/DataContent.js
+++ b/packages/react/src/components/TableOfContents/__stories__/data/DataContent.js
@@ -7,7 +7,7 @@
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
-const dataContent = (
+const DataContent = () => (
   <div>
     <a
       data-title="Cras molestie condimentum"
@@ -223,4 +223,4 @@ const dataContent = (
   </div>
 );
 
-export default dataContent;
+export default DataContent;

--- a/packages/react/src/components/TableOfContents/__tests__/TableOfContents.test.js
+++ b/packages/react/src/components/TableOfContents/__tests__/TableOfContents.test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import dataContent from '../__stories__/data/dataContent';
+import DataContent from '../__stories__/data/DataContent';
 import { mount } from 'enzyme';
 import React from 'react';
 import TableOfContents from '../TableOfContents';
@@ -40,7 +40,7 @@ describe('TableOfContents', () => {
         menuItems={menuItems}
         menuRule={true}
         menuLabel="Menu label">
-        {dataContent}
+        <DataContent />
       </TableOfContents>
     );
     expect(toc.find('.bx--tableofcontents__desktop__item')).toHaveLength(


### PR DESCRIPTION
### Related Ticket(s)

Refs #2693.

### Description

This change makes React component/element instances defined as module export (variable)s for some stories to functions that return React component/element, and thus they are React (function) components.

Doing so avoids React prop type warnings shown as orphaned React component/element tree, shown even in stories that don't use that React component/element tree.

This change also fixes some imports in `<Dotcomshell>` story referring to build artifacts. To see our changes live in storybook, we need to refer to the source.

### Changelog

**Changed**

- Made React component/element instances defined as module export (variable)s for some stories to functions that return React component/element, and thus they are React (function) components.
- Fixes some imports in `<Dotcomshell>` story referring to build artifacts. To see our changes live in storybook, we need to refer to the source.