### PR TITLE
chore(percy): hide web components lightboxmediaviewer in percy

### DIFF
--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
@@ -44,6 +44,9 @@ export default {
   title: 'Components/Lightbox media viewer',
   parameters: {
     ...readme.parameters,
+    percy: {
+      skip: true,
+    },
     knobs: {
       'dds-modal': ({ groupId }) => ({
         open: boolean('Open (open)', true, groupId),


### PR DESCRIPTION
### Related Ticket(s)

#3242 

### Description

The issue here is that the video player is throwing false positives
in percy. Because we don't have an image in lightboxmediaviewer
yet, going to have this configured to be skipped for now until we
have that in place.

### Changelog

**Changed**

- Hide lightboxmediaviewer in percy for web components