### PR TITLE
fix(ButtonGroup): put React key in the right place

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -53,7 +53,6 @@ exports[`Storyshots Components|ButtonGroup Default 1`] = `
             >
               <li
                 className="bx--buttongroup-item"
-                key="0"
               >
                 <ForwardRef(Button)
                   copy="Button 1"
@@ -77,7 +76,6 @@ exports[`Storyshots Components|ButtonGroup Default 1`] = `
               </li>
               <li
                 className="bx--buttongroup-item"
-                key="1"
               >
                 <ForwardRef(Button)
                   copy="Button 2"
@@ -135,7 +133,6 @@ exports[`Storyshots Components|ButtonGroup Default 1`] = `
         >
           <li
             className="bx--buttongroup-item"
-            key="0"
           >
             <ForwardRef(Button)
               copy="Button 1"
@@ -159,7 +156,6 @@ exports[`Storyshots Components|ButtonGroup Default 1`] = `
           </li>
           <li
             className="bx--buttongroup-item"
-            key="1"
           >
             <ForwardRef(Button)
               copy="Button 2"
@@ -2960,7 +2956,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                         >
                                                           <li
                                                             className="bx--buttongroup-item"
-                                                            key="0"
                                                           >
                                                             <ForwardRef(Button)
                                                               copy="Excepteur sint occaecat"
@@ -6510,7 +6505,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                         >
                                           <li
                                             className="bx--buttongroup-item"
-                                            key="0"
                                           >
                                             <ForwardRef(Button)
                                               copy={
@@ -7138,7 +7132,6 @@ exports[`Storyshots Components|Expressive Modal Default 1`] = `
                       >
                         <li
                           className="bx--buttongroup-item"
-                          key="0"
                         >
                           <ForwardRef(Button)
                             copy="Lorem ipsum dolor"
@@ -7367,7 +7360,6 @@ exports[`Storyshots Components|Expressive Modal Expanded 1`] = `
                       >
                         <li
                           className="bx--buttongroup-item"
-                          key="0"
                         >
                           <ForwardRef(Button)
                             copy="Lorem ipsum dolor"
@@ -32360,7 +32352,6 @@ exports[`Storyshots Patterns (Blocks)|LeadSpaceBlock Default 1`] = `
                             >
                               <li
                                 className="bx--buttongroup-item"
-                                key="0"
                               >
                                 <ForwardRef(Button)
                                   copy="Contact sales"
@@ -33330,7 +33321,6 @@ exports[`Storyshots Patterns (Sections)|CTASection Default 1`] = `
                             >
                               <li
                                 className="bx--buttongroup-item"
-                                key="0"
                               >
                                 <ForwardRef(Button)
                                   copy="Contact sales"
@@ -33576,7 +33566,6 @@ exports[`Storyshots Patterns (Sections)|CTASection With Content Items 1`] = `
                             >
                               <li
                                 className="bx--buttongroup-item"
-                                key="0"
                               >
                                 <ForwardRef(Button)
                                   copy="Contact sales"
@@ -35689,7 +35678,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Centered 1`] = `
                   >
                     <li
                       className="bx--buttongroup-item"
-                      key="0"
                     >
                       <ForwardRef(Button)
                         copy="Button 1"
@@ -35750,7 +35738,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Centered 1`] = `
                     </li>
                     <li
                       className="bx--buttongroup-item"
-                      key="1"
                     >
                       <ForwardRef(Button)
                         copy="Button 2"
@@ -35950,7 +35937,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Centered with image 1`] = `
                   >
                     <li
                       className="bx--buttongroup-item"
-                      key="0"
                     >
                       <ForwardRef(Button)
                         copy="Button 1"
@@ -36011,7 +35997,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Centered with image 1`] = `
                     </li>
                     <li
                       className="bx--buttongroup-item"
-                      key="1"
                     >
                       <ForwardRef(Button)
                         copy="Button 2"
@@ -36220,7 +36205,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
                   >
                     <li
                       className="bx--buttongroup-item"
-                      key="0"
                     >
                       <ForwardRef(Button)
                         copy="Button 1"
@@ -36281,7 +36265,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with image 1`] = `
                     </li>
                     <li
                       className="bx--buttongroup-item"
-                      key="1"
                     >
                       <ForwardRef(Button)
                         copy="Button 2"
@@ -36542,7 +36525,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                     >
                       <li
                         className="bx--buttongroup-item"
-                        key="0"
                       >
                         <ForwardRef(Button)
                           copy="Button 1"
@@ -36603,7 +36585,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Default with no image 1`] = `
                       </li>
                       <li
                         className="bx--buttongroup-item"
-                        key="1"
                       >
                         <ForwardRef(Button)
                           copy="Button 2"
@@ -36783,7 +36764,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Small 1`] = `
                   >
                     <li
                       className="bx--buttongroup-item"
-                      key="0"
                     >
                       <ForwardRef(Button)
                         copy="Button 1"
@@ -36844,7 +36824,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Small 1`] = `
                     </li>
                     <li
                       className="bx--buttongroup-item"
-                      key="1"
                     >
                       <ForwardRef(Button)
                         copy="Button 2"
@@ -37044,7 +37023,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Small with image 1`] = `
                   >
                     <li
                       className="bx--buttongroup-item"
-                      key="0"
                     >
                       <ForwardRef(Button)
                         copy="Button 1"
@@ -37105,7 +37083,6 @@ exports[`Storyshots Patterns (Sections)|LeadSpace Small with image 1`] = `
                     </li>
                     <li
                       className="bx--buttongroup-item"
-                      key="1"
                     >
                       <ForwardRef(Button)
                         copy="Button 2"

--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { Fragment, useEffect, useLayoutEffect, useRef } from 'react';
 import Button from '../../internal/vendor/carbon-components-react/components/Button/Button';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import PropTypes from 'prop-types';
@@ -128,8 +128,8 @@ const ButtonGroup = ({ buttons, enableSizeByContent }) => {
       ref={groupRef}>
       {buttons.map((button, key) => {
         return (
-          <>
-            <li key={key} className={`${prefix}--buttongroup-item`}>
+          <Fragment key={key}>
+            <li className={`${prefix}--buttongroup-item`}>
               <Button
                 tabIndex={key === 0 ? 2 : 1}
                 data-autoid={`${stablePrefix}--button-group-${key}`}
@@ -143,7 +143,6 @@ const ButtonGroup = ({ buttons, enableSizeByContent }) => {
               undefined
             ) : (
               <li
-                key={`${key}-pseudo`}
                 className={`${prefix}--buttongroup-item ${prefix}--buttongroup-item--pseudo`}>
                 <Button
                   tabIndex={-1}
@@ -154,7 +153,7 @@ const ButtonGroup = ({ buttons, enableSizeByContent }) => {
                 </Button>
               </li>
             )}
-          </>
+          </Fragment>
         );
       })}
     </ol>


### PR DESCRIPTION
### Related Ticket(s)

Refs #2693.

### Description

This change fixes React key put in a wrong place. Given we made the child item there a React fragment, we need to put `key` there.

### Changelog

**Changed**

- Fix a React prop type warning in `<ButtonGroup>`.