### PR TITLE
chore(CardGroup): separate CardGroup knobs into stories

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1434,28 +1434,679 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                   "cta": Object {
                     "href": "https://www.example.com",
                   },
-                  "heading": "Fusce gravida eu arcu",
+                  "heading": "Nunc convallis lobortis",
                 },
                 Object {
                   "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
                   "cta": Object {
                     "href": "https://www.example.com",
                   },
-                  "heading": "Interdum et malesuada",
+                  "heading": "Nunc convallis lobortis",
                 },
                 Object {
                   "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
                   "cta": Object {
                     "href": "https://www.example.com",
                   },
-                  "heading": "Nunc convallis loborti",
+                  "heading": "Nunc convallis lobortis",
                 },
                 Object {
                   "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
                   "cta": Object {
                     "href": "https://www.example.com",
                   },
-                  "heading": "Nunc convallis lbortis",
+                  "heading": "Nunc convallis lobortis",
+                },
+              ]
+            }
+          >
+            <div
+              className="bx--card-group__cards__row bx--row--condensed"
+              data-autoid="dds--card-group"
+            >
+              <div
+                aria-label="Nunc convallis lobortis"
+                className="bx--card-group__cards__col"
+                key="0"
+                role="region"
+              >
+                <Card
+                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  heading="Nunc convallis lobortis"
+                  key="0"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Nunc convallis lobortis
+                        </h3>
+                        <div
+                          className="bx--card__copy"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                            }
+                          }
+                        />
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Nunc convallis lobortis"
+                className="bx--card-group__cards__col"
+                key="1"
+                role="region"
+              >
+                <Card
+                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  heading="Nunc convallis lobortis"
+                  key="1"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Nunc convallis lobortis
+                        </h3>
+                        <div
+                          className="bx--card__copy"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                            }
+                          }
+                        />
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Nunc convallis lobortis"
+                className="bx--card-group__cards__col"
+                key="2"
+                role="region"
+              >
+                <Card
+                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  heading="Nunc convallis lobortis"
+                  key="2"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Nunc convallis lobortis
+                        </h3>
+                        <div
+                          className="bx--card__copy"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                            }
+                          }
+                        />
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Nunc convallis lobortis"
+                className="bx--card-group__cards__col"
+                key="3"
+                role="region"
+              >
+                <Card
+                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  heading="Nunc convallis lobortis"
+                  key="3"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Nunc convallis lobortis
+                        </h3>
+                        <div
+                          className="bx--card__copy"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                            }
+                          }
+                        />
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Nunc convallis lobortis"
+                className="bx--card-group__cards__col"
+                key="4"
+                role="region"
+              >
+                <Card
+                  copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  heading="Nunc convallis lobortis"
+                  key="4"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Nunc convallis lobortis
+                        </h3>
+                        <div
+                          className="bx--card__copy"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.</p> ",
+                            }
+                          }
+                        />
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+            </div>
+          </CardGroup>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Components|CardGroup With CTA 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <div
+      className="bx--grid bx--content-group-story"
+    >
+      <div
+        className="bx--row"
+      >
+        <div
+          className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2"
+        >
+          <CardGroup
+            cards={
+              Array [
+                Object {
+                  "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "heading": "Nunc convallis lobortis",
+                },
+                Object {
+                  "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "heading": "Nunc convallis lobortis",
+                },
+                Object {
+                  "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "heading": "Nunc convallis lobortis",
+                },
+                Object {
+                  "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "heading": "Nunc convallis lobortis",
+                },
+                Object {
+                  "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "heading": "Nunc convallis lobortis",
                 },
               ]
             }
@@ -1587,7 +2238,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                 </Card>
               </div>
               <div
-                aria-label="Fusce gravida eu arcu"
+                aria-label="Nunc convallis lobortis"
                 className="bx--card-group__cards__col"
                 key="1"
                 role="region"
@@ -1606,7 +2257,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                     }
                   }
                   customClassName="bx--card-group__card"
-                  heading="Fusce gravida eu arcu"
+                  heading="Nunc convallis lobortis"
                   key="1"
                 >
                   <ClickableTile
@@ -1634,7 +2285,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                         <h3
                           className="bx--card__heading"
                         >
-                          Fusce gravida eu arcu
+                          Nunc convallis lobortis
                         </h3>
                         <div
                           className="bx--card__copy"
@@ -1701,7 +2352,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                 </Card>
               </div>
               <div
-                aria-label="Interdum et malesuada"
+                aria-label="Nunc convallis lobortis"
                 className="bx--card-group__cards__col"
                 key="2"
                 role="region"
@@ -1720,7 +2371,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                     }
                   }
                   customClassName="bx--card-group__card"
-                  heading="Interdum et malesuada"
+                  heading="Nunc convallis lobortis"
                   key="2"
                 >
                   <ClickableTile
@@ -1748,7 +2399,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                         <h3
                           className="bx--card__heading"
                         >
-                          Interdum et malesuada
+                          Nunc convallis lobortis
                         </h3>
                         <div
                           className="bx--card__copy"
@@ -1815,7 +2466,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                 </Card>
               </div>
               <div
-                aria-label="Nunc convallis loborti"
+                aria-label="Nunc convallis lobortis"
                 className="bx--card-group__cards__col"
                 key="3"
                 role="region"
@@ -1834,7 +2485,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                     }
                   }
                   customClassName="bx--card-group__card"
-                  heading="Nunc convallis loborti"
+                  heading="Nunc convallis lobortis"
                   key="3"
                 >
                   <ClickableTile
@@ -1862,7 +2513,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                         <h3
                           className="bx--card__heading"
                         >
-                          Nunc convallis loborti
+                          Nunc convallis lobortis
                         </h3>
                         <div
                           className="bx--card__copy"
@@ -1929,7 +2580,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                 </Card>
               </div>
               <div
-                aria-label="Nunc convallis lbortis"
+                aria-label="Nunc convallis lobortis"
                 className="bx--card-group__cards__col"
                 key="4"
                 role="region"
@@ -1948,7 +2599,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                     }
                   }
                   customClassName="bx--card-group__card"
-                  heading="Nunc convallis lbortis"
+                  heading="Nunc convallis lobortis"
                   key="4"
                 >
                   <ClickableTile
@@ -1976,7 +2627,7 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                         <h3
                           className="bx--card__heading"
                         >
-                          Nunc convallis lbortis
+                          Nunc convallis lobortis
                         </h3>
                         <div
                           className="bx--card__copy"
@@ -1986,6 +2637,1667 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                             }
                           }
                         />
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                className="bx--card-group__cards__col"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  heading="Top level card link"
+                  inverse={true}
+                >
+                  <ClickableTile
+                    className="bx--card bx--card--inverse"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card--inverse"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Top level card link
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+            </div>
+          </CardGroup>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Components|CardGroup With Images 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <div
+      className="bx--grid bx--content-group-story"
+    >
+      <div
+        className="bx--row"
+      >
+        <div
+          className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2"
+        >
+          <CardGroup
+            cards={
+              Array [
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+              ]
+            }
+          >
+            <div
+              className="bx--card-group__cards__row bx--row--condensed"
+              data-autoid="dds--card-group"
+            >
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="0"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="0"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="1"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="1"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="2"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="2"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="3"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="3"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="4"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="4"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+            </div>
+          </CardGroup>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <div
+      className="bx--grid bx--content-group-story"
+    >
+      <div
+        className="bx--row"
+      >
+        <div
+          className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2"
+        >
+          <CardGroup
+            cards={
+              Array [
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+                Object {
+                  "cta": Object {
+                    "href": "https://www.example.com",
+                  },
+                  "eyebrow": "Topic",
+                  "heading": "Natural language processing.",
+                  "image": Object {
+                    "alt": "Image alt text",
+                    "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                  },
+                },
+              ]
+            }
+            cta={
+              Object {
+                "cta": Object {
+                  "href": "https://www.example.com",
+                },
+                "heading": "Top level card link",
+              }
+            }
+          >
+            <div
+              className="bx--card-group__cards__row bx--row--condensed"
+              data-autoid="dds--card-group"
+            >
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="0"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="0"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="1"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="1"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="2"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="2"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="3"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="3"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
+                        <div
+                          className="bx--card__footer"
+                        >
+                          <ForwardRef(ArrowRight20)
+                            className="bx--card__cta"
+                            src={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
+                          >
+                            <Icon
+                              className="bx--card__cta"
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              src={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "render": [Function],
+                                }
+                              }
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="bx--card__cta"
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                src={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  }
+                                }
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowRight20)>
+                        </div>
+                      </div>
+                    </a>
+                  </ClickableTile>
+                </Card>
+              </div>
+              <div
+                aria-label="Natural language processing."
+                className="bx--card-group__cards__col"
+                key="4"
+                role="region"
+              >
+                <Card
+                  cta={
+                    Object {
+                      "href": "https://www.example.com",
+                      "icon": Object {
+                        "src": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                      },
+                    }
+                  }
+                  customClassName="bx--card-group__card"
+                  eyebrow="Topic"
+                  heading="Natural language processing."
+                  image={
+                    Object {
+                      "alt": "Image alt text",
+                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616&text=4:3",
+                    }
+                  }
+                  key="4"
+                >
+                  <ClickableTile
+                    className="bx--card bx--card-group__card"
+                    clicked={false}
+                    data-autoid="dds--card"
+                    handleClick={[Function]}
+                    handleKeyDown={[Function]}
+                    href="https://www.example.com"
+                    light={false}
+                    onClick={[Function]}
+                    target={null}
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable bx--card bx--card-group__card"
+                      data-autoid="dds--card"
+                      href="https://www.example.com"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      target={null}
+                    >
+                      <Image
+                        alt="Image alt text"
+                        classname="bx--card__img"
+                        defaultSrc="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                      >
+                        <div
+                          className="bx--image"
+                          data-autoid="dds--image__longdescription"
+                        >
+                          <picture>
+                            <img
+                              alt="Image alt text"
+                              className="bx--image__img bx--card__img"
+                              src="https://dummyimage.com/1056x792/ee5396/161616&text=4:3"
+                            />
+                          </picture>
+                        </div>
+                      </Image>
+                      <div
+                        className="bx--card__wrapper"
+                      >
+                        <p
+                          className="bx--card__eyebrow"
+                        >
+                          Topic
+                        </p>
+                        <h3
+                          className="bx--card__heading"
+                        >
+                          Natural language processing.
+                        </h3>
                         <div
                           className="bx--card__footer"
                         >
@@ -3419,7 +5731,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                       >
                                                         <div
                                                           className="bx--video-player__video"
-                                                          id="bx--video-player__video-0_uka1msg4-3"
+                                                          id="bx--video-player__video-0_uka1msg4-13"
                                                         >
                                                           <VideoImageOverlay
                                                             embedVideo={[Function]}
@@ -5362,7 +7674,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             >
                                                               <div
                                                                 className="bx--video-player__video"
-                                                                id="bx--video-player__video-0_uka1msg4-8"
+                                                                id="bx--video-player__video-0_uka1msg4-18"
                                                               >
                                                                 <VideoImageOverlay
                                                                   embedVideo={[Function]}
@@ -9837,7 +12149,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                                 >
                                   <div
                                     className="bx--video-player__video"
-                                    id="bx--video-player__video-0_uka1msg4-23"
+                                    id="bx--video-player__video-0_uka1msg4-33"
                                   />
                                 </div>
                               </div>
@@ -16692,14 +19004,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                           />
                           <img
                             alt="Lorem Ipsum"
-                            aria-describedby="bx--image-24"
+                            aria-describedby="bx--image-34"
                             className="bx--image__img"
                             src="https://dummyimage.com/672x672"
                           />
                         </picture>
                         <div
                           className="bx--image__longdescription"
-                          id="bx--image-24"
+                          id="bx--image-34"
                         >
                           Lorem Ipsum Dolor
                         </div>
@@ -17067,14 +19379,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                             />
                             <img
                               alt="Lorem Ipsum"
-                              aria-describedby="bx--image-25"
+                              aria-describedby="bx--image-35"
                               className="bx--image__img"
                               src="https://dummyimage.com/672x672"
                             />
                           </picture>
                           <div
                             className="bx--image__longdescription"
-                            id="bx--image-25"
+                            id="bx--image-35"
                           >
                             Lorem Ipsum Dolor
                           </div>
@@ -17286,7 +19598,7 @@ exports[`Storyshots Components|VideoPlayer Default 1`] = `
               >
                 <div
                   className="bx--video-player__video"
-                  id="bx--video-player__video-0_uka1msg4-27"
+                  id="bx--video-player__video-0_uka1msg4-37"
                 >
                   <VideoImageOverlay
                     embedVideo={[Function]}
@@ -28044,7 +30356,7 @@ exports[`Storyshots Patterns (Blocks)|ContentBlockSegmented With Video 1`] = `
                           >
                             <div
                               className="bx--video-player__video"
-                              id="bx--video-player__video-0_uka1msg4-45"
+                              id="bx--video-player__video-0_uka1msg4-55"
                             >
                               <VideoImageOverlay
                                 embedVideo={[Function]}
@@ -35002,14 +37314,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-55"
+                                        aria-describedby="bx--image-65"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-55"
+                                      id="bx--image-65"
                                     >
                                       Company A
                                     </div>
@@ -35043,14 +37355,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-56"
+                                        aria-describedby="bx--image-66"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-56"
+                                      id="bx--image-66"
                                     >
                                       Company B
                                     </div>
@@ -35084,14 +37396,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-57"
+                                        aria-describedby="bx--image-67"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-57"
+                                      id="bx--image-67"
                                     >
                                       Company C
                                     </div>
@@ -35125,14 +37437,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-58"
+                                        aria-describedby="bx--image-68"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-58"
+                                      id="bx--image-68"
                                     >
                                       Company D
                                     </div>
@@ -35166,14 +37478,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-59"
+                                        aria-describedby="bx--image-69"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-59"
+                                      id="bx--image-69"
                                     >
                                       Company E
                                     </div>
@@ -35207,14 +37519,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-60"
+                                        aria-describedby="bx--image-70"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-60"
+                                      id="bx--image-70"
                                     >
                                       Company F
                                     </div>
@@ -35248,14 +37560,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-61"
+                                        aria-describedby="bx--image-71"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-61"
+                                      id="bx--image-71"
                                     >
                                       Company G
                                     </div>
@@ -35289,14 +37601,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-62"
+                                        aria-describedby="bx--image-72"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-62"
+                                      id="bx--image-72"
                                     >
                                       Company H
                                     </div>
@@ -35330,14 +37642,14 @@ exports[`Storyshots Patterns (Blocks)|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-63"
+                                        aria-describedby="bx--image-73"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&amp;text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-63"
+                                      id="bx--image-73"
                                     >
                                       Company I
                                     </div>

--- a/packages/react/src/components/CardGroup/__stories__/CardGroup.stories.js
+++ b/packages/react/src/components/CardGroup/__stories__/CardGroup.stories.js
@@ -5,38 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { boolean, object, select } from '@storybook/addon-knobs';
 import CardGroup from '../CardGroup';
-import cards from './data/cards.json';
+import { number } from '@storybook/addon-knobs';
 import React from 'react';
 import readme from '../README.stories.mdx';
-
-const cardTypes = Object.keys(cards);
 
 export default {
   title: 'Components|CardGroup',
 
   parameters: {
     ...readme.parameters,
-    knobs: {
-      CardGroup: ({ groupId }) => {
-        const type = select('Card (type)', cardTypes, cardTypes[0], groupId);
-        const data = object(`Data (${type})`, cards[type], groupId);
-        cards[type] = data; // Preservices the knob edit for the card type
-        return {
-          cards: data,
-          cta:
-            (boolean('cta', true, groupId) && {
-              heading: 'Top level card link',
-              cta: {
-                href: 'https://www.example.com',
-              },
-            }) ||
-            undefined,
-        };
-      },
-    },
-
     propsSet: {
       default: {
         CardGroup: {
@@ -88,6 +66,34 @@ export default {
   },
 };
 
+const defaultCard = {
+  heading: 'Nunc convallis lobortis',
+  copy:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.',
+  cta: {
+    href: 'https://www.example.com',
+  },
+};
+
+const cardWithImages = {
+  image: {
+    defaultSrc: 'https://dummyimage.com/1056x792/ee5396/161616&text=4:3',
+    alt: 'Image alt text',
+  },
+  eyebrow: 'Topic',
+  heading: 'Natural language processing.',
+  cta: {
+    href: 'https://www.example.com',
+  },
+};
+
+const groupCTA = {
+  heading: 'Top level card link',
+  cta: {
+    href: 'https://www.example.com',
+  },
+};
+
 export const Default = ({ parameters }) => {
   const { cards: data, cta } = parameters?.props?.CardGroup ?? {};
 
@@ -100,4 +106,96 @@ export const Default = ({ parameters }) => {
       </div>
     </div>
   );
+};
+
+Default.story = {
+  parameters: {
+    knobs: {
+      CardGroup: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 5, {}, groupId),
+        }).map(_ => defaultCard),
+      }),
+    },
+  },
+};
+
+export const WithCTA = ({ parameters }) => {
+  const { cards: data, cta } = parameters?.props?.CardGroup ?? {};
+
+  return (
+    <div className="bx--grid bx--content-group-story">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
+          <CardGroup cards={data} cta={cta} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+WithCTA.story = {
+  parameters: {
+    knobs: {
+      CardGroup: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 5, {}, groupId),
+        }).map(_ => defaultCard),
+        cta: groupCTA,
+      }),
+    },
+  },
+};
+
+export const WithImages = ({ parameters }) => {
+  const { cards: data, cta } = parameters?.props?.CardGroup ?? {};
+
+  return (
+    <div className="bx--grid bx--content-group-story">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
+          <CardGroup cards={data} cta={cta} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+WithImages.story = {
+  parameters: {
+    knobs: {
+      CardGroup: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 5, {}, groupId),
+        }).map(_ => cardWithImages),
+      }),
+    },
+  },
+};
+
+export const WithImagesAndCTA = ({ parameters }) => {
+  const { cards: data, cta } = parameters?.props?.CardGroup ?? {};
+
+  return (
+    <div className="bx--grid bx--content-group-story">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
+          <CardGroup cards={data} cta={cta} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+WithImagesAndCTA.story = {
+  parameters: {
+    knobs: {
+      CardGroup: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 5, {}, groupId),
+        }).map(_ => cardWithImages),
+        cta: groupCTA,
+      }),
+    },
+  },
 };


### PR DESCRIPTION
### Related Ticket(s)

#2949 

### Description

Separate `CardGroup` into individual stories

### Changelog

**Changed**

- separate `CardGroup` variations into individual stories

<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
