### PR TITLE
chore(lightbox-media-viewer): add stable selector

### DIFF
--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/README.stories.mdx
@@ -1,6 +1,6 @@
 import { Preview, Props, Description, Story } from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../../docs/contributing-license.md';
-import '../lightbox-video-player'
+import '../lightbox-video-player';
 
 # Lightbox Media Viewer
 
@@ -55,8 +55,7 @@ document.addEventListener('click', async event => {
 <dds-modal id="lightbox" size="full-width">
   <bx-modal-close-button></bx-modal-close-button>
   <dds-lightbox-media-viewer-body>
-    <dds-lightbox-video-player id="video-player">
-    </dds-lightbox-video-player>
+    <dds-lightbox-video-player id="video-player"> </dds-lightbox-video-player>
   </dds-lightbox-media-viewer-body>
 </dds-modal>
 ```
@@ -66,6 +65,16 @@ document.addEventListener('click', async event => {
 `<dds-lightbox-video-player>` works as the video player in lightbox media viewer.
 
 <Props of="dds-lightbox-video-player" />
+
+## Stable selectors
+
+See [our README](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/web-components#stable-selectors-for-analytics-and-integratione2e-testing-in-web-components) to see how Web Components selector and `data-autoid` should be used.
+
+| Web Components selector                                | Compatibility selector                                     | Description |
+| ------------------------------------------------------ | ---------------------------------------------------------- | ----------- |
+| `<dds-modal>`                                          | `data-autoid="dds--expressive-modal"`                      | Component   |
+| `::part(title)` in `<dds-lightbox-video-player>`       | `data-autoid="dds--Lightbox-media-viewer__content__title"` | Interactive |
+| `::part(description)` in `<dds-lightbox-video-player>` | `data-autoid="dds--Lightbox-media-viewer__content__desc"`  | Interactive |
 
 ## Contributing
 

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
@@ -45,10 +45,18 @@ class DDSLightboxVideoPlayer extends DDSVideoPlayer {
             ${hideCaption
               ? undefined
               : html`
-                  <div class="${prefix}--lightbox-media-viewer__content__title">
+                  <div
+                    part="title"
+                    class="${prefix}--lightbox-media-viewer__content__title"
+                    data-autoid="${ddsPrefix}--lightbox-media-viewer__content__title"
+                  >
                     <slot name="name">${formatCaption({ duration, name })}</slot>
                   </div>
-                  <div class="${prefix}--lightbox-media-viewer__content__desc">
+                  <div
+                    part="description"
+                    class="${prefix}--lightbox-media-viewer__content__desc"
+                    data-autoid="${ddsPrefix}--lightbox-media-viewer__content__desc"
+                  >
                     <slot name="description">${description}</slot>
                   </div>
                 `}

--- a/packages/web-components/tests/snapshots/dds-lightbox-video-player.md
+++ b/packages/web-components/tests/snapshots/dds-lightbox-video-player.md
@@ -14,11 +14,19 @@
   </div>
   <div class="bx--lightbox-media-viewer__media-description bx--no-gutter">
     <div class="bx--lightbox-media-viewer__content">
-      <div class="bx--lightbox-media-viewer__content__title">
+      <div
+        class="bx--lightbox-media-viewer__content__title"
+        data-autoid="dds--lightbox-media-viewer__content__title"
+        part="title"
+      >
         <slot name="name">
         </slot>
       </div>
-      <div class="bx--lightbox-media-viewer__content__desc">
+      <div
+        class="bx--lightbox-media-viewer__content__desc"
+        data-autoid="dds--lightbox-media-viewer__content__desc"
+        part="description"
+      >
         <slot name="description">
         </slot>
       </div>
@@ -42,12 +50,20 @@
   </div>
   <div class="bx--lightbox-media-viewer__media-description bx--no-gutter">
     <div class="bx--lightbox-media-viewer__content">
-      <div class="bx--lightbox-media-viewer__content__title">
+      <div
+        class="bx--lightbox-media-viewer__content__title"
+        data-autoid="dds--lightbox-media-viewer__content__title"
+        part="title"
+      >
         <slot name="name">
           video-name-foo (0:30)
         </slot>
       </div>
-      <div class="bx--lightbox-media-viewer__content__desc">
+      <div
+        class="bx--lightbox-media-viewer__content__desc"
+        data-autoid="dds--lightbox-media-viewer__content__desc"
+        part="description"
+      >
         <slot name="description">
           video-description-foo
         </slot>


### PR DESCRIPTION
### Related Ticket(s)

Refs #3153.

### Description

This change adds stable selectors to `<dds-lightbox-media-viewer>`.
This change also adds [`part` attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) there for better styling flexibility.

### Changelog

**New**

- `part` attribute to `<dds-lightbox-media-viewer>`.
- `data-autoid` to `<dds-lightbox-media-viewer>`.