### PR TITLE
chore(autoid): remove class name from stable prefix

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5094,7 +5094,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                               >
                                 <section
                                   className="bx--logo-grid"
-                                  data-autoid="dds--logo-grid bx--logo-grid"
+                                  data-autoid="dds--logo-grid"
                                 >
                                   <div
                                     className="bx--logo-grid__container"
@@ -32115,7 +32115,7 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
           >
             <section
               className="bx--logo-grid"
-              data-autoid="dds--logo-grid bx--logo-grid"
+              data-autoid="dds--logo-grid"
             >
               <div
                 className="bx--logo-grid__container"

--- a/packages/react/src/patterns/blocks/LogoGrid/LogoGrid.js
+++ b/packages/react/src/patterns/blocks/LogoGrid/LogoGrid.js
@@ -40,7 +40,7 @@ const LogoGrid = ({ heading, logosGroup, ctaCopy, ctaHref, hideBorder }) => {
 
   return (
     <section
-      data-autoid={`${stablePrefix}--logo-grid ${prefix}--logo-grid`}
+      data-autoid={`${stablePrefix}--logo-grid`}
       className={classNames(`${prefix}--logo-grid`, {
         [`${prefix}--logo-grid__no-border`]: hideBorder,
       })}>


### PR DESCRIPTION
### Description

Remove class name from `autoid`.

### Changelog

**Removed**

- rogue class name in `autoid`

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
