### PR TITLE
fix(Card): reduce bottom margin when link has text

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1325,7 +1325,7 @@ exports[`Storyshots Components|Card Default 1`] = `
                       Lorem ipsum dolor sit amet
                     </h3>
                     <div
-                      className="bx--card__footer"
+                      className="bx--card__footer bx--card__footer__copy"
                     >
                       <span
                         className="bx--card__cta__copy"

--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -85,6 +85,7 @@ function renderFooter(cta) {
       <div
         className={classNames(`${prefix}--card__footer`, {
           [`${prefix}--card__footer__icon-left`]: cta.iconPlacement === 'left',
+          [`${prefix}--card__footer__copy`]: cta.copy,
         })}>
         {cta.copy && (
           <span className={`${prefix}--card__cta__copy`}>{cta.copy}</span>

--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -69,6 +69,10 @@
       display: flex;
       margin-top: auto;
 
+      &__copy {
+        margin-bottom: -$carbon--spacing-01;
+      }
+
       svg {
         fill: currentColor;
         display: block;


### PR DESCRIPTION
### Related Ticket(s)

[Card] Add link text #2196

### Description

Reduce the bottom margin for Card when there is text in the link so that it is 16px from bottom of cta icon to bottom of card

Issue: (should be 16px from icon to bottom of card)
![image (2)](https://user-images.githubusercontent.com/54281166/87469898-fd8ab800-c5e9-11ea-865b-30bb297d6b9a.png)


### Changelog

**Changed**

- set -2px margin when there is cta text

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
