### PR TITLE
chore(Codesandbox): add examples and docs

### DIFF
--- a/packages/react/examples/codesandbox/components/Image/.gitignore
+++ b/packages/react/examples/codesandbox/components/Image/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/dist
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/react/examples/codesandbox/components/Image/index.html
+++ b/packages/react/examples/codesandbox/components/Image/index.html
@@ -1,0 +1,23 @@
+<!--
+ Copyright IBM Corp. 2016, 2020
+
+ This source code is licensed under the Apache-2.0 license found in the
+ LICENSE file in the root directory of this source tree.
+ -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Parcel Sandbox</title>
+	<meta charset="UTF-8" />
+</head>
+
+<body>
+	<div id="app"></div>
+
+	<script src="src/index.js">
+	</script>
+</body>
+
+</html>

--- a/packages/react/examples/codesandbox/components/Image/package.json
+++ b/packages/react/examples/codesandbox/components/Image/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ibmdotcom-react-image-example",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel index.html --open",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-react": "latest",
+    "@carbon/ibmdotcom-styles": "latest",
+    "@carbon/icons-react": "10.11.0",
+    "react": "16.9.0",
+    "react-dom": "16.9.0",
+    "sass": "1.26.8"
+  },
+  "devDependencies": {
+    "@babel/core": "7.2.0",
+    "parcel-bundler": "latest"
+  },
+  "sass": {
+    "includePaths": [
+      "./node_modules"
+    ]
+  }
+}

--- a/packages/react/examples/codesandbox/components/Image/src/index.js
+++ b/packages/react/examples/codesandbox/components/Image/src/index.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import "./styles.scss";
+
+import React from "react";
+import ReactDom from "react-dom";
+import { Image } from "@carbon/ibmdotcom-react";
+
+const image = [
+  {
+    src: 'https://dummyimage.com/320x160/ee5396/161616&text=2x1',
+    breakpoint: 'sm',
+  },
+  {
+    src: 'https://dummyimage.com/400x200/ee5396/161616&text=2x1',
+    breakpoint: 'md',
+  },
+  {
+    src: 'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
+    breakpoint: 'lg',
+  },
+];
+const alt = "Image alt text";
+const defaultSrc = "https://dummyimage.com/672x336/ee5396/161616&text=2x1";
+
+const App = () => (
+  <div className="bx--grid">
+    <div className="bx--row">
+      <div className="bx--col-sm-4 bx--col-lg-8">
+        <Image sources={image} defaultSrc={defaultSrc} alt={alt} />
+      </div>
+    </div>
+  </div>
+);
+
+ReactDom.render(<App />, document.getElementById("app"));

--- a/packages/react/examples/codesandbox/components/Image/src/styles.scss
+++ b/packages/react/examples/codesandbox/components/Image/src/styles.scss
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.bx--grid {
+  padding-top: 1rem;
+}
+
+.bx--row {
+  padding-top: 1rem;
+  h4 {
+    margin-top: 1rem;
+  }
+}
+
+@import "@carbon/ibmdotcom-styles/scss/components/image/image";

--- a/packages/react/examples/codesandbox/components/ImageWithCaption/.gitignore
+++ b/packages/react/examples/codesandbox/components/ImageWithCaption/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/dist
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/react/examples/codesandbox/components/ImageWithCaption/index.html
+++ b/packages/react/examples/codesandbox/components/ImageWithCaption/index.html
@@ -1,0 +1,23 @@
+<!--
+ Copyright IBM Corp. 2016, 2020
+
+ This source code is licensed under the Apache-2.0 license found in the
+ LICENSE file in the root directory of this source tree.
+ -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Parcel Sandbox</title>
+	<meta charset="UTF-8" />
+</head>
+
+<body>
+	<div id="app"></div>
+
+	<script src="src/index.js">
+	</script>
+</body>
+
+</html>

--- a/packages/react/examples/codesandbox/components/ImageWithCaption/package.json
+++ b/packages/react/examples/codesandbox/components/ImageWithCaption/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ibmdotcom-react-imagewithcaption-example",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel index.html --open",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-react": "latest",
+    "@carbon/ibmdotcom-styles": "latest",
+    "@carbon/icons-react": "10.11.0",
+    "react": "16.9.0",
+    "react-dom": "16.9.0",
+    "sass": "1.26.8"
+  },
+  "devDependencies": {
+    "@babel/core": "7.2.0",
+    "parcel-bundler": "latest"
+  },
+  "sass": {
+    "includePaths": [
+      "./node_modules"
+    ]
+  }
+}

--- a/packages/react/examples/codesandbox/components/ImageWithCaption/src/index.js
+++ b/packages/react/examples/codesandbox/components/ImageWithCaption/src/index.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import "./styles.scss";
+
+import React from "react";
+import ReactDom from "react-dom";
+import { ImageWithCaption } from "@carbon/ibmdotcom-react";
+
+const image = {
+  sources: [
+    {
+      src: 'https://dummyimage.com/320x160/ee5396/161616&text=2x1',
+      breakpoint: 'sm',
+    },
+    {
+      src: 'https://dummyimage.com/400x200/ee5396/161616&text=2x1',
+      breakpoint: 'md',
+    },
+    {
+      src: 'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
+      breakpoint: 'lg',
+    },
+  ],
+  alt: 'Image with caption image',
+  defaultSrc: 'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
+};
+const copy = "This is a description of the image.";
+const heading = "This is the image caption.";
+
+const App = () => (
+  <div className="bx--grid">
+    <div className="bx--row">
+      <div className="bx--col-sm-4 bx--col-lg-8">
+        <h4>Default</h4>
+        <ImageWithCaption
+          copy={copy}
+          image={image}
+          heading={heading}
+          inverse={false}
+        />
+      </div>
+    </div>
+    <div className="bx--row">
+      <div className="bx--col-sm-4 bx--col-lg-8">
+        <h4>Opens in modal</h4>
+        <ImageWithCaption
+          copy={copy}
+          image={image}
+          heading={heading}
+          inverse={false}
+          lightbox={true}
+        />
+      </div>
+    </div>
+  </div>
+);
+
+ReactDom.render(<App />, document.getElementById("app"));

--- a/packages/react/examples/codesandbox/components/ImageWithCaption/src/styles.scss
+++ b/packages/react/examples/codesandbox/components/ImageWithCaption/src/styles.scss
@@ -1,0 +1,19 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.bx--grid {
+  padding-top: 1rem;
+}
+
+.bx--row {
+  padding-top: 1rem;
+  h4 {
+    margin-top: 1rem;
+  }
+}
+
+@import "@carbon/ibmdotcom-styles/scss/components/image-with-caption/image-with-caption";

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -3505,7 +3505,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                         >
                                           <div
                                             className="bx--image"
-                                            data-autoid="dds--image__longdescription-"
+                                            data-autoid="dds--image__longdescription"
                                           >
                                             <picture>
                                               <img
@@ -3809,22 +3809,22 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--image"
-                                                          data-autoid="dds--image__longdescription-"
+                                                          data-autoid="dds--image__longdescription"
                                                         >
                                                           <picture>
                                                             <source
                                                               key="0"
-                                                              media="(min-width: 672px )"
+                                                              media="(min-width: 672px)"
                                                               srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                             />
                                                             <source
                                                               key="1"
-                                                              media="(min-width: 400px )"
+                                                              media="(min-width: 400px)"
                                                               srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                                             />
                                                             <source
                                                               key="2"
-                                                              media="(min-width: 320px )"
+                                                              media="(min-width: 320px)"
                                                               srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                                             />
                                                             <img
@@ -4031,22 +4031,22 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--image"
-                                                          data-autoid="dds--image__longdescription-"
+                                                          data-autoid="dds--image__longdescription"
                                                         >
                                                           <picture>
                                                             <source
                                                               key="0"
-                                                              media="(min-width: 672px )"
+                                                              media="(min-width: 672px)"
                                                               srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                             />
                                                             <source
                                                               key="1"
-                                                              media="(min-width: 400px )"
+                                                              media="(min-width: 400px)"
                                                               srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                                             />
                                                             <source
                                                               key="2"
-                                                              media="(min-width: 320px )"
+                                                              media="(min-width: 320px)"
                                                               srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                                             />
                                                             <img
@@ -5149,7 +5149,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -5181,7 +5181,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -5213,7 +5213,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -5245,7 +5245,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -5277,7 +5277,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -5309,7 +5309,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -5681,7 +5681,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--image"
-                                                          data-autoid="dds--image__longdescription-"
+                                                          data-autoid="dds--image__longdescription"
                                                         >
                                                           <picture>
                                                             <img
@@ -5816,7 +5816,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--image"
-                                                          data-autoid="dds--image__longdescription-"
+                                                          data-autoid="dds--image__longdescription"
                                                         >
                                                           <picture>
                                                             <img
@@ -5951,7 +5951,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--image"
-                                                          data-autoid="dds--image__longdescription-"
+                                                          data-autoid="dds--image__longdescription"
                                                         >
                                                           <picture>
                                                             <img
@@ -7436,7 +7436,7 @@ exports[`Storyshots Components|FeatureCard Default 1`] = `
                     >
                       <div
                         className="bx--image"
-                        data-autoid="dds--image__longdescription-"
+                        data-autoid="dds--image__longdescription"
                       >
                         <picture>
                           <img
@@ -7964,48 +7964,48 @@ exports[`Storyshots Components|Image Default 1`] = `
         >
           <Image
             alt="Image alt text"
-            defaultSrc="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
+            defaultSrc="https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1"
             sources={
               Array [
                 Object {
-                  "breakpoint": 320,
+                  "breakpoint": "sm",
                   "src": "https://dummyimage.com/320x160/ee5396/161616&amp;text=2x1",
                 },
                 Object {
-                  "breakpoint": 400,
-                  "src": "https://dummyimage.com/400x400/ee5396/161616&amp;text=1x1",
+                  "breakpoint": "md",
+                  "src": "https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1",
                 },
                 Object {
-                  "breakpoint": 672,
-                  "src": "https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1",
+                  "breakpoint": "lg",
+                  "src": "https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1",
                 },
               ]
             }
           >
             <div
               className="bx--image"
-              data-autoid="dds--image__longdescription-"
+              data-autoid="dds--image__longdescription"
             >
               <picture>
                 <source
                   key="0"
-                  media="(min-width: 672px )"
-                  srcSet="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
+                  media="(min-width: 1056px)"
+                  srcSet="https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1"
                 />
                 <source
                   key="1"
-                  media="(min-width: 400px )"
-                  srcSet="https://dummyimage.com/400x400/ee5396/161616&amp;text=1x1"
+                  media="(min-width: 672px)"
+                  srcSet="https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1"
                 />
                 <source
                   key="2"
-                  media="(min-width: 320px )"
+                  media="(min-width: 320px)"
                   srcSet="https://dummyimage.com/320x160/ee5396/161616&amp;text=2x1"
                 />
                 <img
                   alt="Image alt text"
                   className="bx--image__img"
-                  src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
+                  src="https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1"
                 />
               </picture>
             </div>
@@ -8050,7 +8050,7 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
             image={
               Object {
                 "alt": "image with caption image",
-                "defaultSrc": "https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1",
+                "defaultSrc": "https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1",
                 "sources": Array [
                   Object {
                     "breakpoint": "sm",
@@ -8059,6 +8059,10 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
                   Object {
                     "breakpoint": "md",
                     "src": "https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1",
+                  },
+                  Object {
+                    "breakpoint": "lg",
+                    "src": "https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1",
                   },
                 ],
               }
@@ -8077,7 +8081,7 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
               >
                 <Image
                   alt="image with caption image"
-                  defaultSrc="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
+                  defaultSrc="https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1"
                   sources={
                     Array [
                       Object {
@@ -8088,28 +8092,37 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
                         "breakpoint": "md",
                         "src": "https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1",
                       },
+                      Object {
+                        "breakpoint": "lg",
+                        "src": "https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1",
+                      },
                     ]
                   }
                 >
                   <div
                     className="bx--image"
-                    data-autoid="dds--image__longdescription-"
+                    data-autoid="dds--image__longdescription"
                   >
                     <picture>
                       <source
                         key="0"
-                        media="(min-width: 672px )"
-                        srcSet="https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1"
+                        media="(min-width: 1056px)"
+                        srcSet="https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1"
                       />
                       <source
                         key="1"
-                        media="(min-width: 320px )"
+                        media="(min-width: 672px)"
+                        srcSet="https://dummyimage.com/400x200/ee5396/161616&amp;text=2x1"
+                      />
+                      <source
+                        key="2"
+                        media="(min-width: 320px)"
                         srcSet="https://dummyimage.com/320x160/ee5396/161616&amp;text=2x1"
                       />
                       <img
                         alt="image with caption image"
                         className="bx--image__img"
-                        src="https://dummyimage.com/672x672/ee5396/161616&amp;text=1x1"
+                        src="https://dummyimage.com/672x336/ee5396/161616&amp;text=2x1"
                       />
                     </picture>
                   </div>
@@ -8589,7 +8602,7 @@ exports[`Storyshots Components|LightboxMediaViewer Default 1`] = `
                           >
                             <div
                               className="bx--image"
-                              data-autoid="dds--image__longdescription-"
+                              data-autoid="dds--image__longdescription"
                             >
                               <picture>
                                 <img
@@ -15526,22 +15539,22 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                     >
                       <div
                         className="bx--image"
-                        data-autoid="dds--image__longdescription-"
+                        data-autoid="dds--image__longdescription"
                       >
                         <picture>
                           <source
                             key="0"
-                            media="(min-width: 1056px )"
+                            media="(min-width: 1056px)"
                             srcSet="https://dummyimage.com/672x672&text=Example%20Children"
                           />
                           <source
                             key="1"
-                            media="(min-width: 672px )"
+                            media="(min-width: 672px)"
                             srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                           />
                           <source
                             key="2"
-                            media="(min-width: 400px )"
+                            media="(min-width: 400px)"
                             srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                           />
                           <img
@@ -15899,22 +15912,22 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                       >
                         <div
                           className="bx--image"
-                          data-autoid="dds--image__longdescription-"
+                          data-autoid="dds--image__longdescription"
                         >
                           <picture>
                             <source
                               key="0"
-                              media="(min-width: 1056px )"
+                              media="(min-width: 1056px)"
                               srcSet="https://dummyimage.com/672x672&text=Example%20Children"
                             />
                             <source
                               key="1"
-                              media="(min-width: 672px )"
+                              media="(min-width: 672px)"
                               srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                             />
                             <source
                               key="2"
-                              media="(min-width: 400px )"
+                              media="(min-width: 400px)"
                               srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                             />
                             <img
@@ -16588,22 +16601,22 @@ exports[`Storyshots Patterns (Blocks)|CalloutWithMedia Default 1`] = `
                                         >
                                           <div
                                             className="bx--image"
-                                            data-autoid="dds--image__longdescription-"
+                                            data-autoid="dds--image__longdescription"
                                           >
                                             <picture>
                                               <source
                                                 key="0"
-                                                media="(min-width: 672px )"
+                                                media="(min-width: 672px)"
                                                 srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                               />
                                               <source
                                                 key="1"
-                                                media="(min-width: 400px )"
+                                                media="(min-width: 400px)"
                                                 srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                               />
                                               <source
                                                 key="2"
-                                                media="(min-width: 320px )"
+                                                media="(min-width: 320px)"
                                                 srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                               />
                                               <img
@@ -17708,22 +17721,22 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                     >
                                       <div
                                         className="bx--image"
-                                        data-autoid="dds--image__longdescription-"
+                                        data-autoid="dds--image__longdescription"
                                       >
                                         <picture>
                                           <source
                                             key="0"
-                                            media="(min-width: 672px )"
+                                            media="(min-width: 672px)"
                                             srcSet="https://dummyimage.com/672x378/ee5396/161616&amp;text=16:9"
                                           />
                                           <source
                                             key="1"
-                                            media="(min-width: 400px )"
+                                            media="(min-width: 400px)"
                                             srcSet="https://dummyimage.com/400x225/ee5396/161616&amp;text=16:9"
                                           />
                                           <source
                                             key="2"
-                                            media="(min-width: 320px )"
+                                            media="(min-width: 320px)"
                                             srcSet="https://dummyimage.com/320x180/ee5396/161616&amp;text=16:9"
                                           />
                                           <img
@@ -18116,22 +18129,22 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                     >
                                       <div
                                         className="bx--image"
-                                        data-autoid="dds--image__longdescription-"
+                                        data-autoid="dds--image__longdescription"
                                       >
                                         <picture>
                                           <source
                                             key="0"
-                                            media="(min-width: 672px )"
+                                            media="(min-width: 672px)"
                                             srcSet="https://dummyimage.com/672x378/ee5396/161616&amp;text=16:9"
                                           />
                                           <source
                                             key="1"
-                                            media="(min-width: 400px )"
+                                            media="(min-width: 400px)"
                                             srcSet="https://dummyimage.com/400x225/ee5396/161616&amp;text=16:9"
                                           />
                                           <source
                                             key="2"
-                                            media="(min-width: 320px )"
+                                            media="(min-width: 320px)"
                                             srcSet="https://dummyimage.com/320x180/ee5396/161616&amp;text=16:9"
                                           />
                                           <img
@@ -18575,7 +18588,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             >
                                               <div
                                                 className="bx--image"
-                                                data-autoid="dds--image__longdescription-"
+                                                data-autoid="dds--image__longdescription"
                                               >
                                                 <picture>
                                                   <img
@@ -19107,22 +19120,22 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             >
                                               <div
                                                 className="bx--image"
-                                                data-autoid="dds--image__longdescription-"
+                                                data-autoid="dds--image__longdescription"
                                               >
                                                 <picture>
                                                   <source
                                                     key="0"
-                                                    media="(min-width: 672px )"
+                                                    media="(min-width: 672px)"
                                                     srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                   />
                                                   <source
                                                     key="1"
-                                                    media="(min-width: 400px )"
+                                                    media="(min-width: 400px)"
                                                     srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                                   />
                                                   <source
                                                     key="2"
-                                                    media="(min-width: 320px )"
+                                                    media="(min-width: 320px)"
                                                     srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                                   />
                                                   <img
@@ -19515,22 +19528,22 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                             >
                                               <div
                                                 className="bx--image"
-                                                data-autoid="dds--image__longdescription-"
+                                                data-autoid="dds--image__longdescription"
                                               >
                                                 <picture>
                                                   <source
                                                     key="0"
-                                                    media="(min-width: 672px )"
+                                                    media="(min-width: 672px)"
                                                     srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                   />
                                                   <source
                                                     key="1"
-                                                    media="(min-width: 400px )"
+                                                    media="(min-width: 400px)"
                                                     srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                                   />
                                                   <source
                                                     key="2"
-                                                    media="(min-width: 320px )"
+                                                    media="(min-width: 320px)"
                                                     srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                                   />
                                                   <img
@@ -19974,7 +19987,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                                                     >
                                                       <div
                                                         className="bx--image"
-                                                        data-autoid="dds--image__longdescription-"
+                                                        data-autoid="dds--image__longdescription"
                                                       >
                                                         <picture>
                                                           <img
@@ -22010,22 +22023,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed Default 1`] = `
                                     >
                                       <div
                                         className="bx--image"
-                                        data-autoid="dds--image__longdescription-"
+                                        data-autoid="dds--image__longdescription"
                                       >
                                         <picture>
                                           <source
                                             key="0"
-                                            media="(min-width: 672px )"
+                                            media="(min-width: 672px)"
                                             srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                           />
                                           <source
                                             key="1"
-                                            media="(min-width: 400px )"
+                                            media="(min-width: 400px)"
                                             srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                           />
                                           <source
                                             key="2"
-                                            media="(min-width: 320px )"
+                                            media="(min-width: 320px)"
                                             srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                           />
                                           <img
@@ -23927,22 +23940,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockMixed With aside elements 1`] 
                                             >
                                               <div
                                                 className="bx--image"
-                                                data-autoid="dds--image__longdescription-"
+                                                data-autoid="dds--image__longdescription"
                                               >
                                                 <picture>
                                                   <source
                                                     key="0"
-                                                    media="(min-width: 672px )"
+                                                    media="(min-width: 672px)"
                                                     srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                   />
                                                   <source
                                                     key="1"
-                                                    media="(min-width: 400px )"
+                                                    media="(min-width: 400px)"
                                                     srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                                   />
                                                   <source
                                                     key="2"
-                                                    media="(min-width: 320px )"
+                                                    media="(min-width: 320px)"
                                                     srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                                   />
                                                   <img
@@ -24832,22 +24845,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                           >
                             <div
                               className="bx--image"
-                              data-autoid="dds--image__longdescription-"
+                              data-autoid="dds--image__longdescription"
                             >
                               <picture>
                                 <source
                                   key="0"
-                                  media="(min-width: 672px )"
+                                  media="(min-width: 672px)"
                                   srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                 />
                                 <source
                                   key="1"
-                                  media="(min-width: 400px )"
+                                  media="(min-width: 400px)"
                                   srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                 />
                                 <source
                                   key="2"
-                                  media="(min-width: 320px )"
+                                  media="(min-width: 320px)"
                                   srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                 />
                                 <img
@@ -25113,22 +25126,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                   >
                                     <div
                                       className="bx--image"
-                                      data-autoid="dds--image__longdescription-"
+                                      data-autoid="dds--image__longdescription"
                                     >
                                       <picture>
                                         <source
                                           key="0"
-                                          media="(min-width: 672px )"
+                                          media="(min-width: 672px)"
                                           srcSet="https://dummyimage.com/672x378/ee5396/161616&amp;text=16:9"
                                         />
                                         <source
                                           key="1"
-                                          media="(min-width: 400px )"
+                                          media="(min-width: 400px)"
                                           srcSet="https://dummyimage.com/400x225/ee5396/161616&amp;text=16:9"
                                         />
                                         <source
                                           key="2"
-                                          media="(min-width: 320px )"
+                                          media="(min-width: 320px)"
                                           srcSet="https://dummyimage.com/320x180/ee5396/161616&amp;text=16:9"
                                         />
                                         <img
@@ -25734,22 +25747,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                   >
                                     <div
                                       className="bx--image"
-                                      data-autoid="dds--image__longdescription-"
+                                      data-autoid="dds--image__longdescription"
                                     >
                                       <picture>
                                         <source
                                           key="0"
-                                          media="(min-width: 672px )"
+                                          media="(min-width: 672px)"
                                           srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                         />
                                         <source
                                           key="1"
-                                          media="(min-width: 400px )"
+                                          media="(min-width: 400px)"
                                           srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                         />
                                         <source
                                           key="2"
-                                          media="(min-width: 320px )"
+                                          media="(min-width: 320px)"
                                           srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                         />
                                         <img
@@ -25914,22 +25927,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           >
                                             <div
                                               className="bx--image"
-                                              data-autoid="dds--image__longdescription-"
+                                              data-autoid="dds--image__longdescription"
                                             >
                                               <picture>
                                                 <source
                                                   key="0"
-                                                  media="(min-width: 672px )"
+                                                  media="(min-width: 672px)"
                                                   srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                                 />
                                                 <source
                                                   key="1"
-                                                  media="(min-width: 400px )"
+                                                  media="(min-width: 400px)"
                                                   srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                                 />
                                                 <source
                                                   key="2"
-                                                  media="(min-width: 320px )"
+                                                  media="(min-width: 320px)"
                                                   srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                                 />
                                                 <img
@@ -26746,22 +26759,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                             >
                               <div
                                 className="bx--image"
-                                data-autoid="dds--image__longdescription-"
+                                data-autoid="dds--image__longdescription"
                               >
                                 <picture>
                                   <source
                                     key="0"
-                                    media="(min-width: 672px )"
+                                    media="(min-width: 672px)"
                                     srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                   />
                                   <source
                                     key="1"
-                                    media="(min-width: 400px )"
+                                    media="(min-width: 400px)"
                                     srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                   />
                                   <source
                                     key="2"
-                                    media="(min-width: 320px )"
+                                    media="(min-width: 320px)"
                                     srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                   />
                                   <img
@@ -27263,22 +27276,22 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                     >
                                       <div
                                         className="bx--image"
-                                        data-autoid="dds--image__longdescription-"
+                                        data-autoid="dds--image__longdescription"
                                       >
                                         <picture>
                                           <source
                                             key="0"
-                                            media="(min-width: 672px )"
+                                            media="(min-width: 672px)"
                                             srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                           />
                                           <source
                                             key="1"
-                                            media="(min-width: 400px )"
+                                            media="(min-width: 400px)"
                                             srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                           />
                                           <source
                                             key="2"
-                                            media="(min-width: 320px )"
+                                            media="(min-width: 320px)"
                                             srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                           />
                                           <img
@@ -29968,22 +29981,22 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupSimple Default 1`] = `
                           >
                             <div
                               className="bx--image"
-                              data-autoid="dds--image__longdescription-"
+                              data-autoid="dds--image__longdescription"
                             >
                               <picture>
                                 <source
                                   key="0"
-                                  media="(min-width: 672px )"
+                                  media="(min-width: 672px)"
                                   srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                 />
                                 <source
                                   key="1"
-                                  media="(min-width: 400px )"
+                                  media="(min-width: 400px)"
                                   srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                 />
                                 <source
                                   key="2"
-                                  media="(min-width: 320px )"
+                                  media="(min-width: 320px)"
                                   srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                 />
                                 <img
@@ -30351,7 +30364,7 @@ exports[`Storyshots Patterns (Blocks)|FeatureCardBlockLarge Default 1`] = `
                     >
                       <div
                         className="bx--image"
-                        data-autoid="dds--image__longdescription-"
+                        data-autoid="dds--image__longdescription"
                       >
                         <picture>
                           <img
@@ -30588,7 +30601,7 @@ exports[`Storyshots Patterns (Blocks)|FeatureCardBlockMedium Default 1`] = `
                               >
                                 <div
                                   className="bx--image"
-                                  data-autoid="dds--image__longdescription-"
+                                  data-autoid="dds--image__longdescription"
                                 >
                                   <picture>
                                     <img
@@ -30880,22 +30893,22 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                           >
                             <div
                               className="bx--image"
-                              data-autoid="dds--image__longdescription-"
+                              data-autoid="dds--image__longdescription"
                             >
                               <picture>
                                 <source
                                   key="0"
-                                  media="(min-width: 672px )"
+                                  media="(min-width: 672px)"
                                   srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
                                 />
                                 <source
                                   key="1"
-                                  media="(min-width: 400px )"
+                                  media="(min-width: 400px)"
                                   srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
                                 />
                                 <source
                                   key="2"
-                                  media="(min-width: 320px )"
+                                  media="(min-width: 320px)"
                                   srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
                                 />
                                 <img
@@ -31578,7 +31591,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31619,7 +31632,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31660,7 +31673,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31701,7 +31714,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31742,7 +31755,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31783,7 +31796,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31824,7 +31837,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31865,7 +31878,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -31906,7 +31919,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                 >
                                   <div
                                     className="bx--image"
-                                    data-autoid="dds--image__longdescription-"
+                                    data-autoid="dds--image__longdescription"
                                   >
                                     <picture>
                                       <img
@@ -33065,7 +33078,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                             >
                               <div
                                 className="bx--image"
-                                data-autoid="dds--image__longdescription-"
+                                data-autoid="dds--image__longdescription"
                               >
                                 <picture>
                                   <img
@@ -33200,7 +33213,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                             >
                               <div
                                 className="bx--image"
-                                data-autoid="dds--image__longdescription-"
+                                data-autoid="dds--image__longdescription"
                               >
                                 <picture>
                                   <img
@@ -33335,7 +33348,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                             >
                               <div
                                 className="bx--image"
-                                data-autoid="dds--image__longdescription-"
+                                data-autoid="dds--image__longdescription"
                               >
                                 <picture>
                                   <img
@@ -33470,7 +33483,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                             >
                               <div
                                 className="bx--image"
-                                data-autoid="dds--image__longdescription-"
+                                data-autoid="dds--image__longdescription"
                               >
                                 <picture>
                                   <img
@@ -33605,7 +33618,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionImages Default 1`] = `
                             >
                               <div
                                 className="bx--image"
-                                data-autoid="dds--image__longdescription-"
+                                data-autoid="dds--image__longdescription"
                               >
                                 <picture>
                                   <img
@@ -35298,17 +35311,17 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
           >
             <div
               className="bx--image"
-              data-autoid="dds--image__longdescription-"
+              data-autoid="dds--image__longdescription"
             >
               <picture>
                 <source
                   key="0"
-                  media="(min-width: 672px )"
+                  media="(min-width: 672px)"
                   srcSet="https://picsum.photos/id/1076/672/400"
                 />
                 <source
                   key="1"
-                  media="(min-width: 320px )"
+                  media="(min-width: 320px)"
                   srcSet="https://picsum.photos/id/1076/320/370"
                 />
                 <img
@@ -36110,17 +36123,17 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Small with image 1`] = `
           >
             <div
               className="bx--image"
-              data-autoid="dds--image__longdescription-"
+              data-autoid="dds--image__longdescription"
             >
               <picture>
                 <source
                   key="0"
-                  media="(min-width: 672px )"
+                  media="(min-width: 672px)"
                   srcSet="https://picsum.photos/id/1076/672/400"
                 />
                 <source
                   key="1"
-                  media="(min-width: 320px )"
+                  media="(min-width: 320px)"
                   srcSet="https://picsum.photos/id/1076/320/370"
                 />
                 <img

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1396,7 +1396,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
         className="bx--row"
       >
         <div
-          className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2"
+          className="bx--col-sm-4 bx--col-lg-10 bx--offset-lg-2"
         >
           <ContentItemHorizontal
             copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
@@ -1424,7 +1424,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
             heading="Aliquam condimentum"
           >
             <div
-              className="bx--content-item-horizontal__item bx"
+              className="bx--content-item-horizontal__item "
               data-autoid="dds--content-item-horizontal__item"
             >
               <div
@@ -4515,7 +4515,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                           key="0"
                                         >
                                           <div
-                                            className="bx--content-item-horizontal__item bx"
+                                            className="bx--content-item-horizontal__item "
                                             data-autoid="dds--content-item-horizontal__item"
                                           >
                                             <div
@@ -4783,7 +4783,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                           key="1"
                                         >
                                           <div
-                                            className="bx--content-item-horizontal__item bx"
+                                            className="bx--content-item-horizontal__item "
                                             data-autoid="dds--content-item-horizontal__item"
                                           >
                                             <div
@@ -28623,7 +28623,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                       key="0"
                     >
                       <div
-                        className="bx--content-item-horizontal__item bx"
+                        className="bx--content-item-horizontal__item "
                         data-autoid="dds--content-item-horizontal__item"
                       >
                         <div
@@ -28919,7 +28919,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                       key="1"
                     >
                       <div
-                        className="bx--content-item-horizontal__item bx"
+                        className="bx--content-item-horizontal__item "
                         data-autoid="dds--content-item-horizontal__item"
                       >
                         <div
@@ -29208,7 +29208,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                       key="2"
                     >
                       <div
-                        className="bx--content-item-horizontal__item bx"
+                        className="bx--content-item-horizontal__item "
                         data-autoid="dds--content-item-horizontal__item"
                       >
                         <div

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -15357,15 +15357,15 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                   Array [
                     Object {
                       "breakpoint": 400,
-                      "src": "https://dummyimage.com/672x200",
+                      "src": "https://dummyimage.com/672x200&text=Example%20Children",
                     },
                     Object {
                       "breakpoint": 672,
-                      "src": "https://dummyimage.com/672x200",
+                      "src": "https://dummyimage.com/672x200&text=Example%20Children",
                     },
                     Object {
                       "breakpoint": 1056,
-                      "src": "https://dummyimage.com/672x672",
+                      "src": "https://dummyimage.com/672x672&text=Example%20Children",
                     },
                   ]
                 }
@@ -15418,15 +15418,15 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
               Array [
                 Object {
                   "breakpoint": 400,
-                  "src": "https://dummyimage.com/672x200",
+                  "src": "https://dummyimage.com/672x200&text=Example%20Children",
                 },
                 Object {
                   "breakpoint": 672,
-                  "src": "https://dummyimage.com/672x200",
+                  "src": "https://dummyimage.com/672x200&text=Example%20Children",
                 },
                 Object {
                   "breakpoint": 1056,
-                  "src": "https://dummyimage.com/672x672",
+                  "src": "https://dummyimage.com/672x672&text=Example%20Children",
                 },
               ]
             }
@@ -15503,15 +15503,15 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                         Array [
                           Object {
                             "breakpoint": 400,
-                            "src": "https://dummyimage.com/672x200",
+                            "src": "https://dummyimage.com/672x200&text=Example%20Children",
                           },
                           Object {
                             "breakpoint": 672,
-                            "src": "https://dummyimage.com/672x200",
+                            "src": "https://dummyimage.com/672x200&text=Example%20Children",
                           },
                           Object {
                             "breakpoint": 1056,
-                            "src": "https://dummyimage.com/672x672",
+                            "src": "https://dummyimage.com/672x672&text=Example%20Children",
                           },
                         ]
                       }
@@ -15532,17 +15532,17 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                           <source
                             key="0"
                             media="(min-width: 1056px )"
-                            srcSet="https://dummyimage.com/672x672"
+                            srcSet="https://dummyimage.com/672x672&text=Example%20Children"
                           />
                           <source
                             key="1"
                             media="(min-width: 672px )"
-                            srcSet="https://dummyimage.com/672x200"
+                            srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                           />
                           <source
                             key="2"
                             media="(min-width: 400px )"
-                            srcSet="https://dummyimage.com/672x200"
+                            srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                           />
                           <img
                             alt="Lorem Ipsum"
@@ -15581,15 +15581,15 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                             Array [
                               Object {
                                 "breakpoint": 400,
-                                "src": "https://dummyimage.com/672x200",
+                                "src": "https://dummyimage.com/672x200&text=Example%20Children",
                               },
                               Object {
                                 "breakpoint": 672,
-                                "src": "https://dummyimage.com/672x200",
+                                "src": "https://dummyimage.com/672x200&text=Example%20Children",
                               },
                               Object {
                                 "breakpoint": 1056,
-                                "src": "https://dummyimage.com/672x672",
+                                "src": "https://dummyimage.com/672x672&text=Example%20Children",
                               },
                             ]
                           }
@@ -15876,15 +15876,15 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                           Array [
                             Object {
                               "breakpoint": 400,
-                              "src": "https://dummyimage.com/672x200",
+                              "src": "https://dummyimage.com/672x200&text=Example%20Children",
                             },
                             Object {
                               "breakpoint": 672,
-                              "src": "https://dummyimage.com/672x200",
+                              "src": "https://dummyimage.com/672x200&text=Example%20Children",
                             },
                             Object {
                               "breakpoint": 1056,
-                              "src": "https://dummyimage.com/672x672",
+                              "src": "https://dummyimage.com/672x672&text=Example%20Children",
                             },
                           ]
                         }
@@ -15905,17 +15905,17 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                             <source
                               key="0"
                               media="(min-width: 1056px )"
-                              srcSet="https://dummyimage.com/672x672"
+                              srcSet="https://dummyimage.com/672x672&text=Example%20Children"
                             />
                             <source
                               key="1"
                               media="(min-width: 672px )"
-                              srcSet="https://dummyimage.com/672x200"
+                              srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                             />
                             <source
                               key="2"
                               media="(min-width: 400px )"
-                              srcSet="https://dummyimage.com/672x200"
+                              srcSet="https://dummyimage.com/672x200&text=Example%20Children"
                             />
                             <img
                               alt="Lorem Ipsum"

--- a/packages/react/src/components/ButtonGroup/README.stories.mdx
+++ b/packages/react/src/components/ButtonGroup/README.stories.mdx
@@ -4,8 +4,12 @@ import ButtonGroup from './ButtonGroup';
 
 # Button Group
 
-> The button group component is to be utilized within IBM.com for grouping two
-> or more Button components together.
+> Use button groups when you want to display multiple buttons, such as in a
+> call-to-action.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ButtonGroup)
+> example implementation.
 
 ## Getting started
 
@@ -122,7 +126,5 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 | ---------------------------- | ------------------------------------------- |
 | `dds--button-group`          | `ButtonGroup` wrapper layer                 |
 | `dds--button-group-${index}` | `Button` component within the `ButtonGroup` |
-
-
 
 <Description markdown={contributing} />

--- a/packages/react/src/components/CTA/README.stories.mdx
+++ b/packages/react/src/components/CTA/README.stories.mdx
@@ -4,7 +4,13 @@ import CTA from './CTA';
 
 # CTA
 
-> The CTA component will be used to select different cta types pages.
+> The CTA component is used to select from various CTA link types – text, cards,
+> and buttons – as well as defining their behavior, such as anchor links,
+> videos, and external links.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CTA)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/Card/README.stories.mdx
+++ b/packages/react/src/components/Card/README.stories.mdx
@@ -2,11 +2,15 @@ import { Props, Description } from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../docs/contributing-license.md';
 import { Card } from './Card';
 
-# Card Link
+# Card
 
-> The card link component uses
+> Cards use
 > [Carbon's Clickable Tile component](https://www.carbondesignsystem.com/components/tile/code#clickable-tile)
 > while presenting content in a concise and readable style.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Card)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/CardGroup/README.stories.mdx
+++ b/packages/react/src/components/CardGroup/README.stories.mdx
@@ -4,8 +4,8 @@ import CardGroup from './CardGroup';
 
 # Card Group
 
-> The CardGroup component is a collection of Card components that can be used in
-> block and group -level patterns.
+> Card groups are a collection of card components that can be used in block and
+> group -level patterns.
 
 ## Getting started
 
@@ -26,6 +26,10 @@ Here's a quick example to get you started.
 > 💡 Only import fonts once per usage. Don't forget to import the card-group
 > styles from
 > [@carbon/ibmdotcom-styles](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles).
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardGroup)
+> example implementation.
 
 ##### JS
 

--- a/packages/react/src/components/CardLink/README.stories.mdx
+++ b/packages/react/src/components/CardLink/README.stories.mdx
@@ -4,9 +4,13 @@ import { CardLink } from '../CardLink';
 
 # CardLink
 
-> The cardlink component uses
+> Card links use
 > [Carbon's Clickable Tile component](https://www.carbondesignsystem.com/components/tile/code#clickable-tile)
 > while presenting content in a concise and readable style.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardLink)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/ContentItemHorizontal/ContentItemHorizontal.js
+++ b/packages/react/src/components/ContentItemHorizontal/ContentItemHorizontal.js
@@ -28,7 +28,7 @@ const { prefix } = settings;
  */
 const ContentItemHorizontal = ({ eyebrow, heading, copy, cta }) => (
   <div
-    className={`${prefix}--content-item-horizontal__item ${prefix}`}
+    className={`${prefix}--content-item-horizontal__item `}
     data-autoid={`${stablePrefix}--content-item-horizontal__item`}>
     <div className={`${prefix}--content-item-horizontal__row`}>
       <div className={`${prefix}--content-item-horizontal__col`}>

--- a/packages/react/src/components/ContentItemHorizontal/README.stories.mdx
+++ b/packages/react/src/components/ContentItemHorizontal/README.stories.mdx
@@ -4,8 +4,11 @@ import ContentItemHorizontal from './ContentItemHorizontal';
 
 # Content Item - Horizontal
 
-> The ContentItemHorizontal component displays information in a horizontal
-> orientation.
+> Use this component to present content in a horizontal orientation.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentItemHorizontal)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/ContentItemHorizontal/__stories__/ContentItemHorizontal.stories.js
+++ b/packages/react/src/components/ContentItemHorizontal/__stories__/ContentItemHorizontal.stories.js
@@ -58,7 +58,7 @@ export const Default = ({ parameters }) => {
   return (
     <div className="bx--grid bx--content-group-story">
       <div className="bx--row">
-        <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
+        <div className="bx--col-sm-4 bx--col-lg-10 bx--offset-lg-2">
           <ContentItemHorizontal
             eyebrow={eyebrow}
             heading={heading}

--- a/packages/react/src/components/DotcomShell/README.stories.mdx
+++ b/packages/react/src/components/DotcomShell/README.stories.mdx
@@ -5,8 +5,12 @@ import DotcomShell from './DotcomShell';
 
 # DotcomShell
 
-> The DotcomShell component includes the `Masthead`, and `Footer` components,
-> all wrapped in a UI shell using Carbon's grid.
+> The Dotcom shell includes the `Masthead`, and `Footer` components, all wrapped
+> in a UI shell using Carbon's grid.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/DotcomShell)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/ExpressiveModal/README.stories.mdx
+++ b/packages/react/src/components/ExpressiveModal/README.stories.mdx
@@ -8,9 +8,9 @@ import ExpressiveModal from './ExpressiveModal';
 > [Carbon's Modal component](https://www.carbondesignsystem.com/components/modal/code)
 > with slight styling updates to increase readability and reduce strain.
 
-> 💡 Check out
-> [Carbon's Modal component](https://www.carbondesignsystem.com/components/modal/code)
-> for props and other usage documentation.
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ExpressiveModal)
+> example implementation.
 
 ## Getting started
 
@@ -49,6 +49,10 @@ function App() {
 
 ReactDOM.render(<App />, document.querySelector('#app'));
 ```
+
+> 💡 See
+> [Carbon's Modal component](https://www.carbondesignsystem.com/components/modal/code)
+> for props and other usage documentation.
 
 Add the following line in your `.env` file at the root of your project.
 [See more details](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles#usage).

--- a/packages/react/src/components/FeatureCard/README.stories.mdx
+++ b/packages/react/src/components/FeatureCard/README.stories.mdx
@@ -4,9 +4,11 @@ import FeatureCard from './FeatureCard';
 
 # Feature Card
 
-> The Feature Card pattern is to be utilized within IBM.com.
+> Feature cards consist of an image, heading, copy, and CTA.
 
-> 💡 Check our [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/FeatureCard) example implementation.
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/FeatureCard)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/Footer/README.stories.mdx
+++ b/packages/react/src/components/Footer/README.stories.mdx
@@ -8,6 +8,10 @@ import Footer from './Footer';
 > The footer component is a required navigational pattern for IBM.com that
 > displays consistently at the bottom of each page.
 
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Footer)
+> example implementation.
+
 ## Getting started
 
 Here's a quick example to get you started.

--- a/packages/react/src/components/HorizontalRule/README.stories.mdx
+++ b/packages/react/src/components/HorizontalRule/README.stories.mdx
@@ -4,8 +4,11 @@ import HorizontalRule from './HorizontalRule';
 
 # Horizontal Rule
 
-> The horizontal rule component is to be utilized within IBM.com for thematic
-> breaks within the content of the page.
+> Horizontal rules provide thematic breaks between content.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/HorizontalRule)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/Image/Image.js
+++ b/packages/react/src/components/Image/Image.js
@@ -58,12 +58,12 @@ const Image = ({
   return (
     <div
       className={`${prefix}--image`}
-      data-autoid={`${stablePrefix}--image__longdescription-`}>
+      data-autoid={`${stablePrefix}--image__longdescription`}>
       <picture>
         {sortedImages.map((imgSrc, key) => {
           return (
             <source
-              media={`(min-width: ${imgSrc.breakpoint}px )`}
+              media={`(min-width: ${imgSrc.breakpoint}px)`}
               key={key}
               srcSet={imgSrc.src}
             />

--- a/packages/react/src/components/Image/README.stories.mdx
+++ b/packages/react/src/components/Image/README.stories.mdx
@@ -4,8 +4,12 @@ import Image from './Image';
 
 # Image
 
-> The Image component will be used as the primary way of embedding images on
-> pages.
+> The image component is used to embed images within content and can display a
+> specific image depending on viewport size.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Image)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/Image/__stories__/Image.stories.js
+++ b/packages/react/src/components/Image/__stories__/Image.stories.js
@@ -25,15 +25,15 @@ export default {
           [
             {
               src: 'https://dummyimage.com/320x160/ee5396/161616&text=2x1',
-              breakpoint: 320,
+              breakpoint: 'sm',
             },
             {
-              src: 'https://dummyimage.com/400x400/ee5396/161616&text=1x1',
-              breakpoint: 400,
+              src: 'https://dummyimage.com/400x200/ee5396/161616&text=2x1',
+              breakpoint: 'md',
             },
             {
-              src: 'https://dummyimage.com/672x672/ee5396/161616&text=1x1',
-              breakpoint: 672,
+              src: 'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
+              breakpoint: 'lg',
             },
           ],
           groupId
@@ -41,7 +41,7 @@ export default {
         alt: text('Image alt text (required)', 'Image alt text', groupId),
         defaultSrc: text(
           'Default image (required)',
-          'https://dummyimage.com/672x672/ee5396/161616&text=1x1',
+          'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
           groupId
         ),
       }),

--- a/packages/react/src/components/ImageWithCaption/README.stories.mdx
+++ b/packages/react/src/components/ImageWithCaption/README.stories.mdx
@@ -4,8 +4,12 @@ import ImageWithCaption from './ImageWithCaption';
 
 # Image With Caption
 
-> The ImageWithCaption component will be used as the primary way of embedding
-> images on pages.
+> This leverages the image component and can also display a caption for the
+> image.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ImageWithCaption)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/ImageWithCaption/__stories__/ImageWithCaption.stories.js
+++ b/packages/react/src/components/ImageWithCaption/__stories__/ImageWithCaption.stories.js
@@ -35,9 +35,13 @@ export default {
                 src: 'https://dummyimage.com/400x200/ee5396/161616&text=2x1',
                 breakpoint: 'md',
               },
+              {
+                src: 'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
+                breakpoint: 'lg',
+              },
             ],
             alt: 'image with caption image',
-            defaultSrc: 'https://dummyimage.com/672x672/ee5396/161616&text=1x1',
+            defaultSrc: 'https://dummyimage.com/672x336/ee5396/161616&text=2x1',
           },
           groupId
         ),

--- a/packages/react/src/components/LightboxMediaViewer/README.stories.mdx
+++ b/packages/react/src/components/LightboxMediaViewer/README.stories.mdx
@@ -4,7 +4,12 @@ import LightboxMediaViewer from './LightboxMediaViewer';
 
 # Lightbox Media Viewer
 
-> The LightboxMediaViewer component is to be utilized within IBM.com.
+> This launches a modal containing an image or video, and a description
+> detailing the media content.
+
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LightboxMediaViewer)
+> example implementation.
 
 ## Getting started
 
@@ -100,7 +105,11 @@ Add the following line in your `.env` file at the root of your project.
 
 > 💡 See uri object structure above in `Getting started` section.
 
-> 💡 Also refer to [`<ExpressiveModal>`](http://ibmdotcom-react.mybluemix.net/?path=/docs/components-expressive-modal--default) and Carbon's [`<ComposedModal>`](https://react.carbondesignsystem.com/?path=/story/composedmodal--using-child-nodes) for other props.
+> 💡 Also refer to
+> [`<ExpressiveModal>`](http://ibmdotcom-react.mybluemix.net/?path=/docs/components-expressive-modal--default)
+> and Carbon's
+> [`<ComposedModal>`](https://react.carbondesignsystem.com/?path=/story/composedmodal--using-child-nodes)
+> for other props.
 
 ## Stable selectors
 

--- a/packages/react/src/components/LinkList/README.stories.mdx
+++ b/packages/react/src/components/LinkList/README.stories.mdx
@@ -4,9 +4,12 @@ import LinkList from './LinkList';
 
 # Link List
 
-> The Link List component will be used to have list of different cta types.
+> Link lists are a collection of links that can be presented in various
+> orientations and styles, such as horizontal, vertical, and cards.
 
-> 💡 Check our [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LinkList) example implementation.
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LinkList)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/LinkWithIcon/README.stories.mdx
+++ b/packages/react/src/components/LinkWithIcon/README.stories.mdx
@@ -4,11 +4,13 @@ import LinkWithIcon from './LinkWithIcon';
 
 # LinkWithIcon
 
-> The LinkWithIcon component should be used primarily as a navigational element,
-> with an icon as an indicator to the type of content being referenced, e.g.
-> url, external url, file.
+> Links with an icon should be used primarily as a navigational element, with
+> the icon as an indicator to the type of content being referenced, e.g. url,
+> file, video.
 
-> 💡 Check our [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LinkWithIcon) example implementation.
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LinkWithIcon)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/LocaleModal/README.stories.mdx
+++ b/packages/react/src/components/LocaleModal/README.stories.mdx
@@ -8,6 +8,10 @@ import LocaleModal from './LocaleModal';
 > The locale modal allows users to change geographic regions and translate pages
 > to those region languages, if available.
 
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LocaleModal)
+> example implementation.
+
 ## Getting started
 
 Here's a quick example to get you started.
@@ -73,7 +77,9 @@ See how to
 
 > 💡 Props default to English if not provided.
 
-> 💡 Also refer to Carbon's [`<ComposedModal>`](https://react.carbondesignsystem.com/?path=/story/composedmodal--using-child-nodes) for other props.
+> 💡 Also refer to Carbon's
+> [`<ComposedModal>`](https://react.carbondesignsystem.com/?path=/story/composedmodal--using-child-nodes)
+> for other props.
 
 ## Stable selectors
 

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -9,6 +9,10 @@ import Masthead from './Masthead';
 > displays consistently at the top of each page. It also includes search and
 > profile services for IBM.com.
 
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Masthead)
+> example implementation.
+
 ## Getting started
 
 Here's a quick example to get you started.

--- a/packages/react/src/components/TableOfContents/README.stories.mdx
+++ b/packages/react/src/components/TableOfContents/README.stories.mdx
@@ -2,11 +2,15 @@ import { Props, Description } from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../docs/contributing-license.md';
 import TableOfContents from './TableOfContents';
 
-# Sticky Table of Contents
+# Table of Contents
 
-> The Sticky Table of Contents component is to be utilized within IBM.com.
+> Table of contents display pre-defined sections of the page and provide a
+> convenient way to navigate to those sections. It also sticks to the top of the
+> page when scrolling for easy access.
 
-> 💡 Check our [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/TableOfContents) example implementation.
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/TableOfContents)
+> example implementation.
 
 ## Getting started
 

--- a/packages/react/src/components/TableOfContents/TableOfContents.js
+++ b/packages/react/src/components/TableOfContents/TableOfContents.js
@@ -8,6 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
+import { HorizontalRule } from '../HorizontalRule';
 import Layout from '../Layout/Layout';
 import PropTypes from 'prop-types';
 import settings from 'carbon-components/es/globals/js/settings';
@@ -197,15 +198,13 @@ const TableOfContents = ({
       })}>
       <Layout {...layoutProps}>
         <div className={`${prefix}--tableofcontents__sidebar`}>
-          {headingContent ? (
+          {headingContent && (
             <div className={`${prefix}--tableofcontents__desktop__children`}>
               {headingContent}
 
-              {menuRule ? (
-                <hr className={`${prefix}--tableofcontents__desktop__rule`} />
-              ) : null}
+              {menuRule && <HorizontalRule />}
             </div>
-          ) : null}
+          )}
           <div className={`${prefix}--tableofcontents__mobile-top`}></div>
           <div style={{ position: 'sticky', top: '0' }}>
             <TOCDesktop

--- a/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
+++ b/packages/react/src/components/TableOfContents/__stories__/TableOfContents.stories.js
@@ -37,15 +37,15 @@ const defaultMenuItems = [
 
 const sources = [
   {
-    src: 'https://dummyimage.com/672x200',
+    src: 'https://dummyimage.com/672x200&text=Example%20Children',
     breakpoint: 400,
   },
   {
-    src: 'https://dummyimage.com/672x200',
+    src: 'https://dummyimage.com/672x200&text=Example%20Children',
     breakpoint: 672,
   },
   {
-    src: 'https://dummyimage.com/672x672',
+    src: 'https://dummyimage.com/672x672&text=Example%20Children',
     breakpoint: 1056,
   },
 ];

--- a/packages/react/src/components/VideoPlayer/README.stories.mdx
+++ b/packages/react/src/components/VideoPlayer/README.stories.mdx
@@ -4,12 +4,13 @@ import VideoPlayer from './VideoPlayer';
 
 # Video Player
 
-> The Video Player component plays embedded videos using the Kaltura video
-> platform. It can be used in inline patterns as well as modals. It is always
-> the full width of its containing element and maintains an aspect ratio of
-> 16:9.
+> Video players play embedded videos using the Kaltura video platform. It can be
+> used in inline patterns as well as modals. It is always the full width of its
+> containing element and maintains an aspect ratio of 16:9.
 
-> 💡 Check our [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/VideoPlayer) example implementation.
+> 💡 Check our
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/VideoPlayer)
+> example implementation.
 
 ## Getting started
 

--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -55,7 +55,6 @@
         @include carbon--breakpoint(lg) {
           margin-bottom: $layout-05;
         }
-
         p {
           color: $text-01;
         }
@@ -66,7 +65,6 @@
 
         .#{$prefix}--link-list {
           padding: 0;
-
           &:first-of-type {
             padding: 0;
           }
@@ -103,7 +101,6 @@
     &__row {
       @include carbon--make-row;
 
-      width: 100%;
       min-height: 160px;
     }
 

--- a/packages/styles/scss/components/image-with-caption/image-with-caption.scss
+++ b/packages/styles/scss/components/image-with-caption/image-with-caption.scss
@@ -6,6 +6,8 @@
  */
 
 @import '../../globals/imports';
+@import '../image/image';
+@import '../lightbox-media-viewer/lightbox-media-viewer';
 @import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/motion/motion.scss';
 
 @mixin image-with-caption {

--- a/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
+++ b/packages/styles/scss/components/tableofcontents/_tableofcontents.scss
@@ -13,15 +13,16 @@
   color: $text-01;
   background: $ui-background;
   .#{$prefix}--tableofcontents__mobile {
-    border-top: 1px solid $ui-04;
     border-bottom: 1px solid $ui-04;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+
     &:hover {
       background-color: $hover-ui;
     }
   }
   .#{$prefix}--tableofcontents__desktop__item {
     a {
-      border-left: carbon--rem(4px) solid $ui-01;
+      border-left: carbon--rem(4px) solid $ui-03;
       color: $text-02;
 
       &:hover {
@@ -43,6 +44,7 @@
     &__sidebar {
       position: sticky;
       top: 0;
+      z-index: 1;
 
       @include carbon--breakpoint('lg') {
         position: inherit;
@@ -81,7 +83,7 @@
             motion(standard, productive),
           outline $duration--fast-01 motion(standard, productive);
         &__wrapper {
-          height: carbon--rem(48px);
+          height: carbon--rem(47px);
           position: relative;
           display: flex;
           align-items: center;
@@ -105,10 +107,10 @@
           text-decoration: none;
           display: inline-block;
           width: 100%;
-          padding-top: carbon--rem(13px);
-          padding-bottom: carbon--rem(13px);
+          padding-top: carbon--rem(12px);
+          padding-bottom: carbon--rem(12px);
           padding-left: carbon--rem(12px);
-          @include carbon--type-style('body-short-02');
+          @include carbon--type-style('body-long-02');
 
           transition: all $duration--fast-01 motion(standard, productive);
         }
@@ -121,12 +123,6 @@
           z-index: 1;
           position: relative;
         }
-      }
-
-      &__rule {
-        margin-top: $layout-03;
-        margin-left: $spacing-05;
-        margin-bottom: 0;
       }
 
       &__children {
@@ -150,8 +146,6 @@
     @include carbon--breakpoint('md') {
       &__mobile {
         padding-left: $carbon--spacing-07;
-        margin-left: -$carbon--spacing-07;
-        margin-right: -$carbon--spacing-07;
       }
     }
     @include carbon--breakpoint('lg') {
@@ -161,6 +155,11 @@
       &__desktop {
         display: block;
       }
+    }
+    .#{$prefix}--hr {
+      margin-top: $layout-02;
+      margin-left: $spacing-05;
+      margin-bottom: 0;
     }
 
     @include themed-items;


### PR DESCRIPTION
### Description

Update component documentation with links to Codesandbox examples. Also adds `Image` and `ImageWithCaption` examples.

### Changelog

**New**

- `Image` and `ImageWithCaption` Codesandbox examples
- add missing css imports to `ImageWithCaption`

**Changed**

- add Codesandbox links to React component docs


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
