### PR TITLE
fix(masthead): fixed missing platform on masthead

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2247,6 +2247,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                     <MastheadLeftNav
                       isSideNavExpanded={false}
                       navigation={Array []}
+                      platform={null}
                     >
                       <ForwardRef(SideNav)
                         addFocusListeners={true}
@@ -13037,6 +13038,7 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                   <MastheadLeftNav
                     isSideNavExpanded={false}
                     navigation={Array []}
+                    platform={null}
                   >
                     <ForwardRef(SideNav)
                       addFocusListeners={true}
@@ -13639,6 +13641,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                   <MastheadLeftNav
                     isSideNavExpanded={false}
                     navigation={Array []}
+                    platform={null}
                   >
                     <ForwardRef(SideNav)
                       addFocusListeners={true}
@@ -14136,6 +14139,12 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                     <MastheadLeftNav
                       isSideNavExpanded={false}
                       navigation={Array []}
+                      platform={
+                        Object {
+                          "name": "IBM Cloud",
+                          "url": "https://www.ibm.com/cloud",
+                        }
+                      }
                     >
                       <ForwardRef(SideNav)
                         addFocusListeners={true}
@@ -14160,6 +14169,14 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                           <nav
                             data-autoid="dds--masthead__l0-sidenav"
                           >
+                            <a
+                              aria-haspopup="true"
+                              className="bx--side-nav__submenu bx--side-nav__submenu-platform"
+                              data-autoid="dds--side-nav__submenu-platform"
+                              href="yi jian mei"
+                            >
+                              IBM Cloud
+                            </a>
                             <SideNavItems>
                               <ul
                                 className="bx--side-nav__items"

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -14046,7 +14046,7 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                               aria-haspopup="true"
                               className="bx--side-nav__submenu bx--side-nav__submenu-platform"
                               data-autoid="dds--side-nav__submenu-platform"
-                              href="yi jian mei"
+                              href="https://www.ibm.com/cloud"
                             >
                               IBM Cloud
                             </a>

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -231,6 +231,7 @@ const Masthead = ({
               {navigation && (
                 <MastheadLeftNav
                   {...mastheadProps}
+                  platform={platform}
                   navigation={mastheadData}
                   isSideNavExpanded={isSideNavExpanded}
                 />

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -23,11 +23,7 @@ const { prefix } = settings;
 /**
  * Masthead left nav component.
  */
-const MastheadLeftNav = ({
-  navigation,
-  isSideNavExpanded,
-  ...leftNavProps
-}) => {
+const MastheadLeftNav = ({ navigation, isSideNavExpanded, platform }) => {
   /**
    * Left side navigation
    *
@@ -70,13 +66,13 @@ const MastheadLeftNav = ({
       expanded={isSideNavExpanded}
       isPersistent={false}>
       <nav data-autoid={`${stablePrefix}--masthead__l0-sidenav`}>
-        {leftNavProps.platform && (
+        {platform && (
           <a
             data-autoid={`${stablePrefix}--side-nav__submenu-platform`}
-            href={leftNavProps.platform.url}
+            href="yi jian mei"
             aria-haspopup="true"
             className={`${prefix}--side-nav__submenu ${prefix}--side-nav__submenu-platform`}>
-            {leftNavProps.platform.name}
+            {platform.name}
           </a>
         )}
         <SideNavItems>
@@ -131,11 +127,18 @@ MastheadLeftNav.propTypes = {
       ),
     })
   ),
-
   /**
    * `true` to make the sidenav expanded.
    */
   isSideNavExpanded: PropTypes.bool,
+
+  /**
+   * Platform object with name and url
+   */
+  platform: PropTypes.shape({
+    name: PropTypes.string,
+    url: PropTypes.string,
+  }),
 };
 
 export default MastheadLeftNav;

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -69,7 +69,7 @@ const MastheadLeftNav = ({ navigation, isSideNavExpanded, platform }) => {
         {platform && (
           <a
             data-autoid={`${stablePrefix}--side-nav__submenu-platform`}
-            href="yi jian mei"
+            href={platform.url}
             aria-haspopup="true"
             className={`${prefix}--side-nav__submenu ${prefix}--side-nav__submenu-platform`}>
             {platform.name}


### PR DESCRIPTION
### Related Ticket(s)

#2769 

### Description

A bug was fixed where the platform name was not passed as a prop to `MastheadLeftNav`, causing the platform to not be shown on mobile devices.