### PR TITLE
fix(footer): change color for visited and hover state

### DIFF
--- a/packages/styles/scss/components/footer/_footer.scss
+++ b/packages/styles/scss/components/footer/_footer.scss
@@ -47,8 +47,7 @@
 
       .#{$prefix}--footer__link.#{$prefix}--link {
         &,
-        &:visited,
-        &:visited:hover {
+        &:visited {
           color: $text-02;
         }
 
@@ -61,7 +60,8 @@
           color: $text-04;
         }
 
-        &:hover {
+        &:hover,
+        &:visited:hover {
           color: $text-01;
         }
       }


### PR DESCRIPTION
### Related Ticket(s)

Refs #3068.

### Description

Changes `:visited:hover` color of footer link from `$text-02` to `$text-01`.

### Changelog

**Changed**

- `:visited:hover` color of footer link from `$text-02` to `$text-01`.