### PR TITLE
fix(LinkList): added 640px max-width for the card type

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2475,6 +2475,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           <button
                                                             className="bx--video-player__image-overlay"
                                                             data-autoid="dds--video-player__image-overlay"
+                                                            id="video-thumbnail-overlay"
                                                             onClick={[Function]}
                                                           >
                                                             <Image
@@ -4391,6 +4392,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                 <button
                                                                   className="bx--video-player__image-overlay"
                                                                   data-autoid="dds--video-player__image-overlay"
+                                                                  id="video-thumbnail-overlay"
                                                                   onClick={[Function]}
                                                                 >
                                                                   <Image
@@ -4566,14 +4568,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="vertical"
+                                                  style="horizontal"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--vertical"
+                                                      className="bx--link-list__list bx--link-list__list--horizontal"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -4834,14 +4836,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="vertical"
+                                                  style="horizontal"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--vertical"
+                                                      className="bx--link-list__list bx--link-list__list--horizontal"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -6263,7 +6265,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                       theme="g10"
                     >
                       <section
-                        className="bx--cta-section bx--cta-section--g10 bx--cta-section__has-items"
+                        className="bx--cta-section bx--cta-section--g10"
                         data-autoid="dds--cta-section"
                       >
                         <ContentBlock
@@ -6490,6 +6492,9 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                             </div>
                           </div>
                         </ContentBlock>
+                        <hr
+                          className="bx--horizontal-line"
+                        />
                         <div
                           className="bx--helper-wrapper"
                         >

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2475,7 +2475,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           <button
                                                             className="bx--video-player__image-overlay"
                                                             data-autoid="dds--video-player__image-overlay"
-                                                            id="video-thumbnail-overlay"
                                                             onClick={[Function]}
                                                           >
                                                             <Image
@@ -4392,7 +4391,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                 <button
                                                                   className="bx--video-player__image-overlay"
                                                                   data-autoid="dds--video-player__image-overlay"
-                                                                  id="video-thumbnail-overlay"
                                                                   onClick={[Function]}
                                                                 >
                                                                   <Image
@@ -4568,14 +4566,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="horizontal"
+                                                  style="vertical"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--horizontal"
+                                                      className="bx--link-list__list bx--link-list__list--vertical"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -4836,14 +4834,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       },
                                                     ]
                                                   }
-                                                  style="horizontal"
+                                                  style="vertical"
                                                 >
                                                   <div
                                                     className="bx--link-list"
                                                     data-autoid="dds--link-list"
                                                   >
                                                     <ul
-                                                      className="bx--link-list__list bx--link-list__list--horizontal"
+                                                      className="bx--link-list__list bx--link-list__list--vertical"
                                                     >
                                                       <li
                                                         className="bx--link-list__list__CTA bx--link-list__list--local"
@@ -6265,7 +6263,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                       theme="g10"
                     >
                       <section
-                        className="bx--cta-section bx--cta-section--g10"
+                        className="bx--cta-section bx--cta-section--g10 bx--cta-section__has-items"
                         data-autoid="dds--cta-section"
                       >
                         <ContentBlock
@@ -6492,9 +6490,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                             </div>
                           </div>
                         </ContentBlock>
-                        <hr
-                          className="bx--horizontal-line"
-                        />
                         <div
                           className="bx--helper-wrapper"
                         >

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -80,6 +80,7 @@
         }
 
         .#{$prefix}--link-list__list--card & {
+          max-width: carbon--mini-units(80);
           div .#{$prefix}--tile {
             margin-left: 0;
             margin-right: 0;


### PR DESCRIPTION
### Related Ticket(s)

Pattern: ContentBlock Segmented - On iPad, all sub section are not stretched to full screen size as per specs. #2570

### Description

In the `md` breakpoint the `ContentBlockMixed` and `ContentBlockSegmented` patterns had it's `LinksList` fulfilling the entire screen when they were supposed to have a max-width of 640px.

### Changelog

**New**

- `max-width: carbon--mini-units(80);` in the LinksList style