### PR TITLE
chore(react): better support conditional class names

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2186,14 +2186,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                   >
                     <Layout
                       border={false}
-                      marginBottom="none"
-                      marginTop="none"
+                      marginBottom={null}
+                      marginTop={null}
                       nested={false}
                       stickyOffset={null}
                       type="1-3"
                     >
                       <section
-                        className="bx--grid bx--layout--top-none bx--layout--bottom-none"
+                        className="bx--grid"
                         data-autoid="dds--layout"
                       >
                         <div
@@ -6265,7 +6265,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                         theme="g10"
                       >
                         <section
-                          className="bx--cta-section bx--cta-section--g10 bx--cta-section__has-items"
+                          className="bx--cta-section bx--cta-section__has-items bx--cta-section--g10"
                           data-autoid="dds--cta-section"
                         >
                           <ContentBlock
@@ -14514,14 +14514,14 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
         >
           <Layout
             border={false}
-            marginBottom="none"
-            marginTop="none"
+            marginBottom={null}
+            marginTop={null}
             nested={false}
             stickyOffset={null}
             type="1-3"
           >
             <section
-              className="bx--grid bx--layout--top-none bx--layout--bottom-none"
+              className="bx--grid"
               data-autoid="dds--layout"
             >
               <div
@@ -14862,14 +14862,14 @@ exports[`Storyshots Components|Table of Contents Manually define Menu Items 1`] 
       >
         <Layout
           border={false}
-          marginBottom="none"
-          marginTop="none"
+          marginBottom={null}
+          marginTop={null}
           nested={false}
           stickyOffset={null}
           type="1-3"
         >
           <section
-            className="bx--grid bx--layout--top-none bx--layout--bottom-none"
+            className="bx--grid"
             data-autoid="dds--layout"
           >
             <div
@@ -15475,14 +15475,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
         >
           <Layout
             border={false}
-            marginBottom="none"
-            marginTop="none"
+            marginBottom={null}
+            marginTop={null}
             nested={false}
             stickyOffset={null}
             type="1-3"
           >
             <section
-              className="bx--grid bx--layout--top-none bx--layout--bottom-none"
+              className="bx--grid"
               data-autoid="dds--layout"
             >
               <div

--- a/packages/react/src/components/ExpressiveModal/ExpressiveModal.js
+++ b/packages/react/src/components/ExpressiveModal/ExpressiveModal.js
@@ -36,29 +36,14 @@ const ExpressiveModal = ({
       onClose={onClose}
       open={isOpen}
       data-autoid={`${stablePrefix}--expressive-modal`}
-      className={classNames(
-        `${prefix}--modal--expressive`,
-        className,
-        setVariant(fullwidth)
-      )}
+      className={classNames(`${prefix}--modal--expressive`, className, {
+        [`${prefix}--modal--expressive--fullwidth`]: fullwidth,
+      })}
       {...props}>
       <ExpressiveModalCloseBtn onClick={closeModal} />
       {children}
     </ComposedModal>
   );
-
-  /**
-   * sets the class name based if model type is fullwidth
-   *
-   * @param {boolean} isFullwidth includes variant class name or not ( true | false )
-   * @returns {string} fullwidth variant css class name
-   */
-  function setVariant(isFullwidth) {
-    let fullwidth;
-    fullwidth =
-      isFullwidth === true ? `${prefix}--modal--expressive--fullwidth` : '';
-    return fullwidth;
-  }
 
   /**
    * Close modal

--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -93,7 +93,9 @@ const Footer = ({
   return (
     <footer
       data-autoid={`${stablePrefix}--footer`}
-      className={classNames(`${prefix}--footer`, _setFooterType(type))}>
+      className={classNames(`${prefix}--footer`, {
+        [`${prefix}--footer--short`]: type === 'short',
+      })}>
       <section className={`${prefix}--footer__main`}>
         <div className={`${prefix}--footer__main-container`}>
           <FooterLogo />
@@ -163,23 +165,6 @@ function _optionalFooterNav(type, data) {
   if (type !== 'short') {
     return <FooterNav groups={data} />;
   }
-}
-
-/**
- * sets the footer type
- *
- * @param {string} type type of footer in use
- * @returns {object} JSX object
- * @private
- */
-function _setFooterType(type) {
-  let typeClassName;
-
-  if (type === 'short') {
-    typeClassName = `${prefix}--footer--short`;
-  }
-
-  return typeClassName;
 }
 
 Footer.propTypes = {

--- a/packages/react/src/components/HorizontalRule/HorizontalRule.js
+++ b/packages/react/src/components/HorizontalRule/HorizontalRule.js
@@ -14,28 +14,17 @@ const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 
 /**
- * creates modifier classnames
- *
- * @param {string} mod modifier
- * @returns {*} Horizontal Rule component
- */
-function hrMod(mod) {
-  return mod && `${prefix}--hr--${mod}`;
-}
-
-/**
  * Horizontal Rule component.
  */
 const HorizontalRule = ({ style, size, contrast, weight }) => (
   <hr
     data-autoid={`${stablePrefix}--hr`}
-    className={classnames(
-      `${prefix}--hr`,
-      hrMod(style),
-      hrMod(contrast),
-      hrMod(size),
-      hrMod(weight)
-    )}
+    className={classnames(`${prefix}--hr`, {
+      [`${prefix}--hr--${style}`]: style,
+      [`${prefix}--hr--${contrast}`]: contrast,
+      [`${prefix}--hr--${size}`]: size,
+      [`${prefix}--hr--${weight}`]: weight,
+    })}
   />
 );
 

--- a/packages/react/src/components/Layout/Layout.js
+++ b/packages/react/src/components/Layout/Layout.js
@@ -106,16 +106,14 @@ const Layout = ({
 }) => (
   <section
     data-autoid={`${stablePrefix}--layout`}
-    className={classnames(
-      nested ? `` : `${prefix}--grid`,
-      _spacingClass('top', marginTop),
-      _spacingClass('bottom', marginBottom)
-    )}>
+    className={classnames(nested ? `` : `${prefix}--grid`, {
+      [_spacingClass('top', marginTop)]: marginTop,
+      [_spacingClass('bottom', marginBottom)]: marginBottom,
+    })}>
     <div
-      className={classnames(
-        `${prefix}--row`,
-        border ? `${prefix}--layout--border` : ''
-      )}>
+      className={classnames(`${prefix}--row`, {
+        [`${prefix}--layout--border`]: border,
+      })}>
       {_updateChild(type, stickyOffset, children)}
     </div>
   </section>

--- a/packages/react/src/components/Quote/Quote.js
+++ b/packages/react/src/components/Quote/Quote.js
@@ -99,10 +99,9 @@ const Quote = ({ markType = 'doubleCurved', copy, source, cta, inverse }) => {
   return (
     <div
       data-autoid={`${stablePrefix}--quote`}
-      className={classnames(
-        `${prefix}--quote`,
-        `${inverse ? `${prefix}--quote__inverse` : ''}`
-      )}>
+      className={classnames(`${prefix}--quote`, {
+        [`${prefix}--quote__inverse`]: inverse,
+      })}>
       <div className={`${prefix}--quote__container`}>
         <div
           className={`${prefix}--quote__wrapper`}

--- a/packages/react/src/components/TableOfContents/TOCDesktop.js
+++ b/packages/react/src/components/TableOfContents/TOCDesktop.js
@@ -34,8 +34,7 @@ const TOCDesktop = ({ menuItems, selectedId }) => {
           <li
             key={index}
             data-autoid={`${stablePrefix}--tableofcontents__desktop__item-${item.id}`}
-            className={classNames({
-              [`${prefix}--tableofcontents__desktop__item`]: true,
+            className={classNames(`${prefix}--tableofcontents__desktop__item`, {
               [`${prefix}--tableofcontents__desktop__item--active`]: isActive,
             })}>
             <a

--- a/packages/react/src/components/TableOfContents/TableOfContents.js
+++ b/packages/react/src/components/TableOfContents/TableOfContents.js
@@ -142,25 +142,12 @@ const TableOfContents = ({
   };
 
   /**
-   * sets the class name based on theme type
-   *
-   * @private
-   * @param {string} theme theme type ( g100 | white/default )
-   * @returns {string} theme css class names
-   */
-  const _setTheme = theme => {
-    return theme && `${prefix}--tableofcontents--${theme}`;
-  };
-
-  /**
    * Props for the Layout component
    *
    * @type {{marginBottom: string, type: string, marginTop: string}}
    */
   const layoutProps = {
     type: '1-3',
-    marginTop: 'none',
-    marginBottom: 'none',
     stickyOffset,
   };
 
@@ -205,7 +192,9 @@ const TableOfContents = ({
   return (
     <section
       data-autoid={`${stablePrefix}--tableofcontents`}
-      className={classNames(`${prefix}--tableofcontents`, _setTheme(theme))}>
+      className={classNames(`${prefix}--tableofcontents`, {
+        [`${prefix}--tableofcontents--${theme}`]: theme,
+      })}>
       <Layout {...layoutProps}>
         <div className={`${prefix}--tableofcontents__sidebar`}>
           {headingContent ? (

--- a/packages/react/src/internal/components/ContentSection/ContentSection.js
+++ b/packages/react/src/internal/components/ContentSection/ContentSection.js
@@ -23,43 +23,24 @@ const ContentSection = ({
   children,
   customClassName,
   ...otherProps
-}) => {
-  /**
-   * sets the class name based on theme type
-   *
-   * @private
-   * @param {string} theme theme type
-   * @returns {string} theme css class names
-   */
-  const _setTheme = theme => {
-    return theme && `${prefix}--content-section--${theme}`;
-  };
-
-  return (
-    <section
-      className={classNames(
-        `${prefix}--content-section`,
-        customClassName,
-        _setTheme(theme)
-      )}
-      data-autoid={
-        otherProps.autoid
-          ? otherProps.autoid
-          : `${stablePrefix}--content-section`
-      }>
-      <div className={`${prefix}--content-section__grid`}>
-        <div className={`${prefix}--content-section__row`}>
-          <div className={`${prefix}--content-section__left`}>
-            <h2 className={`${prefix}--content-section__heading`}>{heading}</h2>
-          </div>
-          <div className={`${prefix}--content-section__children`}>
-            {children}
-          </div>
+}) => (
+  <section
+    className={classNames(`${prefix}--content-section`, customClassName, {
+      [`${prefix}--content-section--${theme}`]: theme,
+    })}
+    data-autoid={
+      otherProps.autoid ? otherProps.autoid : `${stablePrefix}--content-section`
+    }>
+    <div className={`${prefix}--content-section__grid`}>
+      <div className={`${prefix}--content-section__row`}>
+        <div className={`${prefix}--content-section__left`}>
+          <h2 className={`${prefix}--content-section__heading`}>{heading}</h2>
         </div>
+        <div className={`${prefix}--content-section__children`}>{children}</div>
       </div>
-    </section>
-  );
-};
+    </div>
+  </section>
+);
 
 ContentSection.propTypes = {
   /**

--- a/packages/react/src/patterns/sections/CTASection/CTASection.js
+++ b/packages/react/src/patterns/sections/CTASection/CTASection.js
@@ -20,22 +20,12 @@ const { prefix } = settings;
  * CTASection pattern.
  */
 const CTASection = ({ heading, copy, cta, items, theme }) => {
-  /**
-   * sets the class name based on theme type
-   *
-   * @private
-   * @param {string} theme theme type
-   * @returns {string} theme css class names
-   */
-  const _setTheme = theme => {
-    return theme && `${prefix}--cta-section--${theme}`;
-  };
-
   return (
     <section
       data-autoid={`${stablePrefix}--cta-section`}
-      className={classNames(`${prefix}--cta-section`, _setTheme(theme), {
+      className={classNames(`${prefix}--cta-section`, {
         [`${prefix}--cta-section__has-items`]: items,
+        [`${prefix}--cta-section--${theme}`]: theme,
       })}>
       <ContentBlock heading={heading} copy={copy} cta={cta} />
       {items && (

--- a/packages/react/src/patterns/sections/CardSectionImages/CardSectionImages.js
+++ b/packages/react/src/patterns/sections/CardSectionImages/CardSectionImages.js
@@ -25,22 +25,13 @@ const CardSectionImages = ({ cards, theme, ...otherProps }) => {
       image && eyebrow && heading && !copy && href
   );
 
-  /**
-   * sets the class name based on theme type
-   *
-   * @private
-   * @param {string} theme theme type ( g10 | g100 | white/default )
-   * @returns {string} theme css class names
-   */
-  const _setTheme = theme => {
-    return theme && `${prefix}--card-group--${theme}`;
-  };
-
   return (
     <ContentSection
       heading={otherProps.heading}
       autoid={`${stablePrefix}--card-group-images-group`}
-      customClassName={classNames(`${prefix}--card-group`, _setTheme(theme))}>
+      customClassName={classNames(`${prefix}--card-group`, {
+        [`${prefix}--card-group--${theme}`]: theme,
+      })}>
       <CardGroup cards={cardsWithImages} />
     </ContentSection>
   );

--- a/packages/react/src/patterns/sections/CardSectionSimple/CardSectionSimple.js
+++ b/packages/react/src/patterns/sections/CardSectionSimple/CardSectionSimple.js
@@ -25,22 +25,13 @@ const CardSectionSimple = ({ cards, cta, theme, ...otherProps }) => {
       !image && !eyebrow && heading && copy && href
   );
 
-  /**
-   * sets the class name based on theme type
-   *
-   * @private
-   * @param {string} theme theme type ( g10 | g100 | white/default )
-   * @returns {string} theme css class names
-   */
-  const _setTheme = theme => {
-    return theme && `${prefix}--card-group--${theme}`;
-  };
-
   return (
     <ContentSection
       heading={otherProps.heading}
       autoid={`${stablePrefix}--card-group-simple-group`}
-      customClassName={classNames(`${prefix}--card-group`, _setTheme(theme))}>
+      customClassName={classNames(`${prefix}--card-group`, {
+        [`${prefix}--card-group--${theme}`]: theme,
+      })}>
       <CardGroup cards={cardsWithoutImages} cta={cta} />
     </ContentSection>
   );

--- a/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
+++ b/packages/react/src/patterns/sections/LeadSpace/LeadSpace.js
@@ -28,16 +28,11 @@ const className = (theme, type, image) => {
   const mainClassName = `${prefix}--leadspace${
     type === 'centered' ? '--centered' : ''
   }`;
-  return classnames(
-    mainClassName,
-    theme && `${mainClassName}--${theme}`,
-    {
-      [`${prefix}--leadspace--productive`]: type === 'small',
-    },
-    {
-      [`${prefix}--leadspace--centered__image`]: image && type === 'centered',
-    }
-  );
+  return classnames(mainClassName, {
+    [`${mainClassName}--${theme}`]: theme,
+    [`${prefix}--leadspace--productive`]: type === 'small',
+    [`${prefix}--leadspace--centered__image`]: image && type === 'centered',
+  });
 };
 
 /**


### PR DESCRIPTION
(Please use gear icon - Hide whitespace changes for reviewing)

### Related Ticket(s)

Refs #2693.

### Description

This change attempts to better utilize `classnames` library's feature of setting/unsetting CSS class names conditionally.

Doing so avoids the need for:

* Sending a pseudo value to `marginTop`/`marginBottom` prop in `<Layout>` (e.g. `none`) that is not explicitly defined and caused prop type warnings. Such pseudo value seem to have been used to use e.g. `bx--layout--top-none` class to unset styles that e.g. `bx--layout--top-layout-01` defines, given `bx--layout--top-none` doesn't seem to be defined at: https://github.com/carbon-design-system/ibm-dotcom-library/blob/v1.8.0/packages/styles/scss/components/layout/_layout.scss#L29-L41
* Utility functions that attempts to achieve the feature of setting/unsetting CSS class names conditionally

### Changelog

**Changed**

- Change to unify the usage of `classname()`, to:

```javascript
classname('a-non-conditional-class', {
  'a-conditional-class': someCondition,
  'another-conditional-lcass': anotherCondition,
});
```