### PR TITLE
fix(VideoPlayer): create distinct videoplayer ids in order to place multiple of the same video

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2462,7 +2462,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--video-player__video"
-                                                          id="bx--video-player__video-0_uka1msg4"
+                                                          id="bx--video-player__video-0_uka1msg4-2"
                                                         >
                                                           <VideoImageOverlay
                                                             embedVideo={[Function]}
@@ -4379,7 +4379,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             >
                                                               <div
                                                                 className="bx--video-player__video"
-                                                                id="bx--video-player__video-undefined"
+                                                                id="bx--video-player__video-undefined-7"
                                                               >
                                                                 <VideoImageOverlay
                                                                   embedVideo={[Function]}
@@ -8823,7 +8823,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                                 >
                                   <div
                                     className="bx--video-player__video"
-                                    id="bx--video-player__video-0_uka1msg4"
+                                    id="bx--video-player__video-0_uka1msg4-22"
                                   />
                                 </div>
                               </div>
@@ -15559,14 +15559,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                           />
                           <img
                             alt="Lorem Ipsum"
-                            aria-describedby="bx--image-17"
+                            aria-describedby="bx--image-23"
                             className="bx--image__img"
                             src="https://dummyimage.com/672x672"
                           />
                         </picture>
                         <div
                           className="bx--image__longdescription"
-                          id="bx--image-17"
+                          id="bx--image-23"
                         >
                           Lorem Ipsum Dolor
                         </div>
@@ -15932,14 +15932,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                             />
                             <img
                               alt="Lorem Ipsum"
-                              aria-describedby="bx--image-18"
+                              aria-describedby="bx--image-24"
                               className="bx--image__img"
                               src="https://dummyimage.com/672x672"
                             />
                           </picture>
                           <div
                             className="bx--image__longdescription"
-                            id="bx--image-18"
+                            id="bx--image-24"
                           >
                             Lorem Ipsum Dolor
                           </div>
@@ -16150,7 +16150,7 @@ exports[`Storyshots Components|VideoPlayer Default 1`] = `
               >
                 <div
                   className="bx--video-player__video"
-                  id="bx--video-player__video-0_uka1msg4"
+                  id="bx--video-player__video-0_uka1msg4-26"
                 >
                   <VideoImageOverlay
                     embedVideo={[Function]}
@@ -31596,14 +31596,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-38"
+                                        aria-describedby="bx--image-46"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-38"
+                                      id="bx--image-46"
                                     >
                                       Company A
                                     </div>
@@ -31637,14 +31637,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-39"
+                                        aria-describedby="bx--image-47"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-39"
+                                      id="bx--image-47"
                                     >
                                       Company B
                                     </div>
@@ -31678,14 +31678,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-40"
+                                        aria-describedby="bx--image-48"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-40"
+                                      id="bx--image-48"
                                     >
                                       Company C
                                     </div>
@@ -31719,14 +31719,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-41"
+                                        aria-describedby="bx--image-49"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-41"
+                                      id="bx--image-49"
                                     >
                                       Company D
                                     </div>
@@ -31760,14 +31760,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-42"
+                                        aria-describedby="bx--image-50"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-42"
+                                      id="bx--image-50"
                                     >
                                       Company E
                                     </div>
@@ -31801,14 +31801,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-43"
+                                        aria-describedby="bx--image-51"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-43"
+                                      id="bx--image-51"
                                     >
                                       Company F
                                     </div>
@@ -31842,14 +31842,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-44"
+                                        aria-describedby="bx--image-52"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-44"
+                                      id="bx--image-52"
                                     >
                                       Company G
                                     </div>
@@ -31883,14 +31883,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-45"
+                                        aria-describedby="bx--image-53"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-45"
+                                      id="bx--image-53"
                                     >
                                       Company H
                                     </div>
@@ -31924,14 +31924,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-46"
+                                        aria-describedby="bx--image-54"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-46"
+                                      id="bx--image-54"
                                     >
                                       Company I
                                     </div>

--- a/packages/react/src/components/VideoPlayer/VideoPlayer.js
+++ b/packages/react/src/components/VideoPlayer/VideoPlayer.js
@@ -10,6 +10,7 @@ import cx from 'classnames';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import PropTypes from 'prop-types';
 import settings from 'carbon-components/es/globals/js/settings';
+import uniqueid from '@carbon/ibmdotcom-utilities/es/utilities/uniqueid/uniqueid';
 import VideoImageOverlay from './VideoImageOverlay';
 import VideoPlayerAPI from '@carbon/ibmdotcom-services/es/services/VideoPlayer/VideoPlayer';
 
@@ -30,7 +31,7 @@ const VideoPlayer = ({
 
   // embedVideo is set to true when overlay thumbnail is clicked
   const [embedVideo, setEmbedVideo] = useState(false);
-  const videoPlayerId = `video-player__video-${videoId}`;
+  const videoPlayerId = `video-player__video-${uniqueid(`${videoId}-`)}`;
   const videoDuration = VideoPlayerAPI.getVideoDuration(videoData.msDuration);
 
   useEffect(() => {
@@ -69,7 +70,7 @@ const VideoPlayer = ({
       className={classnames}>
       <div
         className={`${prefix}--video-player__video-container`}
-        data-autoid={`${stablePrefix}--${videoPlayerId}`}>
+        data-autoid={`${stablePrefix}--video-player__video-${videoId}`}>
         <div
           className={`${prefix}--video-player__video`}
           id={`${prefix}--${videoPlayerId}`}>

--- a/packages/react/src/components/VideoPlayer/VideoPlayer.js
+++ b/packages/react/src/components/VideoPlayer/VideoPlayer.js
@@ -31,7 +31,7 @@ const VideoPlayer = ({
 
   // embedVideo is set to true when overlay thumbnail is clicked
   const [embedVideo, setEmbedVideo] = useState(false);
-  const videoPlayerId = `video-player__video-${uniqueid(`${videoId}-`)}`;
+  const videoPlayerId = uniqueid(`video-player__video-${videoId}-`);
   const videoDuration = VideoPlayerAPI.getVideoDuration(videoData.msDuration);
 
   useEffect(() => {


### PR DESCRIPTION
### Related Ticket(s)

Inline and Linklist Video Player error #2502

### Description

Use the `uniqueid` util to create unique videoplayer ids. This way the `VideoPlayerAPI` knows where to embed the video properly even if there are multiple of the same video in the same page.


![Jun-29-2020 13-10-54](https://user-images.githubusercontent.com/54281166/86035271-0dab7080-ba0a-11ea-87fa-3600d1df5799.gif)


### Changelog

**Changed**

- use `uniqueid` util to concatenate a unique id to the videoplayer id