### PR TITLE
fix(LeadSpace): decrease z-index of overlay to prevent clash with masthead

### DIFF
--- a/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
@@ -105,7 +105,7 @@ $btn-min-width: 26;
       justify-content: space-between;
       padding-top: $carbon--layout-03;
       padding-bottom: $carbon--layout-03;
-      z-index: 1;
+      z-index: 2;
       position: absolute;
       top: 0;
       height: 100%;

--- a/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
+++ b/packages/styles/scss/patterns/sections/leadspace/_leadspace.scss
@@ -105,7 +105,7 @@ $btn-min-width: 26;
       justify-content: space-between;
       padding-top: $carbon--layout-03;
       padding-bottom: $carbon--layout-03;
-      z-index: 2;
+      z-index: 1;
       position: absolute;
       top: 0;
       height: 100%;


### PR DESCRIPTION
### Related Ticket(s)

LeadSpace: LeadSpace content and gradient is appearing over the masthead #2983

### Description

Set `z-index` value to 1 to prevent it from overlapping the masthead on scroll

### Changelog

**Changed**

- set z-index to 1 for overlay

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
