### PR TITLE
chore(build): add exports field

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -6,6 +6,11 @@
   "main": "es/index.js",
   "module": "es/index.js",
   "typings": "es/index.d.ts",
+  "exports": {
+    "./es/": "./es/",
+    "./custom-elements.json": "./custom-elements.json",
+    "./package.json": "./package.json"
+  },
   "files": [
     "es/**/*",
     "scss/**/*",


### PR DESCRIPTION
### Related Ticket(s)

Refs carbon-design-system/carbon-custom-elements#443.

### Description

This change adds [`exports` field](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_package_entry_points) in `package.json`.
Doing so enables several CDNs that support module path mapping.

### Changelog

**New**

- `exports` field in `package.json`.