### PR TITLE
fix(contentblock): optional copy

### DIFF
--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -44,9 +44,13 @@ const mediaDataByType = {
   },
 };
 
-const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
-      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
-      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.`;
+const copy = {
+  default:
+    'Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.\n' +
+    '      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales\n' +
+    '      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.',
+  none: '',
+};
 
 const ctaStyles = {
   text: 'text',
@@ -74,7 +78,7 @@ const getBaseKnobs = ({ groupId }) => {
   return {
     mediaType,
     mediaData: mediaDataByType[mediaType],
-    copy,
+    copy: select('Copy (optional)', copy, copy.default),
     cta: {
       cta: {
         href: 'https://www.example.com',


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2638

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
