### PR TITLE
fix(LogoGrid): removed Carbon Themes addon

### DIFF
--- a/packages/react/src/patterns/blocks/LogoGrid/README.stories.mdx
+++ b/packages/react/src/patterns/blocks/LogoGrid/README.stories.mdx
@@ -4,7 +4,7 @@ import LogoGrid  from './LogoGrid';
 
 # Logo Grid
 
-> The Logo Grid pattern is to be utilized within IBM.com.
+> The Logo Grid pattern is to be utilized within IBM.com. It's available **only under** the [Carbon white theme](https://www.carbondesignsystem.com/guidelines/themes/overview#default-theme).
 
 ## Getting started
 

--- a/packages/react/src/patterns/blocks/LogoGrid/__stories__/LogoGrid.stories.js
+++ b/packages/react/src/patterns/blocks/LogoGrid/__stories__/LogoGrid.stories.js
@@ -14,6 +14,7 @@ import readme from '../README.stories.mdx';
 export default {
   title: 'Patterns (Blocks)|LogoGrid',
   parameters: {
+    ['carbon-theme']: { disabled: true },
     ...readme.parameters,
     knobs: {
       LogoGrid: ({ groupId }) => ({


### PR DESCRIPTION
### Related Ticket(s)

Pattern: Logo grid: Carbon theme #2829

### Description

Added a description in the docs explaining that this pattern is available only under the Carbon white theme. 

### Changelog

**Removed**

- Carbon Themes addon from `LogoGrid` pattern story.