### PR TITLE
chore(percy): hide stories with videos

### DIFF
--- a/packages/react/src/components/ContentBlockCards/__stories__/ContentBlockCards.stories.js
+++ b/packages/react/src/components/ContentBlockCards/__stories__/ContentBlockCards.stories.js
@@ -144,6 +144,9 @@ export const WithVideos = ({ parameters }) => {
 
 WithVideos.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       ContentBlockCards: ({ groupId }) => {
         const knobs = getBaseKnobs({ groupId });

--- a/packages/react/src/components/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
+++ b/packages/react/src/components/ContentBlockSegmented/__stories__/ContentBlockSegmented.stories.js
@@ -197,6 +197,9 @@ export const WithVideo = ({ parameters }) => {
 
 WithVideo.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       ContentBlockSegmented: ({ groupId }) => {
         const knobs = getBaseKnobs({ groupId });

--- a/packages/react/src/components/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
+++ b/packages/react/src/components/ContentBlockSimple/__stories__/ContentBlockSimple.stories.js
@@ -175,6 +175,9 @@ export const WithVideo = ({ parameters }) => {
 
 WithVideo.story = {
   parameters: {
+    percy: {
+      skip: true,
+    },
     knobs: {
       ContentBlockSimple: ({ groupId }) => {
         const knobs = getBaseKnobs({ groupId });


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The video player is throwing false positives in percy for React.
This will suppress the stories in percy that includes
videos.

### Changelog

**Changed**

- Adding percy `skip: true` configuration for video related stories