### PR TITLE
chore(percy): hide stories with videos

### DIFF
--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -143,7 +143,8 @@
     }
 
     .bx--link-list__list--video,
-    .bx--leadspace-block .bx--video-player {
+    .bx--video-player,
+    .bx--card__video {
       display: none !important;
     }
   }

--- a/packages/react/src/components/ContentGroupSimple/__stories__/ContentGroupSimple.stories.js
+++ b/packages/react/src/components/ContentGroupSimple/__stories__/ContentGroupSimple.stories.js
@@ -100,3 +100,11 @@ export const WithVideo = ({ parameters }) => {
     </div>
   );
 };
+
+WithVideo.story = {
+  parameters: {
+    percy: {
+      skip: true,
+    },
+  },
+};

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -8,7 +8,7 @@
 @import '../../globals/imports';
 @import '../../globals/utils/content-width';
 @import '../../globals/utils/hang';
-@import '../../patterns/blocks/feature-card-block-medium/feature-card-block-medium';
+@import '../../components/feature-card-block-medium/feature-card-block-medium';
 
 @mixin content-block {
   .#{$prefix}--content-block--inverse {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15414,7 +15414,7 @@ jest-dev-server@^4.4.0:
     tree-kill "^1.2.2"
     wait-on "^3.3.0"
 
-jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.9.0:
+jest-diff@^24.3.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The video player is throwing false positives in percy.
This will suppress additional stories in percy that includes
videos by targeting video specific classes.

### Changelog

**Changed**

- Adding video classes for percy media query