### PR TITLE
chore(CardSectionImages): remove object knobs from story

### DIFF
--- a/packages/react/src/patterns/sections/CardSectionImages/__stories__/CardSectionImages.stories.js
+++ b/packages/react/src/patterns/sections/CardSectionImages/__stories__/CardSectionImages.stories.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { object, text } from '@storybook/addon-knobs';
 import cards from '../../../../components/CardGroup/__stories__/data/cards.json';
 import CardSectionImages from '../CardSectionImages';
 import React from 'react';
 import readme from '../README.stories.mdx';
+import { text } from '@storybook/addon-knobs';
 
 export default {
   title: 'Patterns (Sections)|CardSectionImages',
@@ -19,11 +19,11 @@ export default {
     knobs: {
       CardSectionImages: ({ groupId }) => ({
         heading: text(
-          'Heading (required):',
+          'Heading (heading):',
           'Aliquam condimentum interdum',
           groupId
         ),
-        cards: object('Data', cards.Images, groupId),
+        cards: cards.Images,
       }),
     },
     propsSet: {


### PR DESCRIPTION
### Related Ticket(s)

#2954 

### Description

Removes object knobs from story.

### Changelog

**Removed**

- all JSON knobs

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
