### PR TITLE
fix(ContentBlockSegmented): added padding between bottom border and content

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-segmented/_content-block-segmented.scss
@@ -24,6 +24,14 @@
         margin-top: -$layout-02;
       }
     }
+
+    .#{$prefix}--row {
+      &.#{$prefix}--layout--border {
+        @include carbon--breakpoint('lg') {
+          padding-bottom: $carbon--layout-06;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Pattern: ContentBlock Segmented - No spacing between bottom section and the border line. #2603 

### Description

Added padding between bottom section and border starting on large breakpoint. For `sm` and `md` the padding is already being applied correctly. 

![image](https://user-images.githubusercontent.com/26546511/85739411-24368c80-b6d7-11ea-8be0-445024e4f88b.png)

### Changelog

**New**

- Added CSS to provide padding between border and section when border is set to `true` in border options