### PR TITLE
chore(storybook): adding build static storybook for web components

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,9 +23,11 @@
 - {{removed thing}}
 
 <!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
-<!-- *** "package: react": React, React (experimental) -->
+<!-- *** "package: react": React -->
+<!-- *** "package: web components": Web Components -->
 <!-- *** "package: vanilla": Vanilla -->
 <!-- *** "package: services": Services -->
-<!-- *** "package: utilities" Utilities -->
-<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
-<!-- *** "RTL" React (RTL) -->
+<!-- *** "package: utilities": Utilities -->
+<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
+<!-- *** "RTL": React (RTL) -->
+<!-- *** "feature flag": React (experimental) -->

--- a/packages/web-components/.eslintignore
+++ b/packages/web-components/.eslintignore
@@ -2,4 +2,5 @@
 dist
 es
 node_modules
+storybook-static
 tests/coverage

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -26,6 +26,7 @@
   ],
   "scripts": {
     "build": "gulp build && yarn wca",
+    "build-storybook": "build-storybook",
     "ci-check": "yarn wca && yarn format:diff && yarn lint:src && yarn typecheck && yarn build && yarn test:unit",
     "clean": "gulp clean",
     "format": "prettier --write \"**/*.{css,js,ts,md,scss}\"",


### PR DESCRIPTION
### Related Ticket(s)

Refs #2810 

### Description

This adds static builds of storybook, which will be needed for test deployments.

The PR template has also been updated to include the web components label in the instructions.

### Changelog

**Changed**

- `package.json` updated in web components package to include storybook static builds
- pull request template updated

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
