### PR TITLE
fix(ContentBlockSegmented): fixing sections padding for all breakpoints

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-block-segmented/_content-block-segmented.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-segmented/_content-block-segmented.scss
@@ -8,16 +8,12 @@
 @mixin content-block-segmented {
   .#{$prefix}--content-block-segmented {
     .#{$prefix}--content-group {
-      margin-top: $carbon--layout-04;
-      margin-bottom: $carbon--layout-04;
+      margin-top: $carbon--layout-05;
+      margin-bottom: $carbon--layout-05;
 
       @include carbon--breakpoint('lg') {
-        margin-top: $carbon--layout-05;
-        margin-bottom: $carbon--layout-05;
-      }
-
-      @include carbon--breakpoint('xlg') {
         margin-top: $carbon--layout-06;
+        margin-bottom: $carbon--layout-06;
       }
 
       &__cta {
@@ -26,7 +22,6 @@
     }
   }
 }
-
 @include exports('content-block-segmented') {
   @include content-block-segmented;
 }


### PR DESCRIPTION
### Related Ticket(s)

Patterns: ContentBlock Segmented - spacing variations between sub section on desktop and mobile view. #2567

### Description

The paddings were set incorrectly between content groups in `ContentBlockSegmented`. I fixed them based on `Visual Specs`: https://ibm.ent.box.com/file/662609167728

Please note I did other changes in the same file in this PR: https://github.com/carbon-design-system/ibm-dotcom-library/pull/2899

### Changelog

**Changed**

- Increased padding on top and bottom for content group components in `ContentBlockSegmented`

