### PR TITLE
fix(contentblockmixed): style path fix

### DIFF
--- a/packages/styles/scss/patterns/blocks/content-block-mixed/index.scss
+++ b/packages/styles/scss/patterns/blocks/content-block-mixed/index.scss
@@ -7,7 +7,7 @@
 
 @import '../../../globals/imports';
 @import '../../../internal/content-block/content-block';
-@import '../../../internal//content-group/content-group';
+@import '../../../internal/content-group/content-group';
 @import '../../blocks/content-group-cards/index';
 @import '../content-group-pictograms/index';
 @import '../content-group-simple/index';


### PR DESCRIPTION
### Description

This change fixes a `@import` path in `content-block-mixed/index.scss`.
This was found during my test against CodeSandbox example of `<ContentBlockMixed>`.

### Changelog

**Changed**

- Fix a `@import` path in `content-block-mixed/index.scss`.