### PR TITLE
docs(developers): fix broken link

### DIFF
--- a/packages/web-components/docs/developer.md
+++ b/packages/web-components/docs/developer.md
@@ -60,4 +60,4 @@ Above options can be used together. This is useful to debug your code as you tes
 
 ## Coding conventions
 
-Can be found at [here](./docs/coding-conventions.md).
+Can be found at [here](./coding-conventions.md).


### PR DESCRIPTION
### Description

This change fixes broken link to coding conversion developer doc for Web Components.

### Changelog

**Changed**

- Fix broken link to `packages/web-components/docs/coding-conventions.md`.