### PR TITLE
fix(CalloutData): exporting pattern properly

### DIFF
--- a/packages/react/src/patterns/blocks/index.js
+++ b/packages/react/src/patterns/blocks/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export * from './CalloutData';
 export * from './CalloutQuote';
 export * from './CalloutWithMedia';
 export * from './ContentBlockCards';


### PR DESCRIPTION
Added CalloutData export to index.js in Blocks patterns

### Related Ticket(s)

Pattern: CalloutData - Is not being exported properly #2998

### Description

According to the issue mentioned above, we detected the `CalloutData` wasn't being exported properly, so it was impossible to use it in external projects.

### Changelog

**New**

- Added export syntax for `CalloutData` in `index.js` from Blocks patterns


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
