### PR TITLE
fix(contentblocksegmented) added copy knob for storybook

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -591,7 +591,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                             }
                           }
                         />
@@ -705,7 +705,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                             }
                           }
                         />
@@ -819,7 +819,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                             }
                           }
                         />
@@ -933,7 +933,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                             }
                           }
                         />
@@ -1047,7 +1047,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                             }
                           }
                         />
@@ -1305,7 +1305,7 @@ exports[`Storyshots Components|CardLink Default 1`] = `
                       className="bx--card__copy"
                       dangerouslySetInnerHTML={
                         Object {
-                          "__html": "<p>Explore AI use cases in all industries</p>",
+                          "__html": "<p>Explore AI use cases in all industries</p> ",
                         }
                       }
                     />
@@ -1453,7 +1453,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                     className="bx--content-item-horizontal__item--copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
+                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
                       }
                     }
                     data-autoid="dds--content-item-horizontal__item--copy"
@@ -2435,7 +2435,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                 className="bx--content-block__copy"
                                                 dangerouslySetInnerHTML={
                                                   Object {
-                                                    "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>",
+                                                    "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p> ",
                                                   }
                                                 }
                                               />
@@ -3096,7 +3096,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3228,7 +3228,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3280,7 +3280,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3412,7 +3412,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3536,7 +3536,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p>",
+                                                  "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p> ",
                                                 }
                                               }
                                             />
@@ -3751,7 +3751,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3973,7 +3973,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -4357,7 +4357,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             className="bx--content-item__copy"
                                                             dangerouslySetInnerHTML={
                                                               Object {
-                                                                "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p>",
+                                                                "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p> ",
                                                               }
                                                             }
                                                             data-autoid="dds--content-item__copy"
@@ -4548,7 +4548,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   className="bx--content-item-horizontal__item--copy"
                                                   dangerouslySetInnerHTML={
                                                     Object {
-                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> sellus at elit sollicitudin.</p>",
+                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> sellus at elit sollicitudin.</p> ",
                                                     }
                                                   }
                                                   data-autoid="dds--content-item-horizontal__item--copy"
@@ -4816,7 +4816,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   className="bx--content-item-horizontal__item--copy"
                                                   dangerouslySetInnerHTML={
                                                     Object {
-                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
+                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
                                                     }
                                                   }
                                                   data-autoid="dds--content-item-horizontal__item--copy"
@@ -5446,7 +5446,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               className="bx--card__copy"
                                                               dangerouslySetInnerHTML={
                                                                 Object {
-                                                                  "__html": "<p>Amet justo donec</p>",
+                                                                  "__html": "<p>Amet justo donec</p> ",
                                                                 }
                                                               }
                                                             />
@@ -6313,7 +6313,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                 className="bx--content-block__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
+                                    "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
                                   }
                                 }
                               />
@@ -6527,7 +6527,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p>",
+                                        "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -6642,7 +6642,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p>",
+                                        "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -7702,7 +7702,7 @@ exports[`Storyshots Components|Footer Short 1`] = `
           },
           "component": undefined,
           "docs": Object {},
-          "fileName": null,
+          "fileName": "./components/Footer/__stories__/Footer.stories.js",
           "framework": "react",
           "knobs": Object {
             "Footer": [Function],
@@ -8679,7 +8679,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
           "__id": "components-lightboxmediaviewer--embedded-video-player",
           "component": undefined,
           "docs": Object {},
-          "fileName": null,
+          "fileName": "./components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js",
           "framework": "react",
           "knobs": Object {
             "LightboxMediaViewer": [Function],
@@ -9130,7 +9130,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Learn more</p>",
+                                        "__html": "<p>Learn more</p> ",
                                       }
                                     }
                                   />
@@ -9309,7 +9309,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Containerization A Complete Guide</p>",
+                                        "__html": "<p>Containerization A Complete Guide</p> ",
                                       }
                                     }
                                   />
@@ -9491,7 +9491,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Microservices and containers</p>",
+                                        "__html": "<p>Microservices and containers</p> ",
                                       }
                                     }
                                   />
@@ -11623,7 +11623,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Learn more</p>",
+                                        "__html": "<p>Learn more</p> ",
                                       }
                                     }
                                   />
@@ -11802,7 +11802,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Containerization A Complete Guide</p>",
+                                        "__html": "<p>Containerization A Complete Guide</p> ",
                                       }
                                     }
                                   />
@@ -11984,7 +11984,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Microservices and containers</p>",
+                                        "__html": "<p>Microservices and containers</p> ",
                                       }
                                     }
                                   />
@@ -13610,7 +13610,7 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
           },
           "component": undefined,
           "docs": Object {},
-          "fileName": null,
+          "fileName": "./components/Masthead/__stories__/Masthead.stories.js",
           "framework": "react",
           "knobs": Object {
             "Masthead": [Function],
@@ -14220,7 +14220,7 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>",
+                            "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p> ",
                           }
                         }
                         data-autoid="dds--content-item__copy"
@@ -14498,7 +14498,7 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
           "__id": "components-table-of-contents--dynamic-items",
           "component": undefined,
           "docs": Object {},
-          "fileName": null,
+          "fileName": "./components/TableOfContents/__stories__/TableOfContents.stories.js",
           "framework": "react",
           "knobs": Object {
             "TableOfContents": [Function],
@@ -15352,7 +15352,7 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
           "__id": "components-table-of-contents--with-heading-content",
           "component": undefined,
           "docs": Object {},
-          "fileName": null,
+          "fileName": "./components/TableOfContents/__stories__/TableOfContents.stories.js",
           "framework": "react",
           "knobs": Object {
             "TableOfContents": [Function],
@@ -16570,7 +16570,7 @@ exports[`Storyshots Patterns (Blocks)|CalloutWithMedia Default 1`] = `
                                         className="bx--content-item__copy"
                                         dangerouslySetInnerHTML={
                                           Object {
-                                            "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p>",
+                                            "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Here are  some common categories:</p> ",
                                           }
                                         }
                                         data-autoid="dds--content-item__copy"
@@ -16882,7 +16882,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                         }
                                       }
                                     />
@@ -16996,7 +16996,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                         }
                                       }
                                     />
@@ -17110,7 +17110,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                         }
                                       }
                                     />
@@ -17224,7 +17224,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                         }
                                       }
                                     />
@@ -17338,7 +17338,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                         }
                                       }
                                     />
@@ -17642,7 +17642,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                       }
                     }
                   />
@@ -17857,7 +17857,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -17896,7 +17896,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -17922,7 +17922,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18047,7 +18047,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                 className="bx--card__copy"
                                                 dangerouslySetInnerHTML={
                                                   Object {
-                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                                   }
                                                 }
                                               />
@@ -18321,7 +18321,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18360,7 +18360,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18386,7 +18386,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18511,7 +18511,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                 className="bx--card__copy"
                                                 dangerouslySetInnerHTML={
                                                   Object {
-                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                                   }
                                                 }
                                               />
@@ -19172,7 +19172,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                             className="bx--content-block__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                               }
                             }
                           />
@@ -19387,7 +19387,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19426,7 +19426,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19452,7 +19452,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19577,7 +19577,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         className="bx--card__copy"
                                                         dangerouslySetInnerHTML={
                                                           Object {
-                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                                           }
                                                         }
                                                       />
@@ -19851,7 +19851,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19890,7 +19890,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19916,7 +19916,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -20041,7 +20041,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         className="bx--card__copy"
                                                         dangerouslySetInnerHTML={
                                                           Object {
-                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                                           }
                                                         }
                                                       />
@@ -20518,7 +20518,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p>",
+                                                        "__html": "<p>Containerization A Complete Guide</p> ",
                                                       }
                                                     }
                                                   />
@@ -20697,7 +20697,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p>",
+                                                        "__html": "<p>Why should you use microservices and containers</p> ",
                                                       }
                                                     }
                                                   />
@@ -21006,7 +21006,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                       }
                     }
                   />
@@ -21136,7 +21136,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> ",
                                                 }
                                               }
                                             />
@@ -21252,7 +21252,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p> ",
                                                 }
                                               }
                                             />
@@ -21368,7 +21368,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet</p>",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet</p> ",
                                                 }
                                               }
                                             />
@@ -21484,7 +21484,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p> ",
                                                 }
                                               }
                                             />
@@ -21729,7 +21729,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -21924,7 +21924,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -22118,7 +22118,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -22404,7 +22404,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -22443,7 +22443,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -22469,7 +22469,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -22599,7 +22599,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                         }
                                       }
                                     />
@@ -22996,7 +22996,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                             className="bx--content-block__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                               }
                             }
                           />
@@ -23126,7 +23126,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> ",
                                                         }
                                                       }
                                                     />
@@ -23242,7 +23242,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p> ",
                                                         }
                                                       }
                                                     />
@@ -23358,7 +23358,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet</p>",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet</p> ",
                                                         }
                                                       }
                                                     />
@@ -23474,7 +23474,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p> ",
                                                         }
                                                       }
                                                     />
@@ -23719,7 +23719,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--content-item__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                                       }
                                                     }
                                                     data-autoid="dds--content-item__copy"
@@ -23914,7 +23914,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--content-item__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                                       }
                                                     }
                                                     data-autoid="dds--content-item__copy"
@@ -24108,7 +24108,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--content-item__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                                       }
                                                     }
                                                     data-autoid="dds--content-item__copy"
@@ -24394,7 +24394,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -24433,7 +24433,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -24459,7 +24459,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -24589,7 +24589,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                                 }
                                               }
                                             />
@@ -24807,7 +24807,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p>",
+                                                        "__html": "<p>Containerization A Complete Guide</p> ",
                                                       }
                                                     }
                                                   />
@@ -24986,7 +24986,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p>",
+                                                        "__html": "<p>Why should you use microservices and containers</p> ",
                                                       }
                                                     }
                                                   />
@@ -25213,7 +25213,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p>",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p> ",
                       }
                     }
                   />
@@ -25352,7 +25352,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                   className="bx--content-item__copy"
                                   dangerouslySetInnerHTML={
                                     Object {
-                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                     }
                                   }
                                   data-autoid="dds--content-item__copy"
@@ -25491,7 +25491,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                   className="bx--content-item__copy"
                                   dangerouslySetInnerHTML={
                                     Object {
-                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                     }
                                   }
                                   data-autoid="dds--content-item__copy"
@@ -25797,7 +25797,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor</p>",
+                                          "__html": "<p>Lorem ipsum dolor</p> ",
                                         }
                                       }
                                     />
@@ -26111,7 +26111,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                             className="bx--content-block__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p>",
+                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p> ",
                               }
                             }
                           />
@@ -26245,7 +26245,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           className="bx--content-item__copy"
                                           dangerouslySetInnerHTML={
                                             Object {
-                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                             }
                                           }
                                           data-autoid="dds--content-item__copy"
@@ -26292,7 +26292,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           className="bx--content-item__copy"
                                           dangerouslySetInnerHTML={
                                             Object {
-                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                                             }
                                           }
                                           data-autoid="dds--content-item__copy"
@@ -26511,7 +26511,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor</p>",
+                                                  "__html": "<p>Lorem ipsum dolor</p> ",
                                                 }
                                               }
                                             />
@@ -26729,7 +26729,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p>",
+                                                        "__html": "<p>Containerization A Complete Guide</p> ",
                                                       }
                                                     }
                                                   />
@@ -26908,7 +26908,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p>",
+                                                        "__html": "<p>Why should you use microservices and containers</p> ",
                                                       }
                                                     }
                                                   />
@@ -27134,7 +27134,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                             className="bx--content-item__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p><p> Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> - [list item](https://www.ibm.com)  1. list item 1a  1. list item 2  - list item 2a </p>",
+                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Here are  some common categories:</p> <p> Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                               }
                             }
                             data-autoid="dds--content-item__copy"
@@ -27350,7 +27350,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                         }
                                       }
                                     />
@@ -27661,7 +27661,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p><p> Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> - [list item](https://www.ibm.com)  1. list item 1a  1. list item 2  - list item 2a </p>",
+                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Here are  some common categories:</p> <p> Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -27877,7 +27877,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                                 }
                                               }
                                             />
@@ -28095,7 +28095,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p>",
+                                                        "__html": "<p>Containerization A Complete Guide</p> ",
                                                       }
                                                     }
                                                   />
@@ -28274,7 +28274,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p>",
+                                                        "__html": "<p>Why should you use microservices and containers</p> ",
                                                       }
                                                     }
                                                   />
@@ -28443,7 +28443,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                     className="bx--content-group__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> ",
                       }
                     }
                   />
@@ -28515,7 +28515,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> ",
                                       }
                                     }
                                   />
@@ -28631,7 +28631,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p> ",
                                       }
                                     }
                                   />
@@ -28747,7 +28747,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet</p> ",
                                       }
                                     }
                                   />
@@ -28863,7 +28863,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p> ",
                                       }
                                     }
                                   />
@@ -29112,7 +29112,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                               className="bx--content-item-horizontal__item--copy"
                               dangerouslySetInnerHTML={
                                 Object {
-                                  "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> sellus at elit sollicitudin.</p>",
+                                  "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> sellus at elit sollicitudin.</p> ",
                                 }
                               }
                               data-autoid="dds--content-item-horizontal__item--copy"
@@ -29408,7 +29408,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                               className="bx--content-item-horizontal__item--copy"
                               dangerouslySetInnerHTML={
                                 Object {
-                                  "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
+                                  "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
                                 }
                               }
                               data-autoid="dds--content-item-horizontal__item--copy"
@@ -29697,7 +29697,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                               className="bx--content-item-horizontal__item--copy"
                               dangerouslySetInnerHTML={
                                 Object {
-                                  "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
+                                  "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
                                 }
                               }
                               data-autoid="dds--content-item-horizontal__item--copy"
@@ -29940,7 +29940,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                   className="bx--content-group__copy"
                   dangerouslySetInnerHTML={
                     Object {
-                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
+                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> ",
                     }
                   }
                 />
@@ -30036,7 +30036,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                                 className="bx--content-item__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                                 data-autoid="dds--content-item__copy"
@@ -30135,7 +30135,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                                 className="bx--content-item__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                                 data-autoid="dds--content-item__copy"
@@ -30234,7 +30234,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                                 className="bx--content-item__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                                 data-autoid="dds--content-item__copy"
@@ -30382,7 +30382,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                     className="bx--content-group__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum non porttitor libero, in venenatis magna.</p>",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum non porttitor libero, in venenatis magna.</p> ",
                       }
                     }
                   />
@@ -30499,7 +30499,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                           className="bx--content-item__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                             }
                           }
                           data-autoid="dds--content-item__copy"
@@ -30538,7 +30538,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                           className="bx--content-item__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
+                              "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
                             }
                           }
                           data-autoid="dds--content-item__copy"
@@ -30564,7 +30564,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                           className="bx--content-item__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
                             }
                           }
                           data-autoid="dds--content-item__copy"
@@ -30689,7 +30689,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
+                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
                                         }
                                       }
                                     />
@@ -30991,7 +30991,7 @@ exports[`Storyshots Patterns (Blocks)|FeatureCardBlockLarge Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..</p>",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..</p> ",
                             }
                           }
                         />
@@ -31414,7 +31414,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Automate your software release process with continuous delivery (CD)—the most  critical part of adopting DevOps. Build, test, and deploy code changes quickly,  ensuring software is always ready for deployment.</p>",
+                        "__html": "<p>Automate your software release process with continuous delivery (CD)—the most  critical part of adopting DevOps. Build, test, and deploy code changes quickly,  ensuring software is always ready for deployment.</p> ",
                       }
                     }
                   />
@@ -32644,7 +32644,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                           className="bx--card__copy"
                                           dangerouslySetInnerHTML={
                                             Object {
-                                              "__html": "<p>Lorem ipsum dolor sit amet</p>",
+                                              "__html": "<p>Lorem ipsum dolor sit amet</p> ",
                                             }
                                           }
                                         />
@@ -32811,7 +32811,7 @@ exports[`Storyshots Patterns (Sections)|CTASection Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
+                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
                       }
                     }
                   />
@@ -33057,7 +33057,7 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
+                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
                       }
                     }
                   />
@@ -33213,7 +33213,7 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p>",
+                            "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p> ",
                           }
                         }
                         data-autoid="dds--content-item__copy"
@@ -33328,7 +33328,7 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p>",
+                            "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p> ",
                           }
                         }
                         data-autoid="dds--content-item__copy"
@@ -34492,7 +34492,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                               />
@@ -34606,7 +34606,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                               />
@@ -34720,7 +34720,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                               />
@@ -34834,7 +34834,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                               />
@@ -34948,7 +34948,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
                                   }
                                 }
                               />
@@ -35942,7 +35942,7 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
           "__id": "patterns-sections-leadspace--default-with-no-image",
           "component": undefined,
           "docs": Object {},
-          "fileName": null,
+          "fileName": "./patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js",
           "framework": "react",
           "knobs": Object {
             "LeadSpace": [Function],

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -591,7 +591,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                             }
                           }
                         />
@@ -705,7 +705,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                             }
                           }
                         />
@@ -819,7 +819,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                             }
                           }
                         />
@@ -933,7 +933,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                             }
                           }
                         />
@@ -1047,7 +1047,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                             }
                           }
                         />
@@ -1305,7 +1305,7 @@ exports[`Storyshots Components|CardLink Default 1`] = `
                       className="bx--card__copy"
                       dangerouslySetInnerHTML={
                         Object {
-                          "__html": "<p>Explore AI use cases in all industries</p> ",
+                          "__html": "<p>Explore AI use cases in all industries</p>",
                         }
                       }
                     />
@@ -1453,7 +1453,7 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                     className="bx--content-item-horizontal__item--copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
+                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
                       }
                     }
                     data-autoid="dds--content-item-horizontal__item--copy"
@@ -2435,7 +2435,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                 className="bx--content-block__copy"
                                                 dangerouslySetInnerHTML={
                                                   Object {
-                                                    "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p> ",
+                                                    "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>",
                                                   }
                                                 }
                                               />
@@ -3096,7 +3096,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3228,7 +3228,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3280,7 +3280,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3412,7 +3412,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3536,7 +3536,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p> ",
+                                                  "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p>",
                                                 }
                                               }
                                             />
@@ -3751,7 +3751,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -3973,7 +3973,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       className="bx--content-item__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p>",
                                                         }
                                                       }
                                                       data-autoid="dds--content-item__copy"
@@ -4357,7 +4357,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             className="bx--content-item__copy"
                                                             dangerouslySetInnerHTML={
                                                               Object {
-                                                                "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p> ",
+                                                                "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p>",
                                                               }
                                                             }
                                                             data-autoid="dds--content-item__copy"
@@ -4548,7 +4548,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   className="bx--content-item-horizontal__item--copy"
                                                   dangerouslySetInnerHTML={
                                                     Object {
-                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> sellus at elit sollicitudin.</p> ",
+                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> sellus at elit sollicitudin.</p>",
                                                     }
                                                   }
                                                   data-autoid="dds--content-item-horizontal__item--copy"
@@ -4816,7 +4816,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   className="bx--content-item-horizontal__item--copy"
                                                   dangerouslySetInnerHTML={
                                                     Object {
-                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
+                                                      "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
                                                     }
                                                   }
                                                   data-autoid="dds--content-item-horizontal__item--copy"
@@ -5446,7 +5446,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               className="bx--card__copy"
                                                               dangerouslySetInnerHTML={
                                                                 Object {
-                                                                  "__html": "<p>Amet justo donec</p> ",
+                                                                  "__html": "<p>Amet justo donec</p>",
                                                                 }
                                                               }
                                                             />
@@ -6313,7 +6313,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                 className="bx--content-block__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
+                                    "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
                                   }
                                 }
                               />
@@ -6527,7 +6527,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p> ",
+                                        "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -6642,7 +6642,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p> ",
+                                        "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -7702,7 +7702,7 @@ exports[`Storyshots Components|Footer Short 1`] = `
           },
           "component": undefined,
           "docs": Object {},
-          "fileName": "./components/Footer/__stories__/Footer.stories.js",
+          "fileName": null,
           "framework": "react",
           "knobs": Object {
             "Footer": [Function],
@@ -8679,7 +8679,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
           "__id": "components-lightboxmediaviewer--embedded-video-player",
           "component": undefined,
           "docs": Object {},
-          "fileName": "./components/LightboxMediaViewer/__stories__/LightboxMediaViewer.stories.js",
+          "fileName": null,
           "framework": "react",
           "knobs": Object {
             "LightboxMediaViewer": [Function],
@@ -9130,7 +9130,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Learn more</p> ",
+                                        "__html": "<p>Learn more</p>",
                                       }
                                     }
                                   />
@@ -9309,7 +9309,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Containerization A Complete Guide</p> ",
+                                        "__html": "<p>Containerization A Complete Guide</p>",
                                       }
                                     }
                                   />
@@ -9491,7 +9491,7 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Microservices and containers</p> ",
+                                        "__html": "<p>Microservices and containers</p>",
                                       }
                                     }
                                   />
@@ -11623,7 +11623,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Learn more</p> ",
+                                        "__html": "<p>Learn more</p>",
                                       }
                                     }
                                   />
@@ -11802,7 +11802,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Containerization A Complete Guide</p> ",
+                                        "__html": "<p>Containerization A Complete Guide</p>",
                                       }
                                     }
                                   />
@@ -11984,7 +11984,7 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Microservices and containers</p> ",
+                                        "__html": "<p>Microservices and containers</p>",
                                       }
                                     }
                                   />
@@ -13610,7 +13610,7 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
           },
           "component": undefined,
           "docs": Object {},
-          "fileName": "./components/Masthead/__stories__/Masthead.stories.js",
+          "fileName": null,
           "framework": "react",
           "knobs": Object {
             "Masthead": [Function],
@@ -14220,7 +14220,7 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p> ",
+                            "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>",
                           }
                         }
                         data-autoid="dds--content-item__copy"
@@ -14498,7 +14498,7 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
           "__id": "components-table-of-contents--dynamic-items",
           "component": undefined,
           "docs": Object {},
-          "fileName": "./components/TableOfContents/__stories__/TableOfContents.stories.js",
+          "fileName": null,
           "framework": "react",
           "knobs": Object {
             "TableOfContents": [Function],
@@ -15352,7 +15352,7 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
           "__id": "components-table-of-contents--with-heading-content",
           "component": undefined,
           "docs": Object {},
-          "fileName": "./components/TableOfContents/__stories__/TableOfContents.stories.js",
+          "fileName": null,
           "framework": "react",
           "knobs": Object {
             "TableOfContents": [Function],
@@ -16570,7 +16570,7 @@ exports[`Storyshots Patterns (Blocks)|CalloutWithMedia Default 1`] = `
                                         className="bx--content-item__copy"
                                         dangerouslySetInnerHTML={
                                           Object {
-                                            "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Here are  some common categories:</p> ",
+                                            "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p>",
                                           }
                                         }
                                         data-autoid="dds--content-item__copy"
@@ -16882,7 +16882,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                         }
                                       }
                                     />
@@ -16996,7 +16996,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                         }
                                       }
                                     />
@@ -17110,7 +17110,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                         }
                                       }
                                     />
@@ -17224,7 +17224,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                         }
                                       }
                                     />
@@ -17338,7 +17338,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockCards Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                         }
                                       }
                                     />
@@ -17642,7 +17642,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                       }
                     }
                   />
@@ -17857,7 +17857,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -17896,7 +17896,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -17922,7 +17922,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18047,7 +18047,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                 className="bx--card__copy"
                                                 dangerouslySetInnerHTML={
                                                   Object {
-                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                                   }
                                                 }
                                               />
@@ -18321,7 +18321,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18360,7 +18360,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18386,7 +18386,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -18511,7 +18511,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                 className="bx--card__copy"
                                                 dangerouslySetInnerHTML={
                                                   Object {
-                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                                    "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                                   }
                                                 }
                                               />
@@ -19172,7 +19172,7 @@ nulla quis, *consequat* libero. Phasellus at elit sollicitudin, sodales nulla qu
                             className="bx--content-block__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                               }
                             }
                           />
@@ -19387,7 +19387,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19426,7 +19426,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19452,7 +19452,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19577,7 +19577,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         className="bx--card__copy"
                                                         dangerouslySetInnerHTML={
                                                           Object {
-                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                                           }
                                                         }
                                                       />
@@ -19851,7 +19851,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19890,7 +19890,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -19916,7 +19916,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -20041,7 +20041,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         className="bx--card__copy"
                                                         dangerouslySetInnerHTML={
                                                           Object {
-                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                                            "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                                           }
                                                         }
                                                       />
@@ -20518,7 +20518,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p> ",
+                                                        "__html": "<p>Containerization A Complete Guide</p>",
                                                       }
                                                     }
                                                   />
@@ -20697,7 +20697,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p> ",
+                                                        "__html": "<p>Why should you use microservices and containers</p>",
                                                       }
                                                     }
                                                   />
@@ -21006,7 +21006,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                       }
                     }
                   />
@@ -21136,7 +21136,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
                                                 }
                                               }
                                             />
@@ -21252,7 +21252,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
                                                 }
                                               }
                                             />
@@ -21368,7 +21368,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet</p>",
                                                 }
                                               }
                                             />
@@ -21484,7 +21484,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
                                                 }
                                               }
                                             />
@@ -21729,7 +21729,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -21924,7 +21924,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -22118,7 +22118,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -22404,7 +22404,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -22443,7 +22443,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -22469,7 +22469,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -22599,7 +22599,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                         }
                                       }
                                     />
@@ -22996,7 +22996,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                             className="bx--content-block__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                               }
                             }
                           />
@@ -23126,7 +23126,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> ",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
                                                         }
                                                       }
                                                     />
@@ -23242,7 +23242,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p> ",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
                                                         }
                                                       }
                                                     />
@@ -23358,7 +23358,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet</p> ",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet</p>",
                                                         }
                                                       }
                                                     />
@@ -23474,7 +23474,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--card__copy"
                                                       dangerouslySetInnerHTML={
                                                         Object {
-                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p> ",
+                                                          "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
                                                         }
                                                       }
                                                     />
@@ -23719,7 +23719,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--content-item__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                                       }
                                                     }
                                                     data-autoid="dds--content-item__copy"
@@ -23914,7 +23914,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--content-item__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                                       }
                                                     }
                                                     data-autoid="dds--content-item__copy"
@@ -24108,7 +24108,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--content-item__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                                       }
                                                     }
                                                     data-autoid="dds--content-item__copy"
@@ -24394,7 +24394,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -24433,7 +24433,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -24459,7 +24459,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             className="bx--content-item__copy"
                                             dangerouslySetInnerHTML={
                                               Object {
-                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                                "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                               }
                                             }
                                             data-autoid="dds--content-item__copy"
@@ -24589,7 +24589,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                                 }
                                               }
                                             />
@@ -24807,7 +24807,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p> ",
+                                                        "__html": "<p>Containerization A Complete Guide</p>",
                                                       }
                                                     }
                                                   />
@@ -24986,7 +24986,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p> ",
+                                                        "__html": "<p>Why should you use microservices and containers</p>",
                                                       }
                                                     }
                                                   />
@@ -25098,9 +25098,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
           className="bx--col-lg-8 bx--col-sm-4 bx--offset-lg-4"
         >
           <ContentBlockSegmented
-            copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
-      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
-      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+            copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
             cta={
               Object {
                 "copy": "Lorem ipsum dolor",
@@ -25186,9 +25184,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
             >
               <ContentBlock
                 border={false}
-                copy="Lorem ipsum *dolor* sit amet, consectetur adipiscing elit. Aenean et ultricies est.
-      Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales
-      nulla quis, *consequat* libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
                 cta={
                   Object {
                     "copy": "Lorem ipsum dolor",
@@ -25217,7 +25213,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p> ",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p>",
                       }
                     }
                   />
@@ -25356,7 +25352,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                   className="bx--content-item__copy"
                                   dangerouslySetInnerHTML={
                                     Object {
-                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                     }
                                   }
                                   data-autoid="dds--content-item__copy"
@@ -25495,7 +25491,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                   className="bx--content-item__copy"
                                   dangerouslySetInnerHTML={
                                     Object {
-                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                     }
                                   }
                                   data-autoid="dds--content-item__copy"
@@ -25801,7 +25797,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor</p> ",
+                                          "__html": "<p>Lorem ipsum dolor</p>",
                                         }
                                       }
                                     />
@@ -26115,7 +26111,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                             className="bx--content-block__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p> ",
+                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p>",
                               }
                             }
                           />
@@ -26249,7 +26245,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           className="bx--content-item__copy"
                                           dangerouslySetInnerHTML={
                                             Object {
-                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                             }
                                           }
                                           data-autoid="dds--content-item__copy"
@@ -26296,7 +26292,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                           className="bx--content-item__copy"
                                           dangerouslySetInnerHTML={
                                             Object {
-                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                                             }
                                           }
                                           data-autoid="dds--content-item__copy"
@@ -26515,7 +26511,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor</p>",
                                                 }
                                               }
                                             />
@@ -26733,7 +26729,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p> ",
+                                                        "__html": "<p>Containerization A Complete Guide</p>",
                                                       }
                                                     }
                                                   />
@@ -26912,7 +26908,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With aside elements 
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p> ",
+                                                        "__html": "<p>Why should you use microservices and containers</p>",
                                                       }
                                                     }
                                                   />
@@ -27138,7 +27134,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                             className="bx--content-item__copy"
                             dangerouslySetInnerHTML={
                               Object {
-                                "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Here are  some common categories:</p> <p> Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p><p> Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> - [list item](https://www.ibm.com)  1. list item 1a  1. list item 2  - list item 2a </p>",
                               }
                             }
                             data-autoid="dds--content-item__copy"
@@ -27354,7 +27350,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple Default 1`] = `
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                         }
                                       }
                                     />
@@ -27665,7 +27661,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                     className="bx--content-item__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em>consequat</em> libero. Here are  some common categories:</p> <p> Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                                        "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est.  Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales  nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are  some common categories:</p><p> Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p><p> - [list item](https://www.ibm.com)  1. list item 1a  1. list item 2  - list item 2a </p>",
                                       }
                                     }
                                     data-autoid="dds--content-item__copy"
@@ -27881,7 +27877,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                               className="bx--card__copy"
                                               dangerouslySetInnerHTML={
                                                 Object {
-                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                                  "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                                 }
                                               }
                                             />
@@ -28099,7 +28095,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Containerization A Complete Guide</p> ",
+                                                        "__html": "<p>Containerization A Complete Guide</p>",
                                                       }
                                                     }
                                                   />
@@ -28278,7 +28274,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSimple With aside elements 1`]
                                                     className="bx--card__copy"
                                                     dangerouslySetInnerHTML={
                                                       Object {
-                                                        "__html": "<p>Why should you use microservices and containers</p> ",
+                                                        "__html": "<p>Why should you use microservices and containers</p>",
                                                       }
                                                     }
                                                   />
@@ -28447,7 +28443,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                     className="bx--content-group__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> ",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
                       }
                     }
                   />
@@ -28519,7 +28515,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
                                       }
                                     }
                                   />
@@ -28635,7 +28631,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>",
                                       }
                                     }
                                   />
@@ -28751,7 +28747,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet</p>",
                                       }
                                     }
                                   />
@@ -28867,7 +28863,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupCards Default 1`] = `
                                     className="bx--card__copy"
                                     dangerouslySetInnerHTML={
                                       Object {
-                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p> ",
+                                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt</p>",
                                       }
                                     }
                                   />
@@ -29116,7 +29112,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                               className="bx--content-item-horizontal__item--copy"
                               dangerouslySetInnerHTML={
                                 Object {
-                                  "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> sellus at elit sollicitudin.</p> ",
+                                  "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> sellus at elit sollicitudin.</p>",
                                 }
                               }
                               data-autoid="dds--content-item-horizontal__item--copy"
@@ -29412,7 +29408,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                               className="bx--content-item-horizontal__item--copy"
                               dangerouslySetInnerHTML={
                                 Object {
-                                  "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
+                                  "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
                                 }
                               }
                               data-autoid="dds--content-item-horizontal__item--copy"
@@ -29701,7 +29697,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupHorizontal Default 1`] = `
                               className="bx--content-item-horizontal__item--copy"
                               dangerouslySetInnerHTML={
                                 Object {
-                                  "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
+                                  "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p>",
                                 }
                               }
                               data-autoid="dds--content-item-horizontal__item--copy"
@@ -29944,7 +29940,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                   className="bx--content-group__copy"
                   dangerouslySetInnerHTML={
                     Object {
-                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> ",
+                      "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
                     }
                   }
                 />
@@ -30040,7 +30036,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                                 className="bx--content-item__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                                 data-autoid="dds--content-item__copy"
@@ -30139,7 +30135,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                                 className="bx--content-item__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                                 data-autoid="dds--content-item__copy"
@@ -30238,7 +30234,7 @@ exports[`Storyshots Patterns (Blocks)|ContentGroupPictograms Default 1`] = `
                                 className="bx--content-item__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                                 data-autoid="dds--content-item__copy"
@@ -30386,7 +30382,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                     className="bx--content-group__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum non porttitor libero, in venenatis magna.</p> ",
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum non porttitor libero, in venenatis magna.</p>",
                       }
                     }
                   />
@@ -30503,7 +30499,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                           className="bx--content-item__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, <em class=\\"bx--type-light\\">consectetur</em> adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                             }
                           }
                           data-autoid="dds--content-item__copy"
@@ -30542,7 +30538,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                           className="bx--content-item__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum <em>dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em>consequat</em> libero. Here are some common categories:</p> <p>Lorem ipsum dolor sit amet, <a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">consectetur adipiscing</a> elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat <strong>libero</strong>.</p> <ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\"><a href=\\"https://www.ibm.com\\" class=\\"bx--link\\">list item link</a><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 1a</li><li class=\\"bx--list__item\\">list item 2a<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a.a</li></ul></li></ol></li></ul><ol class=\\"bx--list--ordered\\"><li class=\\"bx--list__item\\">list item 2<ul class=\\"bx--list--unordered\\"><li class=\\"bx--list__item\\">list item 2a</li></ul></li></ol>",
+                              "__html": "<p>Lorem ipsum <em class=\\"bx--type-light\\">dolor</em> sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, <em class=\\"bx--type-light\\">consequat</em> libero. Here are some common categories:</p><p>Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat __libero__.</p><p>- [list item link](https://www.ibm.com)  1. list item 1a  2. list item 2a  - list item 2a.a 1. list item 2  - list item 2a </p>",
                             }
                           }
                           data-autoid="dds--content-item__copy"
@@ -30568,7 +30564,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                           className="bx--content-item__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</p>",
                             }
                           }
                           data-autoid="dds--content-item__copy"
@@ -30693,7 +30689,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       className="bx--card__copy"
                                       dangerouslySetInnerHTML={
                                         Object {
-                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p> ",
+                                          "__html": "<p>Lorem ipsum dolor sit ametttt</p>",
                                         }
                                       }
                                     />
@@ -30995,7 +30991,7 @@ exports[`Storyshots Patterns (Blocks)|FeatureCardBlockLarge Default 1`] = `
                           className="bx--card__copy"
                           dangerouslySetInnerHTML={
                             Object {
-                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..</p> ",
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..</p>",
                             }
                           }
                         />
@@ -31418,7 +31414,7 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Automate your software release process with continuous delivery (CD)—the most  critical part of adopting DevOps. Build, test, and deploy code changes quickly,  ensuring software is always ready for deployment.</p> ",
+                        "__html": "<p>Automate your software release process with continuous delivery (CD)—the most  critical part of adopting DevOps. Build, test, and deploy code changes quickly,  ensuring software is always ready for deployment.</p>",
                       }
                     }
                   />
@@ -32648,7 +32644,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                           className="bx--card__copy"
                                           dangerouslySetInnerHTML={
                                             Object {
-                                              "__html": "<p>Lorem ipsum dolor sit amet</p> ",
+                                              "__html": "<p>Lorem ipsum dolor sit amet</p>",
                                             }
                                           }
                                         />
@@ -32815,7 +32811,7 @@ exports[`Storyshots Patterns (Sections)|CTASection Default 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
+                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
                       }
                     }
                   />
@@ -33061,7 +33057,7 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                     className="bx--content-block__copy"
                     dangerouslySetInnerHTML={
                       Object {
-                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
+                        "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p>",
                       }
                     }
                   />
@@ -33217,7 +33213,7 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p> ",
+                            "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p>",
                           }
                         }
                         data-autoid="dds--content-item__copy"
@@ -33332,7 +33328,7 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p> ",
+                            "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p>",
                           }
                         }
                         data-autoid="dds--content-item__copy"
@@ -34496,7 +34492,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                               />
@@ -34610,7 +34606,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                               />
@@ -34724,7 +34720,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                               />
@@ -34838,7 +34834,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                               />
@@ -34952,7 +34948,7 @@ exports[`Storyshots Patterns (Sections)|CardSectionSimple Default 1`] = `
                                 className="bx--card__copy"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                                    "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p>",
                                   }
                                 }
                               />
@@ -35946,7 +35942,7 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
           "__id": "patterns-sections-leadspace--default-with-no-image",
           "component": undefined,
           "docs": Object {},
-          "fileName": "./patterns/sections/LeadSpace/__stories__/LeadSpace.stories.js",
+          "fileName": null,
           "framework": "react",
           "knobs": Object {
             "LeadSpace": [Function],

--- a/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/patterns/blocks/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -145,6 +145,11 @@ Default.story = {
 
         return {
           ...knobs,
+          copy: text(
+            'Copy',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.',
+            groupId
+          ),
           heading: text('Heading', 'Lorem ipsum dolor sit amet.', groupId),
           items: object('Content items', defaultItems, groupId),
         };


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2638

### Description

This issue was previously fixed but was non testable in storybook because there wasn't a copy knob. This adds an optional copy knob so the QA folks can test this within storybook. PR is changing in the application

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
