### PR TITLE
fix(styles): optimization fixes for gulp-sass in styles package

### DIFF
--- a/packages/styles/gulp/tasks/sass.js
+++ b/packages/styles/gulp/tasks/sass.js
@@ -13,7 +13,6 @@ const gulp = require('gulp'),
   rename = require('gulp-rename'),
   sass = require('gulp-sass'),
   path = require('path');
-// sourcemaps = require('gulp-sourcemaps');
 
 /**
  * @name _sass
@@ -29,7 +28,6 @@ function _sass() {
   // prettier-ignore
   return gulp
     .src(global.config.scssEntry)
-    // .pipe(sourcemaps.init())
     .pipe(sass({
       includePaths: [
         path.resolve(__dirname, '../../', 'node_modules'),

--- a/packages/styles/gulp/tasks/sass.js
+++ b/packages/styles/gulp/tasks/sass.js
@@ -9,7 +9,7 @@
 
 const gulp = require('gulp'),
   prefix = require('gulp-autoprefixer'),
-  // cleanCSS = require('gulp-clean-css'),
+  cleanCSS = require('gulp-clean-css'),
   rename = require('gulp-rename'),
   sass = require('gulp-sass'),
   path = require('path');
@@ -43,11 +43,7 @@ function _sass() {
     )
     .pipe(rename(global.config.distCss))
     .pipe(gulp.dest('dist'))
-    /*.pipe(
-      cleanCSS({
-        level: 2,
-      })
-    )*/
+    .pipe(cleanCSS())
     .pipe(rename(global.config.distCssMin))
     .pipe(gulp.dest('dist'));
 }

--- a/packages/styles/gulp/tasks/sass.js
+++ b/packages/styles/gulp/tasks/sass.js
@@ -9,11 +9,11 @@
 
 const gulp = require('gulp'),
   prefix = require('gulp-autoprefixer'),
-  cleanCSS = require('gulp-clean-css'),
+  // cleanCSS = require('gulp-clean-css'),
   rename = require('gulp-rename'),
   sass = require('gulp-sass'),
-  path = require('path'),
-  sourcemaps = require('gulp-sourcemaps');
+  path = require('path');
+// sourcemaps = require('gulp-sourcemaps');
 
 /**
  * @name _sass
@@ -29,7 +29,7 @@ function _sass() {
   // prettier-ignore
   return gulp
     .src(global.config.scssEntry)
-    .pipe(sourcemaps.init())
+    // .pipe(sourcemaps.init())
     .pipe(sass({
       includePaths: [
         path.resolve(__dirname, '../../', 'node_modules'),
@@ -43,11 +43,11 @@ function _sass() {
     )
     .pipe(rename(global.config.distCss))
     .pipe(gulp.dest('dist'))
-    .pipe(
+    /*.pipe(
       cleanCSS({
         level: 2,
       })
-    )
+    )*/
     .pipe(rename(global.config.distCssMin))
     .pipe(gulp.dest('dist'));
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 gulp",
+    "build": "gulp",
     "start": "gulp dev",
     "ci-check": "yarn build",
     "build-storybook": "cross-env BABEL_ENV=es build-storybook",

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '../link-with-icon/link-with-icon';
+@import '../../globals/imports';
+@import '../../globals/utils/ratio-base';
 @import '../../internal/content-section/content-section';
 @import '../card/index';
 @import '../image/image';
-@import '../../globals/imports';
-@import '../../globals/utils/ratio-base';
+@import '../link-with-icon/link-with-icon';
 
 @mixin themed-items {
   color: $text-01;


### PR DESCRIPTION
### Related Ticket(s)

Refs #3113 

### Description

The `gulp-sass` task was throwing out of memory errors. This is a step to mitigate the build times for the overall css artifact. To our knowledge, no adopters are using the main entry point and built artifact (nor should they), so for now this is removing sourcemaps ~as well as gulp-clean-css~ from the build pipeline until this can get sorted out.

### Changelog

**Changed**

- Reduced complexity of gulp-sass runner (removed sourcemaps ~and cleanCss~)