### PR TITLE
fix(callout-data): fixed wrong story display on iframe mode

### DIFF
--- a/packages/react/src/components/CalloutData/CalloutData.js
+++ b/packages/react/src/components/CalloutData/CalloutData.js
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React, { useState, useEffect } from 'react';
 import Callout from '../../internal/components/Callout/Callout';
 import { DDS_CALLOUT_DATA } from '../../internal/FeatureFlags';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
+import decodeString from '@carbon/ibmdotcom-utilities/es/utilities/decodeString/decodeString';
 import featureFlag from '@carbon/ibmdotcom-utilities/es/utilities/featureflag/featureflag';
 import PropTypes from 'prop-types';
-import React from 'react';
 import settings from 'carbon-components/es/globals/js/settings';
 
 const { stablePrefix } = ddsSettings;
@@ -20,20 +21,30 @@ const { prefix } = settings;
  * Callout with Data pattern.
  */
 
-const CalloutData = ({ data, copy, source }) =>
-  featureFlag(
+const CalloutData = ({ data, copy, source }) => {
+  const [decodedData, setDecodedData] = useState({});
+
+  useEffect(() => {
+    console.log('data', data);
+    setDecodedData({
+      data: decodeString(data),
+      copy: decodeString(copy),
+    });
+  }, [data, copy]);
+
+  return featureFlag(
     DDS_CALLOUT_DATA,
     <div
       data-autoid={`${stablePrefix}--callout-data`}
       className={`${prefix}--callout-data`}>
       <Callout>
-        <h4 className={`${prefix}--callout-data__data`}>{data}</h4>
-
-        <p className={`${prefix}--callout-data__copy`}>{copy}</p>
+        <h4 className={`${prefix}--callout-data__data`}>{decodedData.data}</h4>
+        <p className={`${prefix}--callout-data__copy`}>{decodedData.copy}</p>
       </Callout>
       <p className={`${prefix}--callout-data__source`}>{source}</p>
     </div>
   );
+};
 
 CalloutData.PropTypes = {
   /**

--- a/packages/styles/scss/components/callout-data/_callout-data.scss
+++ b/packages/styles/scss/components/callout-data/_callout-data.scss
@@ -49,19 +49,19 @@
         height: auto;
 
         @include carbon--breakpoint('md') {
-          height: carbon--mini-units(40);
+          min-height: carbon--mini-units(40);
         }
 
         @include carbon--breakpoint('lg') {
-          height: carbon--mini-units(50);
+          min-height: carbon--mini-units(50);
         }
 
         @include carbon--breakpoint('xlg') {
-          height: carbon--mini-units(60);
+          min-height: carbon--mini-units(60);
         }
 
         @include carbon--breakpoint('max') {
-          height: carbon--mini-units(70);
+          min-height: carbon--mini-units(70);
         }
       }
 

--- a/packages/utilities/src/utilities/decodeString/decodeString.js
+++ b/packages/utilities/src/utilities/decodeString/decodeString.js
@@ -21,7 +21,16 @@
  */
 function decodeString(str) {
   const div = document.createElement('div');
-  div.innerHTML = str;
+  let targetText;
+  if (str.includes('%20')) {
+    targetText = str
+      .split('%20')
+      .map(elem => `${elem} `)
+      .join('');
+  } else {
+    targetText = str;
+  }
+  div.innerHTML = targetText;
   return div.textContent;
 }
 


### PR DESCRIPTION
### Related Ticket(s)

#3027 

### Description

I've updated `CalloutData` in order to use decode string in order to avoid story bugs when checking the iframe mode.
The decode string was updated as well in order to prevent a bug where spaces would turn into unicode `%20` when using the iframe mode on storybook
