### PR TITLE
fix(MastheadL1): increased max-width, eyebrow validation and new prop

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -322,6 +322,10 @@ Masthead.propTypes = {
     title: PropTypes.string,
 
     /**
+     * Title optional link for the masthead L1 (experimental).
+     */
+    titleLink: PropTypes.string,
+    /**
      * Text for the eyebrow link in masthead L1 (experimental).
      */
     eyebrowText: PropTypes.string,

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -24,6 +24,7 @@ const { prefix } = settings;
 const MastheadL1 = ({
   isShort,
   title,
+  titleLink,
   eyebrowText,
   eyebrowLink,
   navigationL1,
@@ -59,11 +60,15 @@ const MastheadL1 = ({
   return (
     <div className={className}>
       <div className={`${prefix}--masthead__l1-name`}>
-        <span className={`${prefix}--masthead__l1-name-eyebrow`}>
-          <ArrowLeft16 />
-          <a href={eyebrowLink}>{eyebrowText}</a>
+        {eyebrowText && eyebrowLink && (
+          <span className={`${prefix}--masthead__l1-name-eyebrow`}>
+            <ArrowLeft16 />
+            <a href={eyebrowLink}>{eyebrowText}</a>
+          </span>
+        )}
+        <span className={`${prefix}--masthead__l1-name-title`}>
+          <a href={titleLink}>{title}</a>
         </span>
-        <span className={`${prefix}--masthead__l1-name-title`}>{title}</span>
       </div>
       <HeaderNavigation className={`${prefix}--masthead__l1-nav`} aria-label="">
         {mastheadL1Links}
@@ -107,6 +112,10 @@ MastheadL1.propTypes = {
   title: PropTypes.string,
 
   /**
+   * The optional title link (experimental)
+   */
+  titleLink: PropTypes.string,
+  /**
    * Text for the eyebrow link (experimental).
    */
   eyebrowText: PropTypes.string,
@@ -139,6 +148,7 @@ MastheadL1.propTypes = {
 
 MastheadL1.defaultProps = {
   navigationL1: [],
+  titleLink: null,
 };
 
 export default MastheadL1;

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -36,14 +36,9 @@ Default.story = {
             'Stock Charts',
             groupId
           ),
-          eyebrowText: text(
-            'L1 eyebrow text (eyebrowText) (experimental)',
-            'Eyebrow',
-            groupId
-          ),
-          eyebrowLink: text(
-            'L1 eyebrow link (eyebrowLink) (experimental)',
-            '#',
+          titleLink: text(
+            'L1 title link (titleLink) (experimental)',
+            'https://example.com/',
             groupId
           ),
           navigationL1: mastheadKnobs.navigation.custom,

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -16,7 +16,7 @@ $search-transition-timing: 95ms;
 @mixin masthead-l1 {
   .#{$prefix}--masthead__l1 {
     display: flex;
-    max-width: 95rem;
+    max-width: 98rem;
     margin-left: auto;
     margin-right: auto;
     height: 80px;
@@ -111,7 +111,11 @@ $search-transition-timing: 95ms;
       position: relative;
       padding: 0 $carbon--spacing-05;
       margin-top: auto;
-      @include type-style('productive-heading-02');
+      a {
+        color: $text-04;
+        text-decoration: none;
+        @include type-style('productive-heading-02');
+      }
 
       &::after {
         content: '';

--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -117,19 +117,6 @@ $search-transition-timing: 95ms;
         @include type-style('productive-heading-02');
       }
 
-      &::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        bottom: rem(-12px);
-        width: 100%;
-        height: 3px;
-        background-color: $inverse-support-04;
-        @include carbon--breakpoint-down(lg) {
-          bottom: 0;
-        }
-      }
-
       @include carbon--breakpoint-down(lg) {
         line-height: inherit;
         padding-bottom: $carbon--spacing-05;


### PR DESCRIPTION
### Description

 - Added validation to `eyebrownLink` and `eyebrowText`. Now If both props don't exist it shows nothing;
 - Increased `max-width` from `MastheadL1`. Now the `MastheadL1` has a more accurate sizing at the `max` breakpoint;
 - Added a `titleLink` prop. This prop is optional.

Now the "Stock Charts" can be clickable
![Captura de Tela 2020-07-09 às 10 27 48](https://user-images.githubusercontent.com/42848561/87045934-d9d10780-c1ce-11ea-9694-e81afb023cb0.png)