### PR TITLE
fix(calloutquote): fixed bottom padding

### DIFF
--- a/packages/styles/scss/components/quote/_quote.scss
+++ b/packages/styles/scss/components/quote/_quote.scss
@@ -11,7 +11,7 @@
 
 @mixin quote {
   .#{$prefix}--quote {
-    padding-bottom: $layout-03;
+    padding-bottom: $layout-05;
     &__container {
       @include carbon--make-row;
     }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2788

### Description

Padding between the CTA and the bottom of the page was 2rems. The updated correct padding is 4rems.

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
