### PR TITLE
fix(quote): fix color of optional copy

### DIFF
--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -93,7 +93,6 @@
       }
 
       &-optional-copy {
-        color: $inverse-01;
         padding-left: 1rem;
         @include carbon--type-style(body-long-02, true);
       }


### PR DESCRIPTION
### Description

This fix changes the color of optional copy text to be the same as other text in quote.

### Changelog

**Removed**

- Explicit `$inverse-01` usage of text color for optional copy text.