### PR TITLE
test(TranslationAPI): increase coverage

### DIFF
--- a/packages/services/src/services/Translation/__tests__/Translation.test.js
+++ b/packages/services/src/services/Translation/__tests__/Translation.test.js
@@ -45,6 +45,10 @@ describe('TranslationAPI', () => {
       cc: 'us',
     });
 
+    const elseResponse = await TranslationAPI.getTranslation({});
+
+    expect(elseResponse).toEqual(responseSuccess);
+
     expect(mockAxios.get).toHaveBeenCalledWith(fetchUrl, {
       headers: {
         'Content-Type': 'text/plain',
@@ -72,6 +76,10 @@ describe('TranslationAPI', () => {
       cc: 'us',
     });
 
+    const elseResponse = await TranslationAPI.getTranslation({});
+
+    expect(elseResponse).toEqual(responseSuccess);
+
     expect(mockAxios.get).toHaveBeenCalledWith(fetchUrl, {
       headers: {
         'Content-Type': 'text/plain',
@@ -98,6 +106,10 @@ describe('TranslationAPI', () => {
       lc: 'en',
       cc: 'us',
     });
+
+    const elseResponse = await TranslationAPI.getTranslation({});
+
+    expect(elseResponse).toEqual(responseSuccess);
 
     expect(mockAxios.get).toHaveBeenCalledWith(fetchUrl, {
       headers: {


### PR DESCRIPTION
### Related Ticket(s)

#2081 


### Description

Increased testing coverage by checking else of `getTranslation()` 

<img width="486" alt="Screen Shot 2020-06-29 at 9 24 34 AM" src="https://user-images.githubusercontent.com/20210594/86031184-5a7f4f00-b9ea-11ea-8003-aa23327fe29a.png">

### Changelog

**New**

- added empty object


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
