### PR TITLE
Fix(ctasection): Bottom spacing

### DIFF
--- a/packages/styles/scss/components/ctasection/_ctasection.scss
+++ b/packages/styles/scss/components/ctasection/_ctasection.scss
@@ -30,8 +30,13 @@
 @mixin cta-section--pattern {
   .#{$prefix}--cta-section {
     &__cta {
+      padding-bottom: $carbon--layout-05;
+
       @include carbon--breakpoint('md') {
         padding-bottom: $carbon--layout-06;
+      }
+      @include carbon--breakpoint('lg') {
+        padding-bottom: $carbon--layout-07;
       }
     }
 
@@ -138,7 +143,7 @@
           }
 
           @include carbon--breakpoint('lg') {
-            padding-bottom: $carbon--layout-06;
+            padding-bottom: $carbon--layout-07;
           }
         }
       }


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/3017

### Description

### Changelog

**Changed**

- cta section bottom spacing :
        Lg and above -160px
        Sm - 64px

