### PR TITLE
fix(contentblocksegmented) added copy knob for storybook

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -6263,7 +6263,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                       theme="g10"
                     >
                       <section
-                        className="bx--cta-section bx--cta-section--g10 bx--cta-section__has-items"
+                        className="bx--cta-section bx--cta-section--g10"
                         data-autoid="dds--cta-section"
                       >
                         <ContentBlock
@@ -6490,6 +6490,9 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                             </div>
                           </div>
                         </ContentBlock>
+                        <hr
+                          className="bx--horizontal-line"
+                        />
                         <div
                           className="bx--helper-wrapper"
                         >
@@ -24620,9 +24623,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
           className="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4"
         >
           <ContentBlockSegmented
-            copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
-      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
-      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+            copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit"
             cta={
               Object {
                 "copy": "Lorem ipsum dolor",
@@ -24712,9 +24713,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
             >
               <ContentBlock
                 border={false}
-                copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
-      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
-      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit"
                 cta={
                   Object {
                     "copy": "Lorem ipsum dolor",
@@ -24743,7 +24742,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p>",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit</p>",
                       }
                     }
                   />

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -44,6 +44,10 @@ const mediaDataByType = {
   },
 };
 
+const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
+      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.`;
+
 const ctaStyles = {
   text: 'text',
   card: 'card',
@@ -70,6 +74,7 @@ const getBaseKnobs = ({ groupId }) => {
   return {
     mediaType,
     mediaData: mediaDataByType[mediaType],
+    copy,
     cta: {
       cta: {
         href: 'https://www.example.com',

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -44,9 +44,13 @@ const mediaDataByType = {
   },
 };
 
-const copy = `Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
-      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
-      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.`;
+const copy = {
+  default:
+    'Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.\n' +
+    '      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales\n' +
+    '      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.',
+  none: '',
+};
 
 const ctaStyles = {
   text: 'text',
@@ -74,7 +78,7 @@ const getBaseKnobs = ({ groupId }) => {
   return {
     mediaType,
     mediaData: mediaDataByType[mediaType],
-    copy,
+    copy: select('Copy (optional)', copy, copy.default),
     cta: {
       cta: {
         href: 'https://www.example.com',

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -44,14 +44,6 @@ const mediaDataByType = {
   },
 };
 
-const copy = {
-  default:
-    'Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.\n' +
-    '      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales\n' +
-    '      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.',
-  none: '',
-};
-
 const ctaStyles = {
   text: 'text',
   card: 'card',
@@ -78,7 +70,6 @@ const getBaseKnobs = ({ groupId }) => {
   return {
     mediaType,
     mediaData: mediaDataByType[mediaType],
-    copy: select('Copy (optional)', copy, copy.default),
     cta: {
       cta: {
         href: 'https://www.example.com',
@@ -153,6 +144,11 @@ Default.story = {
 
         return {
           ...knobs,
+          copy: text(
+            'Copy',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit',
+            groupId
+          ),
           heading: text('Heading', 'Lorem ipsum dolor sit amet.', groupId),
           items: object('Content items', defaultItems, groupId),
         };


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2638

### Description

This issue was previously fixed but was non testable in storybook because there wasn't a copy knob. This adds an optional copy knob so the QA folks can test this within storybook.

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
