### PR TITLE
chore(masthead): separating L1 stories for Masthead

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2045,6 +2045,83 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Components|CalloutData Default 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <div
+      className="bx--grid"
+    >
+      <div
+        className="bx--row"
+      >
+        <div
+          className="bx--offset-lg-4 bx--col-lg-12"
+        >
+          <CalloutData
+            copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam."
+            data="51%"
+            source="Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+          >
+            <div
+              className="bx--callout-data"
+              data-autoid="dds--callout-data"
+            >
+              <Callout>
+                <section
+                  className="bx--callout__container"
+                  data-autoid="dds--callout__container"
+                >
+                  <div
+                    className="bx--callout__column"
+                    data-autoid="dds--callout__column"
+                  >
+                    <div
+                      className="bx--callout__content"
+                      data-autoid="dds--callout__content"
+                    >
+                      <h4
+                        className="bx--callout-data__data"
+                      >
+                        51%
+                      </h4>
+                      <p
+                        className="bx--callout-data__copy"
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+                      </p>
+                    </div>
+                  </div>
+                </section>
+              </Callout>
+              <p
+                className="bx--callout-data__source"
+              >
+                Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+              </p>
+            </div>
+          </CalloutData>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Components|CalloutQuote Default 1`] = `
 <Container
   story={[Function]}
@@ -16261,6 +16338,493 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
               </ContentBlock>
             </div>
           </ContentBlockCards>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Components|ContentBlockHeadlines Default 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <div
+      className="bx--grid"
+    >
+      <div
+        className="bx--row"
+      >
+        <div
+          className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+        >
+          <ContentBlockHeadlines
+            copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+            heading="Aliquam condimentum"
+            items={
+              Array [
+                Object {
+                  "copy": "Modernize mission-critical applications and infrastructure in a hybrid multicloud environment up to 25 percent faster.",
+                  "headline": "25%",
+                },
+                Object {
+                  "copy": "Realize up to 90 percent reduction in time spent and 75 percent reduction in IT operations expense.",
+                  "cta": Object {
+                    "copy": "View the infographic",
+                    "cta": Object {
+                      "href": "https://example.com",
+                    },
+                    "type": "local",
+                  },
+                  "headline": "75%",
+                },
+                Object {
+                  "copy": "Build cloud native apps with microservices code generation and improved DevOps processes with up to 50 percent less effort.",
+                  "cta": Object {
+                    "copy": "Take the assessment",
+                    "cta": Object {
+                      "href": "https://example.com",
+                    },
+                    "type": "external",
+                  },
+                  "headline": "50%",
+                },
+                Object {
+                  "copy": "Save 1.34M per year by optimizing your time and IT expenses.",
+                  "cta": Object {
+                    "copy": "Calculate your savings",
+                    "cta": Object {
+                      "href": "https://example.com",
+                    },
+                    "type": "local",
+                  },
+                  "headline": "1.34M",
+                },
+              ]
+            }
+          >
+            <div
+              className="bx--content-block-headlines"
+              data-autoid="dds--content-block-headlines"
+            >
+              <ContentBlock
+                border={true}
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit."
+                heading="Aliquam condimentum"
+              >
+                <div
+                  className="bx--content-block"
+                  data-autoid="dds--content-block"
+                >
+                  <div>
+                    <h2
+                      className="bx--content-block__heading"
+                      data-autoid="dds--content-block__heading"
+                    >
+                      Aliquam condimentum
+                    </h2>
+                  </div>
+                  <div
+                    className="bx--content-block__copy"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit.</p> ",
+                      }
+                    }
+                  />
+                  <div
+                    className="bx--content-block__children"
+                    data-autoid="dds--content-block__children"
+                  >
+                    <div
+                      className="bx--content-block-headlines__container"
+                    >
+                      <div
+                        className="bx--content-block-headlines__row"
+                        key="0"
+                      >
+                        <div
+                          className="bx--content-block-headlines__item-container"
+                        >
+                          <div
+                            className="bx--content-block-headlines__item"
+                            key="0"
+                          >
+                            <h4
+                              className="bx--content-block-headlines__headline"
+                            >
+                              25%
+                            </h4>
+                            <p
+                              className="bx--content-block-headlines__copy"
+                            >
+                              Modernize mission-critical applications and infrastructure in a hybrid multicloud environment up to 25 percent faster.
+                            </p>
+                          </div>
+                          <div
+                            className="bx--content-block-headlines__item"
+                            key="1"
+                          >
+                            <h4
+                              className="bx--content-block-headlines__headline"
+                            >
+                              75%
+                            </h4>
+                            <p
+                              className="bx--content-block-headlines__copy"
+                            >
+                              Realize up to 90 percent reduction in time spent and 75 percent reduction in IT operations expense.
+                            </p>
+                            <CTA
+                              copy="View the infographic"
+                              cta={
+                                Object {
+                                  "href": "https://example.com",
+                                }
+                              }
+                              href=""
+                              style="text"
+                              type="local"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="View the infographic"
+                                  cta={
+                                    Object {
+                                      "href": "https://example.com",
+                                    }
+                                  }
+                                  formatCTAcopy={[Function]}
+                                  href=""
+                                  iconPlacement="right"
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "duration": "",
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://example.com"
+                                    iconPlacement="right"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://example.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://example.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            View the infographic
+                                          </span>
+                                          <ForwardRef(ArrowRight20)>
+                                            <Icon
+                                              fill="currentColor"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 20 20"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                fill="currentColor"
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(ArrowRight20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="bx--content-block-headlines__row"
+                        key="1"
+                      >
+                        <div
+                          className="bx--content-block-headlines__item-container"
+                        >
+                          <div
+                            className="bx--content-block-headlines__item"
+                            key="0"
+                          >
+                            <h4
+                              className="bx--content-block-headlines__headline"
+                            >
+                              50%
+                            </h4>
+                            <p
+                              className="bx--content-block-headlines__copy"
+                            >
+                              Build cloud native apps with microservices code generation and improved DevOps processes with up to 50 percent less effort.
+                            </p>
+                            <CTA
+                              copy="Take the assessment"
+                              cta={
+                                Object {
+                                  "href": "https://example.com",
+                                }
+                              }
+                              href=""
+                              style="text"
+                              type="external"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Take the assessment"
+                                  cta={
+                                    Object {
+                                      "href": "https://example.com",
+                                    }
+                                  }
+                                  formatCTAcopy={[Function]}
+                                  href=""
+                                  iconPlacement="right"
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="external"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "duration": "",
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://example.com"
+                                    iconPlacement="right"
+                                    onClick={[Function]}
+                                    target="_blank"
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://example.com"
+                                        onClick={[Function]}
+                                        target="_blank"
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://example.com"
+                                          onClick={[Function]}
+                                          target="_blank"
+                                        >
+                                          <span>
+                                            Take the assessment
+                                          </span>
+                                          <ForwardRef(Launch20)>
+                                            <Icon
+                                              fill="currentColor"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 32 32"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                fill="currentColor"
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 32 32"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                />
+                                                <path
+                                                  d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(Launch20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </div>
+                          <div
+                            className="bx--content-block-headlines__item"
+                            key="1"
+                          >
+                            <h4
+                              className="bx--content-block-headlines__headline"
+                            >
+                              1.34M
+                            </h4>
+                            <p
+                              className="bx--content-block-headlines__copy"
+                            >
+                              Save 1.34M per year by optimizing your time and IT expenses.
+                            </p>
+                            <CTA
+                              copy="Calculate your savings"
+                              cta={
+                                Object {
+                                  "href": "https://example.com",
+                                }
+                              }
+                              href=""
+                              style="text"
+                              type="local"
+                            >
+                              <div>
+                                <TextCTA
+                                  copy="Calculate your savings"
+                                  cta={
+                                    Object {
+                                      "href": "https://example.com",
+                                    }
+                                  }
+                                  formatCTAcopy={[Function]}
+                                  href=""
+                                  iconPlacement="right"
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="text"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "duration": "",
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <LinkWithIcon
+                                    href="https://example.com"
+                                    iconPlacement="right"
+                                    onClick={[Function]}
+                                    target={null}
+                                  >
+                                    <div
+                                      className="bx--link-with-icon__container"
+                                      data-autoid="dds--link-with-icon"
+                                    >
+                                      <Link
+                                        className="bx--link-with-icon"
+                                        href="https://example.com"
+                                        onClick={[Function]}
+                                        target={null}
+                                      >
+                                        <a
+                                          className="bx--link bx--link-with-icon"
+                                          href="https://example.com"
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <span>
+                                            Calculate your savings
+                                          </span>
+                                          <ForwardRef(ArrowRight20)>
+                                            <Icon
+                                              fill="currentColor"
+                                              height={20}
+                                              preserveAspectRatio="xMidYMid meet"
+                                              viewBox="0 0 20 20"
+                                              width={20}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                fill="currentColor"
+                                                focusable="false"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                />
+                                              </svg>
+                                            </Icon>
+                                          </ForwardRef(ArrowRight20)>
+                                        </a>
+                                      </Link>
+                                    </div>
+                                  </LinkWithIcon>
+                                </TextCTA>
+                              </div>
+                            </CTA>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <HorizontalRule>
+                    <hr
+                      className="bx--hr"
+                      data-autoid="dds--hr"
+                    />
+                  </HorizontalRule>
+                </div>
+              </ContentBlock>
+            </div>
+          </ContentBlockHeadlines>
         </div>
       </div>
     </div>
@@ -32290,7 +32854,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
         Object {
           "hasProfile": true,
           "hasSearch": true,
-          "mastheadL1Data": false,
           "navigation": "default",
           "placeHolderText": "Search all of IBM",
           "platform": null,
@@ -32300,7 +32863,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
       <Masthead
         hasProfile={true}
         hasSearch={true}
-        mastheadL1Data={false}
+        mastheadL1Data={null}
         navigation="default"
         placeHolderText="Search all of IBM"
         platform={null}
@@ -37795,6 +38358,8403 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Components|Dotcom Shell With L 1 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <Default
+      parameters={
+        Object {
+          "__id": "components-dotcom-shell--with-l-1",
+          "carbon-theme": Object {
+            "disabled": true,
+          },
+          "component": undefined,
+          "docs": Object {},
+          "fileName": "./components/DotcomShell/__stories__/DotcomShell.stories.js",
+          "framework": "react",
+          "knobs": Object {
+            "DotcomShell": [Function],
+          },
+          "options": Object {
+            "name": "IBM.com Library React",
+            "storySort": [Function],
+            "url": "https://github.com/carbon-design-system/ibm-dotcom-library",
+          },
+          "props": Object {
+            "DotcomShell": Object {
+              "footerProps": Object {
+                "disableLocaleButton": false,
+                "isCustom": false,
+                "items": undefined,
+                "languageCallback": [Function],
+                "languageInitialItem": Object {
+                  "id": "en",
+                  "text": "English",
+                },
+                "languageOnly": false,
+                "navigation": null,
+                "type": undefined,
+              },
+              "mastheadProps": Object {
+                "hasProfile": true,
+                "hasSearch": true,
+                "mastheadL1Data": Object {
+                  "eyebrowLink": "#",
+                  "eyebrowText": "Eyebrow",
+                  "navigationL1": Array [
+                    Object {
+                      "hasMegapanel": true,
+                      "hasMenu": true,
+                      "menuSections": Array [
+                        Object {
+                          "heading": "Explore",
+                          "menuItems": Array [
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "",
+                                "feature": Object {
+                                  "heading": "",
+                                  "imageUrl": "",
+                                  "linkTitle": "",
+                                  "linkUrl": "",
+                                },
+                                "headingTitle": "",
+                                "headingUrl": "",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Subnav 1",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 2",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 3",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 4",
+                                      "url": "",
+                                    },
+                                  ],
+                                  "title": "Title",
+                                },
+                              },
+                              "title": "Link 1",
+                              "url": "",
+                            },
+                          ],
+                        },
+                      ],
+                      "title": "Link 1",
+                      "url": "",
+                    },
+                    Object {
+                      "hasMegapanel": true,
+                      "hasMenu": true,
+                      "menuSections": Array [
+                        Object {
+                          "heading": "",
+                          "menuItems": Array [
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                                "feature": Object {
+                                  "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                                  "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                                  "linkTitle": "Explore all our business consulting and technology services",
+                                  "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                },
+                                "headingTitle": "Services",
+                                "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Subnav 1",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 2",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 3",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 4",
+                                      "url": "",
+                                    },
+                                  ],
+                                  "title": "Quicklinks",
+                                },
+                              },
+                              "title": "Link 2",
+                              "url": "",
+                            },
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "Funding options that fit your business",
+                                "feature": Object {
+                                  "heading": "Cloud financing strategies that work for your business",
+                                  "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                                  "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                                  "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                                },
+                                "headingTitle": "Financing",
+                                "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Subnav 1",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 2",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 3",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 4",
+                                      "url": "",
+                                    },
+                                  ],
+                                  "title": "Quicklinks",
+                                },
+                              },
+                              "title": "Financing",
+                              "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                            },
+                          ],
+                        },
+                      ],
+                      "title": "Link 2",
+                      "url": "",
+                    },
+                    Object {
+                      "hasMegapanel": false,
+                      "hasMenu": false,
+                      "menuSections": Array [],
+                      "title": "Industries",
+                      "url": "https://www.ibm.com/industries?lnk=min",
+                    },
+                    Object {
+                      "hasMegapanel": true,
+                      "hasMenu": true,
+                      "menuSections": Array [
+                        Object {
+                          "heading": "",
+                          "menuItems": Array [
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "",
+                                "feature": Object {
+                                  "heading": "IBM Developer newsletters",
+                                  "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                                  "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                                  "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                "headingTitle": "IBM Developer",
+                                "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Subnav 1",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 2",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 3",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 4",
+                                      "url": "",
+                                    },
+                                  ],
+                                  "title": "Quicklinks",
+                                },
+                              },
+                              "title": "IBM Developer",
+                              "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "",
+                                "feature": Object {
+                                  "heading": "Blockchain 101",
+                                  "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                                  "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                                  "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                "headingTitle": "Blockchain",
+                                "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Subnav 1",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 2",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 3",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "title": "Subnav 4",
+                                      "url": "",
+                                    },
+                                  ],
+                                  "title": "Quicklinks",
+                                },
+                              },
+                              "title": "Blockchain",
+                              "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "",
+                                "feature": Object {
+                                  "heading": "Make sense of Kubernetes",
+                                  "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                                  "linkTitle": "Deploy a simple Python application with Kubernetes",
+                                  "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                "headingTitle": "Containers",
+                                "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Code patterns",
+                                      "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "title": "Tutorials",
+                                      "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "title": "Events",
+                                      "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                  ],
+                                  "title": "Quicklinks",
+                                },
+                              },
+                              "title": "Containers",
+                              "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            Object {
+                              "megapanelContent": Object {
+                                "description": "",
+                                "feature": Object {
+                                  "heading": "Train your data no matter where it lives",
+                                  "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                                  "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                                  "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                "headingTitle": "Analytics",
+                                "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                "quickLinks": Object {
+                                  "links": Array [
+                                    Object {
+                                      "title": "Code patterns",
+                                      "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "title": "Tutorials",
+                                      "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "title": "Events",
+                                      "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "title": "Developer community",
+                                      "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                  ],
+                                  "title": "Quicklinks",
+                                },
+                              },
+                              "title": "Analytics",
+                              "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                          ],
+                        },
+                      ],
+                      "title": "Link 3",
+                      "url": "",
+                    },
+                    Object {
+                      "hasMegapanel": false,
+                      "hasMenu": false,
+                      "menuSections": Array [],
+                      "title": "Support",
+                      "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                    },
+                  ],
+                  "title": "Stock Charts",
+                  "titleLink": "https://www.example.com",
+                },
+                "placeHolderText": "Search all of IBM",
+              },
+            },
+          },
+          "subcomponents": undefined,
+        }
+      }
+    >
+      <DotcomShell
+        footerProps={
+          Object {
+            "disableLocaleButton": false,
+            "isCustom": false,
+            "items": undefined,
+            "languageCallback": [Function],
+            "languageInitialItem": Object {
+              "id": "en",
+              "text": "English",
+            },
+            "languageOnly": false,
+            "navigation": null,
+            "type": undefined,
+          }
+        }
+        mastheadProps={
+          Object {
+            "hasProfile": true,
+            "hasSearch": true,
+            "mastheadL1Data": Object {
+              "eyebrowLink": "#",
+              "eyebrowText": "Eyebrow",
+              "navigationL1": Array [
+                Object {
+                  "hasMegapanel": true,
+                  "hasMenu": true,
+                  "menuSections": Array [
+                    Object {
+                      "heading": "Explore",
+                      "menuItems": Array [
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "",
+                              "imageUrl": "",
+                              "linkTitle": "",
+                              "linkUrl": "",
+                            },
+                            "headingTitle": "",
+                            "headingUrl": "",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Title",
+                            },
+                          },
+                          "title": "Link 1",
+                          "url": "",
+                        },
+                      ],
+                    },
+                  ],
+                  "title": "Link 1",
+                  "url": "",
+                },
+                Object {
+                  "hasMegapanel": true,
+                  "hasMenu": true,
+                  "menuSections": Array [
+                    Object {
+                      "heading": "",
+                      "menuItems": Array [
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                            "feature": Object {
+                              "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                              "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                              "linkTitle": "Explore all our business consulting and technology services",
+                              "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                            },
+                            "headingTitle": "Services",
+                            "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Link 2",
+                          "url": "",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "Funding options that fit your business",
+                            "feature": Object {
+                              "heading": "Cloud financing strategies that work for your business",
+                              "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                              "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                              "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                            },
+                            "headingTitle": "Financing",
+                            "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Financing",
+                          "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                        },
+                      ],
+                    },
+                  ],
+                  "title": "Link 2",
+                  "url": "",
+                },
+                Object {
+                  "hasMegapanel": false,
+                  "hasMenu": false,
+                  "menuSections": Array [],
+                  "title": "Industries",
+                  "url": "https://www.ibm.com/industries?lnk=min",
+                },
+                Object {
+                  "hasMegapanel": true,
+                  "hasMenu": true,
+                  "menuSections": Array [
+                    Object {
+                      "heading": "",
+                      "menuItems": Array [
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "IBM Developer newsletters",
+                              "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                              "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                              "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "IBM Developer",
+                            "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "IBM Developer",
+                          "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "Blockchain 101",
+                              "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                              "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                              "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "Blockchain",
+                            "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Blockchain",
+                          "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "Make sense of Kubernetes",
+                              "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                              "linkTitle": "Deploy a simple Python application with Kubernetes",
+                              "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "Containers",
+                            "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Code patterns",
+                                  "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Tutorials",
+                                  "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Events",
+                                  "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Containers",
+                          "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "Train your data no matter where it lives",
+                              "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                              "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                              "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "Analytics",
+                            "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Code patterns",
+                                  "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Tutorials",
+                                  "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Events",
+                                  "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Developer community",
+                                  "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Analytics",
+                          "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                      ],
+                    },
+                  ],
+                  "title": "Link 3",
+                  "url": "",
+                },
+                Object {
+                  "hasMegapanel": false,
+                  "hasMenu": false,
+                  "menuSections": Array [],
+                  "title": "Support",
+                  "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                },
+              ],
+              "title": "Stock Charts",
+              "titleLink": "https://www.example.com",
+            },
+            "placeHolderText": "Search all of IBM",
+          }
+        }
+      >
+        <Masthead
+          hasProfile={true}
+          hasSearch={true}
+          mastheadL1Data={
+            Object {
+              "eyebrowLink": "#",
+              "eyebrowText": "Eyebrow",
+              "navigationL1": Array [
+                Object {
+                  "hasMegapanel": true,
+                  "hasMenu": true,
+                  "menuSections": Array [
+                    Object {
+                      "heading": "Explore",
+                      "menuItems": Array [
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "",
+                              "imageUrl": "",
+                              "linkTitle": "",
+                              "linkUrl": "",
+                            },
+                            "headingTitle": "",
+                            "headingUrl": "",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Title",
+                            },
+                          },
+                          "title": "Link 1",
+                          "url": "",
+                        },
+                      ],
+                    },
+                  ],
+                  "title": "Link 1",
+                  "url": "",
+                },
+                Object {
+                  "hasMegapanel": true,
+                  "hasMenu": true,
+                  "menuSections": Array [
+                    Object {
+                      "heading": "",
+                      "menuItems": Array [
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                            "feature": Object {
+                              "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                              "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                              "linkTitle": "Explore all our business consulting and technology services",
+                              "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                            },
+                            "headingTitle": "Services",
+                            "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Link 2",
+                          "url": "",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "Funding options that fit your business",
+                            "feature": Object {
+                              "heading": "Cloud financing strategies that work for your business",
+                              "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                              "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                              "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                            },
+                            "headingTitle": "Financing",
+                            "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Financing",
+                          "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                        },
+                      ],
+                    },
+                  ],
+                  "title": "Link 2",
+                  "url": "",
+                },
+                Object {
+                  "hasMegapanel": false,
+                  "hasMenu": false,
+                  "menuSections": Array [],
+                  "title": "Industries",
+                  "url": "https://www.ibm.com/industries?lnk=min",
+                },
+                Object {
+                  "hasMegapanel": true,
+                  "hasMenu": true,
+                  "menuSections": Array [
+                    Object {
+                      "heading": "",
+                      "menuItems": Array [
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "IBM Developer newsletters",
+                              "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                              "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                              "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "IBM Developer",
+                            "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "IBM Developer",
+                          "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "Blockchain 101",
+                              "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                              "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                              "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "Blockchain",
+                            "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Subnav 1",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 3",
+                                  "url": "",
+                                },
+                                Object {
+                                  "title": "Subnav 4",
+                                  "url": "",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Blockchain",
+                          "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "Make sense of Kubernetes",
+                              "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                              "linkTitle": "Deploy a simple Python application with Kubernetes",
+                              "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "Containers",
+                            "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Code patterns",
+                                  "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Tutorials",
+                                  "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Events",
+                                  "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Containers",
+                          "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                        Object {
+                          "megapanelContent": Object {
+                            "description": "",
+                            "feature": Object {
+                              "heading": "Train your data no matter where it lives",
+                              "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                              "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                              "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                            },
+                            "headingTitle": "Analytics",
+                            "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                            "quickLinks": Object {
+                              "links": Array [
+                                Object {
+                                  "title": "Code patterns",
+                                  "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Tutorials",
+                                  "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Events",
+                                  "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "title": "Developer community",
+                                  "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                              ],
+                              "title": "Quicklinks",
+                            },
+                          },
+                          "title": "Analytics",
+                          "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                        },
+                      ],
+                    },
+                  ],
+                  "title": "Link 3",
+                  "url": "",
+                },
+                Object {
+                  "hasMegapanel": false,
+                  "hasMenu": false,
+                  "menuSections": Array [],
+                  "title": "Support",
+                  "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                },
+              ],
+              "title": "Stock Charts",
+              "titleLink": "https://www.example.com",
+            }
+          }
+          placeHolderText="Search all of IBM"
+          platform={null}
+          searchOpenOnload={false}
+        >
+          <HeaderContainer
+            isSideNavExpanded={false}
+            render={[Function]}
+          >
+            <render
+              isSideNavExpanded={false}
+              onClickSideNavExpand={[Function]}
+            >
+              <div
+                className="bx--masthead "
+              >
+                <div
+                  className="bx--masthead__l0"
+                >
+                  <Header
+                    aria-label="IBM"
+                    data-autoid="dds--masthead"
+                  >
+                    <header
+                      aria-label="IBM"
+                      className="bx--header"
+                      data-autoid="dds--masthead"
+                    >
+                      <SkipToContent
+                        href="#main-content"
+                        tabIndex="0"
+                      >
+                        <a
+                          className="bx--skip-to-content"
+                          href="#main-content"
+                          tabIndex="0"
+                        >
+                          Skip to main content
+                        </a>
+                      </SkipToContent>
+                      <HeaderMenuButton
+                        aria-label="Open menu"
+                        data-autoid="dds--masthead__hamburger"
+                        isActive={false}
+                        onClick={[Function]}
+                      >
+                        <button
+                          aria-label="Open menu"
+                          className="bx--header__action bx--header__menu-trigger bx--header__menu-toggle bx--header__menu-toggle__hidden"
+                          data-autoid="dds--masthead__hamburger"
+                          onClick={[Function]}
+                          title="Open menu"
+                          type="button"
+                        >
+                          <ForwardRef(Menu20)>
+                            <Icon
+                              fill="currentColor"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 20 20"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M2 14.8H18V16H2zM2 11.2H18V12.399999999999999H2zM2 7.6H18V8.799999999999999H2zM2 4H18V5.2H2z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(Menu20)>
+                        </button>
+                      </HeaderMenuButton>
+                      <IbmLogo>
+                        <div
+                          className="bx--header__logo"
+                          data-autoid="dds--masthead-logo"
+                        >
+                          <a
+                            aria-label="IBM®"
+                            data-autoid="dds--masthead-logo__link"
+                            href="https://www.ibm.com/"
+                          >
+                            <MastheadLogo
+                              height="23"
+                              viewBox="0 0 58 23"
+                              width="58"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                height="23"
+                                viewBox="0 0 58 23"
+                                width="58"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M58 21.467V23h-7.632v-1.533H58zm-18.316 0V23h-7.631v-1.533h7.631zm5.955 0L45.025 23l-.606-1.533h1.22zm-17.097 0A6.285 6.285 0 0 1 24.391 23H12.21v-1.533zm-17.858 0V23H0v-1.533h10.684zm29-3.067v1.533h-7.631V18.4h7.631zm7.148 0l-.594 1.533H43.82l-.598-1.533h3.609zm-16.764 0a5.719 5.719 0 0 1-.64 1.533H12.21V18.4zm-19.384 0v1.533H0V18.4h10.684zM58 18.4v1.533h-7.632V18.4H58zm-3.053-3.067v1.534h-4.579v-1.534h4.58zm-15.263 0v1.534h-4.579v-1.534h4.58zm8.345 0l-.6 1.534h-4.806l-.604-1.534h6.01zm-18.174 0c.137.49.213 1.003.213 1.534h-5.647v-1.534zm-10.013 0v1.534h-4.579v-1.534h4.58zm-12.21 0v1.534h-4.58v-1.534h4.58zm47.315-3.066V13.8h-4.579v-1.533h4.58zm-15.263 0V13.8h-4.579v-1.533h4.58zm9.541 0l-.597 1.533h-7.22l-.591-1.533h8.408zm-21.248 0c.527.432.98.951 1.328 1.533H15.263v-1.533zm-20.345 0V13.8h-4.58v-1.533h4.58zM44.599 9.2l.427 1.24.428-1.24h9.493v1.533h-4.579V9.324l-.519 1.41h-9.661l-.504-1.41v1.41h-4.579V9.2H44.6zm-36.967 0v1.533h-4.58V9.2h4.58zm21.673 0a5.95 5.95 0 0 1-1.328 1.533H15.263V9.2zm25.642-3.067v1.534h-8.964l.54-1.534h8.424zm-11.413 0l.54 1.534h-8.969V6.133h8.43zm-13.466 0c0 .531-.076 1.045-.213 1.534H24.42V6.133zm-10.226 0v1.534h-4.579V6.133h4.58zm-12.21 0v1.534h-4.58V6.133h4.58zm34.845-3.066l.53 1.533H32.054V3.067h10.424zm15.523 0V4.6H47.04l.55-1.533H58zm-28.573 0c.284.473.504.988.641 1.533H12.211V3.067zm-18.743 0V4.6H0V3.067h10.684zM41.406 0l.54 1.533h-9.893V0h9.353zM58 0v1.533h-9.881L48.647 0H58zM24.39 0c1.601 0 3.057.581 4.152 1.533H12.211V0zM10.685 0v1.533H0V0h10.684z"
+                                  fill="#161616"
+                                  fillRule="evenodd"
+                                />
+                              </svg>
+                            </MastheadLogo>
+                          </a>
+                        </div>
+                      </IbmLogo>
+                      <div
+                        className="bx--header__search "
+                      >
+                        <MastheadSearch
+                          placeHolderText="Search all of IBM"
+                          renderValue={3}
+                          searchOpenOnload={false}
+                        >
+                          <div
+                            className="bx--masthead__search"
+                            data-autoid="dds--masthead__search"
+                          >
+                            <div
+                              className="bx--header__search--actions"
+                            >
+                              <HeaderGlobalAction
+                                aria-label="Open IBM search field"
+                                className="bx--header__search--search"
+                                data-autoid="dds--header__search--search"
+                                onClick={[Function]}
+                                tabIndex="0"
+                              >
+                                <button
+                                  aria-label="Open IBM search field"
+                                  className="bx--header__search--search bx--header__action"
+                                  data-autoid="dds--header__search--search"
+                                  onClick={[Function]}
+                                  tabIndex="0"
+                                  type="button"
+                                >
+                                  <ForwardRef(Search20)>
+                                    <Icon
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(Search20)>
+                                </button>
+                              </HeaderGlobalAction>
+                              <HeaderGlobalAction
+                                aria-label="Close"
+                                className="bx--header__search--close"
+                                data-autoid="dds--header__search--close"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  aria-label="Close"
+                                  className="bx--header__search--close bx--header__action"
+                                  data-autoid="dds--header__search--close"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <ForwardRef(Close20)>
+                                    <Icon
+                                      fill="currentColor"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                        />
+                                      </svg>
+                                    </Icon>
+                                  </ForwardRef(Close20)>
+                                </button>
+                              </HeaderGlobalAction>
+                            </div>
+                          </div>
+                        </MastheadSearch>
+                      </div>
+                      <HeaderGlobalBar>
+                        <div
+                          className="bx--header__global"
+                        >
+                          <MastheadProfile
+                            overflowMenuItemProps={
+                              Object {
+                                "wrapperClassName": "bx--masthead__profile-item",
+                              }
+                            }
+                            overflowMenuProps={
+                              Object {
+                                "ariaLabel": "User Profile",
+                                "data-autoid": "dds--masthead__profile",
+                                "flipped": true,
+                                "onOpen": [Function],
+                                "renderIcon": [Function],
+                                "style": Object {
+                                  "width": "3rem",
+                                },
+                              }
+                            }
+                            profileMenu={Array []}
+                          >
+                            <ForwardRef(OverflowMenu)
+                              ariaLabel="User Profile"
+                              className="bx--header__action"
+                              data-autoid="dds--masthead__profile"
+                              flipped={true}
+                              onOpen={[Function]}
+                              renderIcon={[Function]}
+                              style={
+                                Object {
+                                  "width": "3rem",
+                                }
+                              }
+                            >
+                              <OverflowMenu
+                                ariaLabel="User Profile"
+                                className="bx--header__action"
+                                data-autoid="dds--masthead__profile"
+                                direction="bottom"
+                                flipped={true}
+                                iconDescription="open and close list of options"
+                                innerRef={null}
+                                light={false}
+                                menuOffset={[Function]}
+                                menuOffsetFlip={[Function]}
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                onOpen={[Function]}
+                                open={false}
+                                renderIcon={[Function]}
+                                selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+                                style={
+                                  Object {
+                                    "width": "3rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <ClickListener
+                                  onClickOutside={[Function]}
+                                >
+                                  <button
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    aria-label="User Profile"
+                                    className="bx--header__action bx--overflow-menu"
+                                    data-autoid="dds--masthead__profile"
+                                    onClick={[Function]}
+                                    onClose={[Function]}
+                                    onKeyDown={[Function]}
+                                    open={false}
+                                    style={
+                                      Object {
+                                        "width": "3rem",
+                                      }
+                                    }
+                                    tabIndex={0}
+                                  >
+                                    <renderIcon
+                                      aria-label="open and close list of options"
+                                      className="bx--overflow-menu__icon"
+                                      focusable="false"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                    >
+                                      <ForwardRef(User20)>
+                                        <Icon
+                                          fill="currentColor"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M16 4a5 5 0 11-5 5 5 5 0 015-5m0-2a7 7 0 107 7A7 7 0 0016 2zM26 30H24V25a5 5 0 00-5-5H13a5 5 0 00-5 5v5H6V25a7 7 0 017-7h6a7 7 0 017 7z"
+                                            />
+                                          </svg>
+                                        </Icon>
+                                      </ForwardRef(User20)>
+                                    </renderIcon>
+                                  </button>
+                                </ClickListener>
+                              </OverflowMenu>
+                            </ForwardRef(OverflowMenu)>
+                          </MastheadProfile>
+                        </div>
+                      </HeaderGlobalBar>
+                      <MastheadLeftNav
+                        isSideNavExpanded={false}
+                        navigation={
+                          Array [
+                            Object {
+                              "hasMegapanel": true,
+                              "hasMenu": true,
+                              "menuSections": Array [
+                                Object {
+                                  "heading": "Explore",
+                                  "menuItems": Array [
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "",
+                                        "feature": Object {
+                                          "heading": "",
+                                          "imageUrl": "",
+                                          "linkTitle": "",
+                                          "linkUrl": "",
+                                        },
+                                        "headingTitle": "",
+                                        "headingUrl": "",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Subnav 1",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 2",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 3",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 4",
+                                              "url": "",
+                                            },
+                                          ],
+                                          "title": "Title",
+                                        },
+                                      },
+                                      "title": "Link 1",
+                                      "url": "",
+                                    },
+                                  ],
+                                },
+                              ],
+                              "title": "Link 1",
+                              "url": "",
+                            },
+                            Object {
+                              "hasMegapanel": true,
+                              "hasMenu": true,
+                              "menuSections": Array [
+                                Object {
+                                  "heading": "",
+                                  "menuItems": Array [
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                                        "feature": Object {
+                                          "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                                          "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                                          "linkTitle": "Explore all our business consulting and technology services",
+                                          "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                        },
+                                        "headingTitle": "Services",
+                                        "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Subnav 1",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 2",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 3",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 4",
+                                              "url": "",
+                                            },
+                                          ],
+                                          "title": "Quicklinks",
+                                        },
+                                      },
+                                      "title": "Link 2",
+                                      "url": "",
+                                    },
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "Funding options that fit your business",
+                                        "feature": Object {
+                                          "heading": "Cloud financing strategies that work for your business",
+                                          "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                                          "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                                          "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                                        },
+                                        "headingTitle": "Financing",
+                                        "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Subnav 1",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 2",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 3",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 4",
+                                              "url": "",
+                                            },
+                                          ],
+                                          "title": "Quicklinks",
+                                        },
+                                      },
+                                      "title": "Financing",
+                                      "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                    },
+                                  ],
+                                },
+                              ],
+                              "title": "Link 2",
+                              "url": "",
+                            },
+                            Object {
+                              "hasMegapanel": false,
+                              "hasMenu": false,
+                              "menuSections": Array [],
+                              "title": "Industries",
+                              "url": "https://www.ibm.com/industries?lnk=min",
+                            },
+                            Object {
+                              "hasMegapanel": true,
+                              "hasMenu": true,
+                              "menuSections": Array [
+                                Object {
+                                  "heading": "",
+                                  "menuItems": Array [
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "",
+                                        "feature": Object {
+                                          "heading": "IBM Developer newsletters",
+                                          "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                                          "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                                          "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        "headingTitle": "IBM Developer",
+                                        "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Subnav 1",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 2",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 3",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 4",
+                                              "url": "",
+                                            },
+                                          ],
+                                          "title": "Quicklinks",
+                                        },
+                                      },
+                                      "title": "IBM Developer",
+                                      "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "",
+                                        "feature": Object {
+                                          "heading": "Blockchain 101",
+                                          "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                                          "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                                          "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        "headingTitle": "Blockchain",
+                                        "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Subnav 1",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 2",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 3",
+                                              "url": "",
+                                            },
+                                            Object {
+                                              "title": "Subnav 4",
+                                              "url": "",
+                                            },
+                                          ],
+                                          "title": "Quicklinks",
+                                        },
+                                      },
+                                      "title": "Blockchain",
+                                      "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "",
+                                        "feature": Object {
+                                          "heading": "Make sense of Kubernetes",
+                                          "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                                          "linkTitle": "Deploy a simple Python application with Kubernetes",
+                                          "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        "headingTitle": "Containers",
+                                        "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Code patterns",
+                                              "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                            Object {
+                                              "title": "Tutorials",
+                                              "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                            Object {
+                                              "title": "Events",
+                                              "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                          ],
+                                          "title": "Quicklinks",
+                                        },
+                                      },
+                                      "title": "Containers",
+                                      "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    Object {
+                                      "megapanelContent": Object {
+                                        "description": "",
+                                        "feature": Object {
+                                          "heading": "Train your data no matter where it lives",
+                                          "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                                          "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                                          "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        "headingTitle": "Analytics",
+                                        "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                        "quickLinks": Object {
+                                          "links": Array [
+                                            Object {
+                                              "title": "Code patterns",
+                                              "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                            Object {
+                                              "title": "Tutorials",
+                                              "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                            Object {
+                                              "title": "Events",
+                                              "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                            Object {
+                                              "title": "Developer community",
+                                              "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                            },
+                                          ],
+                                          "title": "Quicklinks",
+                                        },
+                                      },
+                                      "title": "Analytics",
+                                      "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                  ],
+                                },
+                              ],
+                              "title": "Link 3",
+                              "url": "",
+                            },
+                            Object {
+                              "hasMegapanel": false,
+                              "hasMenu": false,
+                              "menuSections": Array [],
+                              "title": "Support",
+                              "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                            },
+                          ]
+                        }
+                        platform={null}
+                      >
+                        <ForwardRef(SideNav)
+                          addFocusListeners={true}
+                          addMouseListeners={true}
+                          aria-label="Side navigation"
+                          defaultExpanded={false}
+                          expanded={false}
+                          isChildOfHeader={true}
+                          isFixedNav={false}
+                          isPersistent={false}
+                          translateById={[Function]}
+                        >
+                          <div
+                            className="bx--side-nav__overlay"
+                          />
+                          <nav
+                            aria-label="Side navigation"
+                            className="bx--side-nav__navigation bx--side-nav bx--side-nav--ux bx--side-nav--hidden"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                          >
+                            <nav
+                              data-autoid="dds--masthead__l0-sidenav"
+                            >
+                              <SideNavItems>
+                                <ul
+                                  className="bx--side-nav__items"
+                                >
+                                  <HeaderSideNavItems
+                                    hasDivider={false}
+                                    key=".0"
+                                  >
+                                    <div
+                                      className="bx--side-nav__header-navigation"
+                                    >
+                                      <ForwardRef
+                                        key="0"
+                                        title="Link 1"
+                                      >
+                                        <SideNavMenu
+                                          buttonRef={null}
+                                          defaultExpanded={false}
+                                          isActive={false}
+                                          large={false}
+                                          title="Link 1"
+                                        >
+                                          <li
+                                            className="bx--side-nav__item"
+                                          >
+                                            <button
+                                              aria-expanded={false}
+                                              aria-haspopup="true"
+                                              className="bx--side-nav__submenu"
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="bx--side-nav__submenu-title"
+                                              >
+                                                Link 1
+                                              </span>
+                                              <SideNavIcon
+                                                className="bx--side-nav__submenu-chevron"
+                                                small={true}
+                                              >
+                                                <div
+                                                  className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+                                                >
+                                                  <ForwardRef(ChevronDown20)>
+                                                    <Icon
+                                                      fill="currentColor"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 32 32"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        fill="currentColor"
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 32 32"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ChevronDown20)>
+                                                </div>
+                                              </SideNavIcon>
+                                            </button>
+                                            <ul
+                                              className="bx--side-nav__menu"
+                                              role="menu"
+                                            >
+                                              <ForwardRef(SideNavMenuItem)
+                                                className="bx--masthead__side-nav--submemu-back"
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-back-0"
+                                                isbackbutton="true"
+                                                key=".$0"
+                                                onClick={[Function]}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item bx--masthead__side-nav--submemu-back"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-back-0"
+                                                    element="a"
+                                                    isbackbutton="true"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-back-0"
+                                                      isbackbutton="true"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          <ForwardRef(ArrowLeft16)>
+                                                            <Icon
+                                                              fill="currentColor"
+                                                              height={16}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                fill="currentColor"
+                                                                focusable="false"
+                                                                height={16}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 16 16"
+                                                                width={16}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowLeft16)>
+                                                          Back
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <li
+                                                className="bx--masthead__side-nav--submemu-title"
+                                                key=".1"
+                                                onClick={null}
+                                              >
+                                                Link 1
+                                              </li>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                href=""
+                                                key=".2:$Link 1"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                    element="a"
+                                                    href=""
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                      href=""
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          Link 1
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                            </ul>
+                                          </li>
+                                        </SideNavMenu>
+                                      </ForwardRef>
+                                      <ForwardRef
+                                        key="1"
+                                        title="Link 2"
+                                      >
+                                        <SideNavMenu
+                                          buttonRef={null}
+                                          defaultExpanded={false}
+                                          isActive={false}
+                                          large={false}
+                                          title="Link 2"
+                                        >
+                                          <li
+                                            className="bx--side-nav__item"
+                                          >
+                                            <button
+                                              aria-expanded={false}
+                                              aria-haspopup="true"
+                                              className="bx--side-nav__submenu"
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="bx--side-nav__submenu-title"
+                                              >
+                                                Link 2
+                                              </span>
+                                              <SideNavIcon
+                                                className="bx--side-nav__submenu-chevron"
+                                                small={true}
+                                              >
+                                                <div
+                                                  className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+                                                >
+                                                  <ForwardRef(ChevronDown20)>
+                                                    <Icon
+                                                      fill="currentColor"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 32 32"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        fill="currentColor"
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 32 32"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ChevronDown20)>
+                                                </div>
+                                              </SideNavIcon>
+                                            </button>
+                                            <ul
+                                              className="bx--side-nav__menu"
+                                              role="menu"
+                                            >
+                                              <ForwardRef(SideNavMenuItem)
+                                                className="bx--masthead__side-nav--submemu-back"
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-back-1"
+                                                isbackbutton="true"
+                                                key=".$1"
+                                                onClick={[Function]}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item bx--masthead__side-nav--submemu-back"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-back-1"
+                                                    element="a"
+                                                    isbackbutton="true"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-back-1"
+                                                      isbackbutton="true"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          <ForwardRef(ArrowLeft16)>
+                                                            <Icon
+                                                              fill="currentColor"
+                                                              height={16}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                fill="currentColor"
+                                                                focusable="false"
+                                                                height={16}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 16 16"
+                                                                width={16}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowLeft16)>
+                                                          Back
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <li
+                                                className="bx--masthead__side-nav--submemu-title"
+                                                key=".1"
+                                                onClick={null}
+                                              >
+                                                Link 2
+                                              </li>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                href=""
+                                                key=".2:$Link 2"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                    element="a"
+                                                    href=""
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                      href=""
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          Link 2
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                                key=".2:$Financing"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                    element="a"
+                                                    href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                      href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          Financing
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                            </ul>
+                                          </li>
+                                        </SideNavMenu>
+                                      </ForwardRef>
+                                      <SideNavLink
+                                        data-autoid="dds--masthead__l0-sidenav--nav-2"
+                                        element="a"
+                                        href="https://www.ibm.com/industries?lnk=min"
+                                        key="2"
+                                        large={false}
+                                      >
+                                        <SideNavItem
+                                          large={false}
+                                        >
+                                          <li
+                                            className="bx--side-nav__item"
+                                          >
+                                            <Link
+                                              className="bx--side-nav__link"
+                                              data-autoid="dds--masthead__l0-sidenav--nav-2"
+                                              element="a"
+                                              href="https://www.ibm.com/industries?lnk=min"
+                                            >
+                                              <a
+                                                className="bx--side-nav__link"
+                                                data-autoid="dds--masthead__l0-sidenav--nav-2"
+                                                href="https://www.ibm.com/industries?lnk=min"
+                                              >
+                                                <SideNavLinkText>
+                                                  <span
+                                                    className="bx--side-nav__link-text"
+                                                  >
+                                                    Industries
+                                                  </span>
+                                                </SideNavLinkText>
+                                              </a>
+                                            </Link>
+                                          </li>
+                                        </SideNavItem>
+                                      </SideNavLink>
+                                      <ForwardRef
+                                        key="3"
+                                        title="Link 3"
+                                      >
+                                        <SideNavMenu
+                                          buttonRef={null}
+                                          defaultExpanded={false}
+                                          isActive={false}
+                                          large={false}
+                                          title="Link 3"
+                                        >
+                                          <li
+                                            className="bx--side-nav__item"
+                                          >
+                                            <button
+                                              aria-expanded={false}
+                                              aria-haspopup="true"
+                                              className="bx--side-nav__submenu"
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="bx--side-nav__submenu-title"
+                                              >
+                                                Link 3
+                                              </span>
+                                              <SideNavIcon
+                                                className="bx--side-nav__submenu-chevron"
+                                                small={true}
+                                              >
+                                                <div
+                                                  className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+                                                >
+                                                  <ForwardRef(ChevronDown20)>
+                                                    <Icon
+                                                      fill="currentColor"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 32 32"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        fill="currentColor"
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 32 32"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ChevronDown20)>
+                                                </div>
+                                              </SideNavIcon>
+                                            </button>
+                                            <ul
+                                              className="bx--side-nav__menu"
+                                              role="menu"
+                                            >
+                                              <ForwardRef(SideNavMenuItem)
+                                                className="bx--masthead__side-nav--submemu-back"
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-back-3"
+                                                isbackbutton="true"
+                                                key=".$3"
+                                                onClick={[Function]}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item bx--masthead__side-nav--submemu-back"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-back-3"
+                                                    element="a"
+                                                    isbackbutton="true"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-back-3"
+                                                      isbackbutton="true"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          <ForwardRef(ArrowLeft16)>
+                                                            <Icon
+                                                              fill="currentColor"
+                                                              height={16}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                fill="currentColor"
+                                                                focusable="false"
+                                                                height={16}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 16 16"
+                                                                width={16}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowLeft16)>
+                                                          Back
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <li
+                                                className="bx--masthead__side-nav--submemu-title"
+                                                key=".1"
+                                                onClick={null}
+                                              >
+                                                Link 3
+                                              </li>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                                key=".2:$IBM Developer"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                    element="a"
+                                                    href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                      href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          IBM Developer
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                                key=".2:$Blockchain"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                    element="a"
+                                                    href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                      href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          Blockchain
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item2"
+                                                href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                                key=".2:$Containers"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item2"
+                                                    element="a"
+                                                    href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item2"
+                                                      href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          Containers
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                              <ForwardRef(SideNavMenuItem)
+                                                data-autoid="dds--masthead__l0-sidenav--subnav-col0-item3"
+                                                href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                                key=".2:$Analytics"
+                                                onClick={null}
+                                              >
+                                                <li
+                                                  className="bx--side-nav__menu-item"
+                                                  role="none"
+                                                >
+                                                  <Link
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item3"
+                                                    element="a"
+                                                    href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <a
+                                                      className="bx--side-nav__link"
+                                                      data-autoid="dds--masthead__l0-sidenav--subnav-col0-item3"
+                                                      href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                                      onClick={null}
+                                                      role="menuitem"
+                                                    >
+                                                      <SideNavLinkText>
+                                                        <span
+                                                          className="bx--side-nav__link-text"
+                                                        >
+                                                          Analytics
+                                                        </span>
+                                                      </SideNavLinkText>
+                                                    </a>
+                                                  </Link>
+                                                </li>
+                                              </ForwardRef(SideNavMenuItem)>
+                                            </ul>
+                                          </li>
+                                        </SideNavMenu>
+                                      </ForwardRef>
+                                      <SideNavLink
+                                        data-autoid="dds--masthead__l0-sidenav--nav-4"
+                                        element="a"
+                                        href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                        key="4"
+                                        large={false}
+                                      >
+                                        <SideNavItem
+                                          large={false}
+                                        >
+                                          <li
+                                            className="bx--side-nav__item"
+                                          >
+                                            <Link
+                                              className="bx--side-nav__link"
+                                              data-autoid="dds--masthead__l0-sidenav--nav-4"
+                                              element="a"
+                                              href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                            >
+                                              <a
+                                                className="bx--side-nav__link"
+                                                data-autoid="dds--masthead__l0-sidenav--nav-4"
+                                                href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                              >
+                                                <SideNavLinkText>
+                                                  <span
+                                                    className="bx--side-nav__link-text"
+                                                  >
+                                                    Support
+                                                  </span>
+                                                </SideNavLinkText>
+                                              </a>
+                                            </Link>
+                                          </li>
+                                        </SideNavItem>
+                                      </SideNavLink>
+                                    </div>
+                                  </HeaderSideNavItems>
+                                </ul>
+                              </SideNavItems>
+                            </nav>
+                          </nav>
+                        </ForwardRef(SideNav)>
+                      </MastheadLeftNav>
+                    </header>
+                  </Header>
+                </div>
+                <div>
+                  <MastheadL1
+                    eyebrowLink="#"
+                    eyebrowText="Eyebrow"
+                    isShort={false}
+                    navigationL1={
+                      Array [
+                        Object {
+                          "hasMegapanel": true,
+                          "hasMenu": true,
+                          "menuSections": Array [
+                            Object {
+                              "heading": "Explore",
+                              "menuItems": Array [
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "",
+                                    "feature": Object {
+                                      "heading": "",
+                                      "imageUrl": "",
+                                      "linkTitle": "",
+                                      "linkUrl": "",
+                                    },
+                                    "headingTitle": "",
+                                    "headingUrl": "",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Subnav 1",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 2",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 3",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 4",
+                                          "url": "",
+                                        },
+                                      ],
+                                      "title": "Title",
+                                    },
+                                  },
+                                  "title": "Link 1",
+                                  "url": "",
+                                },
+                              ],
+                            },
+                          ],
+                          "title": "Link 1",
+                          "url": "",
+                        },
+                        Object {
+                          "hasMegapanel": true,
+                          "hasMenu": true,
+                          "menuSections": Array [
+                            Object {
+                              "heading": "",
+                              "menuItems": Array [
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                                    "feature": Object {
+                                      "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                                      "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                                      "linkTitle": "Explore all our business consulting and technology services",
+                                      "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                    },
+                                    "headingTitle": "Services",
+                                    "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Subnav 1",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 2",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 3",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 4",
+                                          "url": "",
+                                        },
+                                      ],
+                                      "title": "Quicklinks",
+                                    },
+                                  },
+                                  "title": "Link 2",
+                                  "url": "",
+                                },
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "Funding options that fit your business",
+                                    "feature": Object {
+                                      "heading": "Cloud financing strategies that work for your business",
+                                      "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                                      "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                                      "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                                    },
+                                    "headingTitle": "Financing",
+                                    "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Subnav 1",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 2",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 3",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 4",
+                                          "url": "",
+                                        },
+                                      ],
+                                      "title": "Quicklinks",
+                                    },
+                                  },
+                                  "title": "Financing",
+                                  "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                },
+                              ],
+                            },
+                          ],
+                          "title": "Link 2",
+                          "url": "",
+                        },
+                        Object {
+                          "hasMegapanel": false,
+                          "hasMenu": false,
+                          "menuSections": Array [],
+                          "title": "Industries",
+                          "url": "https://www.ibm.com/industries?lnk=min",
+                        },
+                        Object {
+                          "hasMegapanel": true,
+                          "hasMenu": true,
+                          "menuSections": Array [
+                            Object {
+                              "heading": "",
+                              "menuItems": Array [
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "",
+                                    "feature": Object {
+                                      "heading": "IBM Developer newsletters",
+                                      "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                                      "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                                      "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    "headingTitle": "IBM Developer",
+                                    "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Subnav 1",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 2",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 3",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 4",
+                                          "url": "",
+                                        },
+                                      ],
+                                      "title": "Quicklinks",
+                                    },
+                                  },
+                                  "title": "IBM Developer",
+                                  "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "",
+                                    "feature": Object {
+                                      "heading": "Blockchain 101",
+                                      "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                                      "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                                      "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    "headingTitle": "Blockchain",
+                                    "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Subnav 1",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 2",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 3",
+                                          "url": "",
+                                        },
+                                        Object {
+                                          "title": "Subnav 4",
+                                          "url": "",
+                                        },
+                                      ],
+                                      "title": "Quicklinks",
+                                    },
+                                  },
+                                  "title": "Blockchain",
+                                  "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "",
+                                    "feature": Object {
+                                      "heading": "Make sense of Kubernetes",
+                                      "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                                      "linkTitle": "Deploy a simple Python application with Kubernetes",
+                                      "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    "headingTitle": "Containers",
+                                    "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Code patterns",
+                                          "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        Object {
+                                          "title": "Tutorials",
+                                          "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        Object {
+                                          "title": "Events",
+                                          "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                      ],
+                                      "title": "Quicklinks",
+                                    },
+                                  },
+                                  "title": "Containers",
+                                  "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                                Object {
+                                  "megapanelContent": Object {
+                                    "description": "",
+                                    "feature": Object {
+                                      "heading": "Train your data no matter where it lives",
+                                      "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                                      "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                                      "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                                    },
+                                    "headingTitle": "Analytics",
+                                    "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                    "quickLinks": Object {
+                                      "links": Array [
+                                        Object {
+                                          "title": "Code patterns",
+                                          "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        Object {
+                                          "title": "Tutorials",
+                                          "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        Object {
+                                          "title": "Events",
+                                          "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                        Object {
+                                          "title": "Developer community",
+                                          "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                        },
+                                      ],
+                                      "title": "Quicklinks",
+                                    },
+                                  },
+                                  "title": "Analytics",
+                                  "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                },
+                              ],
+                            },
+                          ],
+                          "title": "Link 3",
+                          "url": "",
+                        },
+                        Object {
+                          "hasMegapanel": false,
+                          "hasMenu": false,
+                          "menuSections": Array [],
+                          "title": "Support",
+                          "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                        },
+                      ]
+                    }
+                    title="Stock Charts"
+                    titleLink="https://www.example.com"
+                  >
+                    <div
+                      className="bx--masthead__l1"
+                    >
+                      <div
+                        className="bx--masthead__l1-name"
+                      >
+                        <span
+                          className="bx--masthead__l1-name-eyebrow"
+                        >
+                          <ForwardRef(ArrowLeft16)>
+                            <Icon
+                              fill="currentColor"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="currentColor"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                />
+                              </svg>
+                            </Icon>
+                          </ForwardRef(ArrowLeft16)>
+                          <a
+                            href="#"
+                          >
+                            Eyebrow
+                          </a>
+                        </span>
+                        <span
+                          className="bx--masthead__l1-name-title"
+                        >
+                          <a
+                            href="https://www.example.com"
+                          >
+                            Stock Charts
+                          </a>
+                        </span>
+                      </div>
+                      <HeaderNavigation
+                        aria-label=""
+                        className="bx--masthead__l1-nav"
+                      >
+                        <nav
+                          aria-label=""
+                          className="bx--header__nav bx--masthead__l1-nav"
+                        >
+                          <ul
+                            aria-label=""
+                            className="bx--header__menu-bar"
+                            role="menubar"
+                          >
+                            <ForwardRef
+                              aria-label="Link 1"
+                              data-autoid="dds--masthead__l0-nav--nav-0"
+                              key=".$0"
+                              menuLinkName="Link 1"
+                            >
+                              <HeaderMenu
+                                aria-label="Link 1"
+                                data-autoid="dds--masthead__l0-nav--nav-0"
+                                focusRef={[Function]}
+                                menuLinkName="Link 1"
+                                renderMenuContent={[Function]}
+                              >
+                                <li
+                                  className="bx--header__submenu"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                >
+                                  <a
+                                    aria-expanded={false}
+                                    aria-haspopup="menu"
+                                    aria-label="Link 1"
+                                    className="bx--header__menu-item bx--header__menu-title"
+                                    href="#"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="menuitem"
+                                    tabIndex={0}
+                                  >
+                                    Link 1
+                                    <defaultRenderMenuContent>
+                                      <ForwardRef(ChevronDown20)
+                                        className="bx--header__menu-arrow"
+                                      >
+                                        <Icon
+                                          className="bx--header__menu-arrow"
+                                          fill="currentColor"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="bx--header__menu-arrow"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                            />
+                                          </svg>
+                                        </Icon>
+                                      </ForwardRef(ChevronDown20)>
+                                    </defaultRenderMenuContent>
+                                  </a>
+                                  <ul
+                                    aria-label="Link 1"
+                                    className="bx--header__menu"
+                                    role="menu"
+                                  >
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                      href=""
+                                      key=".$Link 1"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                          element="a"
+                                          href=""
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                            href=""
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              Link 1
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                  </ul>
+                                </li>
+                              </HeaderMenu>
+                            </ForwardRef>
+                            <ForwardRef
+                              aria-label="Link 2"
+                              data-autoid="dds--masthead__l0-nav--nav-1"
+                              key=".$1"
+                              menuLinkName="Link 2"
+                            >
+                              <HeaderMenu
+                                aria-label="Link 2"
+                                data-autoid="dds--masthead__l0-nav--nav-1"
+                                focusRef={[Function]}
+                                menuLinkName="Link 2"
+                                renderMenuContent={[Function]}
+                              >
+                                <li
+                                  className="bx--header__submenu"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                >
+                                  <a
+                                    aria-expanded={false}
+                                    aria-haspopup="menu"
+                                    aria-label="Link 2"
+                                    className="bx--header__menu-item bx--header__menu-title"
+                                    href="#"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="menuitem"
+                                    tabIndex={0}
+                                  >
+                                    Link 2
+                                    <defaultRenderMenuContent>
+                                      <ForwardRef(ChevronDown20)
+                                        className="bx--header__menu-arrow"
+                                      >
+                                        <Icon
+                                          className="bx--header__menu-arrow"
+                                          fill="currentColor"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="bx--header__menu-arrow"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                            />
+                                          </svg>
+                                        </Icon>
+                                      </ForwardRef(ChevronDown20)>
+                                    </defaultRenderMenuContent>
+                                  </a>
+                                  <ul
+                                    aria-label="Link 2"
+                                    className="bx--header__menu"
+                                    role="menu"
+                                  >
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                      href=""
+                                      key=".$Link 2"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                          element="a"
+                                          href=""
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                            href=""
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              Link 2
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                      href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                      key=".$Financing"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                          element="a"
+                                          href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                            href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              Financing
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                  </ul>
+                                </li>
+                              </HeaderMenu>
+                            </ForwardRef>
+                            <ForwardRef(HeaderMenuItem)
+                              data-autoid="dds--masthead__l1-nav--nav-2"
+                              href="https://www.ibm.com/industries?lnk=min"
+                              key=".$2"
+                            >
+                              <li>
+                                <Link
+                                  className="bx--header__menu-item"
+                                  data-autoid="dds--masthead__l1-nav--nav-2"
+                                  element="a"
+                                  href="https://www.ibm.com/industries?lnk=min"
+                                  tabIndex={0}
+                                >
+                                  <a
+                                    className="bx--header__menu-item"
+                                    data-autoid="dds--masthead__l1-nav--nav-2"
+                                    href="https://www.ibm.com/industries?lnk=min"
+                                    tabIndex={0}
+                                  >
+                                    <span
+                                      className="bx--text-truncate--end"
+                                    >
+                                      Industries
+                                    </span>
+                                  </a>
+                                </Link>
+                              </li>
+                            </ForwardRef(HeaderMenuItem)>
+                            <ForwardRef
+                              aria-label="Link 3"
+                              data-autoid="dds--masthead__l0-nav--nav-3"
+                              key=".$3"
+                              menuLinkName="Link 3"
+                            >
+                              <HeaderMenu
+                                aria-label="Link 3"
+                                data-autoid="dds--masthead__l0-nav--nav-3"
+                                focusRef={[Function]}
+                                menuLinkName="Link 3"
+                                renderMenuContent={[Function]}
+                              >
+                                <li
+                                  className="bx--header__submenu"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                >
+                                  <a
+                                    aria-expanded={false}
+                                    aria-haspopup="menu"
+                                    aria-label="Link 3"
+                                    className="bx--header__menu-item bx--header__menu-title"
+                                    href="#"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="menuitem"
+                                    tabIndex={0}
+                                  >
+                                    Link 3
+                                    <defaultRenderMenuContent>
+                                      <ForwardRef(ChevronDown20)
+                                        className="bx--header__menu-arrow"
+                                      >
+                                        <Icon
+                                          className="bx--header__menu-arrow"
+                                          fill="currentColor"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="bx--header__menu-arrow"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                            />
+                                          </svg>
+                                        </Icon>
+                                      </ForwardRef(ChevronDown20)>
+                                    </defaultRenderMenuContent>
+                                  </a>
+                                  <ul
+                                    aria-label="Link 3"
+                                    className="bx--header__menu"
+                                    role="menu"
+                                  >
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                      href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                      key=".$IBM Developer"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                          element="a"
+                                          href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                            href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              IBM Developer
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                      href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                      key=".$Blockchain"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                          element="a"
+                                          href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                            href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              Blockchain
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item2"
+                                      href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                      key=".$Containers"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item2"
+                                          element="a"
+                                          href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item2"
+                                            href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              Containers
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                    <ForwardRef(HeaderMenuItem)
+                                      data-autoid="dds--masthead__l1-nav--subnav-col0-item3"
+                                      href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                      key=".$Analytics"
+                                      role="none"
+                                    >
+                                      <li
+                                        role="none"
+                                      >
+                                        <Link
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item3"
+                                          element="a"
+                                          href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <a
+                                            className="bx--header__menu-item"
+                                            data-autoid="dds--masthead__l1-nav--subnav-col0-item3"
+                                            href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                            tabIndex={0}
+                                          >
+                                            <span
+                                              className="bx--text-truncate--end"
+                                            >
+                                              Analytics
+                                            </span>
+                                          </a>
+                                        </Link>
+                                      </li>
+                                    </ForwardRef(HeaderMenuItem)>
+                                  </ul>
+                                </li>
+                              </HeaderMenu>
+                            </ForwardRef>
+                            <ForwardRef(HeaderMenuItem)
+                              data-autoid="dds--masthead__l1-nav--nav-4"
+                              href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                              key=".$4"
+                            >
+                              <li>
+                                <Link
+                                  className="bx--header__menu-item"
+                                  data-autoid="dds--masthead__l1-nav--nav-4"
+                                  element="a"
+                                  href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                  tabIndex={0}
+                                >
+                                  <a
+                                    className="bx--header__menu-item"
+                                    data-autoid="dds--masthead__l1-nav--nav-4"
+                                    href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                    tabIndex={0}
+                                  >
+                                    <span
+                                      className="bx--text-truncate--end"
+                                    >
+                                      Support
+                                    </span>
+                                  </a>
+                                </Link>
+                              </li>
+                            </ForwardRef(HeaderMenuItem)>
+                          </ul>
+                        </nav>
+                      </HeaderNavigation>
+                    </div>
+                  </MastheadL1>
+                </div>
+              </div>
+            </render>
+          </HeaderContainer>
+        </Masthead>
+        <div
+          className="bx--dotcom-shell"
+          data-autoid="dds--dotcom-shell"
+        >
+          <div
+            className="bx--dotcom-shell__content"
+            data-autoid="dds--dotcom-shell__content"
+          >
+            <main
+              id="main-content"
+            >
+              <div
+                style={
+                  Object {
+                    "paddingTop": "6rem",
+                  }
+                }
+              >
+                <Content>
+                  <TableOfContents
+                    menuItems={null}
+                    menuLabel="Jump to"
+                    stickyOffset={null}
+                    theme="white"
+                  >
+                    <section
+                      className="bx--tableofcontents bx--tableofcontents--white"
+                      data-autoid="dds--tableofcontents"
+                    >
+                      <Layout
+                        border={false}
+                        marginBottom={null}
+                        marginTop={null}
+                        nested={false}
+                        stickyOffset={null}
+                        type="1-3"
+                      >
+                        <section
+                          className="bx--grid"
+                          data-autoid="dds--layout"
+                        >
+                          <div
+                            className="bx--row"
+                          >
+                            <div
+                              className="bx--tableofcontents__sidebar bx--col-lg-4"
+                              key="0"
+                            >
+                              <div
+                                className="bx--tableofcontents__mobile-top"
+                              />
+                              <div
+                                style={
+                                  Object {
+                                    "position": "sticky",
+                                    "top": "0",
+                                  }
+                                }
+                              >
+                                <TOCDesktop
+                                  menuItems={
+                                    Array [
+                                      Object {
+                                        "id": "menuLabel",
+                                        "title": "Jump to ...",
+                                      },
+                                    ]
+                                  }
+                                  menuLabel="Jump to"
+                                  selectedId=""
+                                  selectedTitle=""
+                                  updateState={[Function]}
+                                >
+                                  <div
+                                    className="bx--tableofcontents__desktop"
+                                    data-autoid="dds--tableofcontents__desktop"
+                                  >
+                                    <ul />
+                                  </div>
+                                </TOCDesktop>
+                                <TOCMobile
+                                  menuItems={
+                                    Array [
+                                      Object {
+                                        "id": "menuLabel",
+                                        "title": "Jump to ...",
+                                      },
+                                    ]
+                                  }
+                                  menuLabel="Jump to"
+                                  selectedId=""
+                                  selectedTitle=""
+                                  updateState={[Function]}
+                                >
+                                  <div
+                                    className="bx--tableofcontents__mobile"
+                                    data-autoid="dds--tableofcontents__mobile"
+                                  >
+                                    <div
+                                      className="bx--tableofcontents__mobile__select__wrapper"
+                                    >
+                                      <select
+                                        className="bx--tableofcontents__mobile__select"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        value=""
+                                      >
+                                        <option
+                                          className="bx--tableofcontents__mobile__select__option"
+                                          data-autoid="dds}--tableofcontents__mobile__select__option-menuLabel"
+                                          disabled={true}
+                                          hidden={true}
+                                          key="0"
+                                          selected={true}
+                                          value="menuLabel"
+                                        >
+                                          Jump to ...
+                                        </option>
+                                      </select>
+                                      <ForwardRef(TableOfContents20)
+                                        aria-label="menu icon"
+                                        className="bx--tableofcontents__mobile__select__icon"
+                                      >
+                                        <Icon
+                                          aria-label="menu icon"
+                                          className="bx--tableofcontents__mobile__select__icon"
+                                          fill="currentColor"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <svg
+                                            aria-label="menu icon"
+                                            className="bx--tableofcontents__mobile__select__icon"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height={20}
+                                            preserveAspectRatio="xMidYMid meet"
+                                            role="img"
+                                            viewBox="0 0 32 32"
+                                            width={20}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M4 6H22V8H4zM4 12H22V14H4zM4 18H22V20H4zM4 24H22V26H4zM26 6H28V8H26zM26 12H28V14H26zM26 18H28V20H26zM26 24H28V26H26z"
+                                            />
+                                            <title>
+                                              menu icon
+                                            </title>
+                                          </svg>
+                                        </Icon>
+                                      </ForwardRef(TableOfContents20)>
+                                    </div>
+                                  </div>
+                                </TOCMobile>
+                              </div>
+                            </div>
+                            <div
+                              className="bx--tableofcontents__content bx--col-lg-12"
+                              key="1"
+                            >
+                              <div
+                                className="bx--tableofcontents__content-wrapper"
+                              >
+                                <a
+                                  data-title="Lorem ipsum dolor sit amet"
+                                  name="section-1"
+                                />
+                                <Layout
+                                  border={false}
+                                  marginBottom={null}
+                                  marginTop={null}
+                                  nested={false}
+                                  stickyOffset={null}
+                                  type="2-1"
+                                >
+                                  <section
+                                    className="bx--grid"
+                                    data-autoid="dds--layout"
+                                  >
+                                    <div
+                                      className="bx--row"
+                                    >
+                                      <div
+                                        className="bx--layout-2-3"
+                                        key="0"
+                                      >
+                                        <LeadSpaceBlock
+                                          copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                                          cta={
+                                            Object {
+                                              "buttons": Array [
+                                                Object {
+                                                  "copy": "Excepteur sint occaecat",
+                                                  "href": "https://example.com/",
+                                                  "iconDescription": "right arrow icon",
+                                                  "onClick": [Function],
+                                                  "renderIcon": Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "render": [Function],
+                                                  },
+                                                  "target": null,
+                                                  "type": "local",
+                                                },
+                                              ],
+                                              "style": "button",
+                                              "type": "local",
+                                            }
+                                          }
+                                          heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
+                                          items={
+                                            Object {
+                                              "heading": "Featured products",
+                                              "items": Array [
+                                                Object {
+                                                  "copy": "IBM Cloud Continuous Delivery",
+                                                  "cta": Object {
+                                                    "href": "https://ibm.com",
+                                                  },
+                                                  "type": "local",
+                                                },
+                                                Object {
+                                                  "copy": "UrbanCode",
+                                                  "cta": Object {
+                                                    "href": "https://ibm.com",
+                                                  },
+                                                  "type": "local",
+                                                },
+                                                Object {
+                                                  "copy": "View all products",
+                                                  "cta": Object {
+                                                    "href": "https://ibm.com",
+                                                  },
+                                                  "type": "local",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          mediaData={
+                                            Object {
+                                              "showDescription": true,
+                                              "videoId": "0_uka1msg4",
+                                            }
+                                          }
+                                          mediaType="video"
+                                          title="Lorem ipsum dolor sit amet"
+                                        >
+                                          <div
+                                            className="bx--leadspace-block"
+                                            data-autoid="dds--leadspace-block"
+                                          >
+                                            <div>
+                                              <h1
+                                                className="bx--leadspace-block__title"
+                                                data-autoid="dds--leadspace-block__title"
+                                              >
+                                                Lorem ipsum dolor sit amet
+                                              </h1>
+                                            </div>
+                                            <ContentBlock
+                                              border={false}
+                                              copy="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                                              heading="Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut."
+                                            >
+                                              <div
+                                                className="bx--content-block"
+                                                data-autoid="dds--content-block"
+                                              >
+                                                <div>
+                                                  <h2
+                                                    className="bx--content-block__heading"
+                                                    data-autoid="dds--content-block__heading"
+                                                  >
+                                                    Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut.
+                                                  </h2>
+                                                </div>
+                                                <div
+                                                  className="bx--content-block__copy"
+                                                  dangerouslySetInnerHTML={
+                                                    Object {
+                                                      "__html": "<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p> ",
+                                                    }
+                                                  }
+                                                />
+                                                <div
+                                                  className="bx--content-block__children"
+                                                  data-autoid="dds--content-block__children"
+                                                >
+                                                  <div
+                                                    className="bx--leadspace-block__media"
+                                                    data-autoid="dds--leadspace-block__media"
+                                                  >
+                                                    <VideoPlayer
+                                                      autoPlay={false}
+                                                      showDescription={true}
+                                                      videoId="0_uka1msg4"
+                                                    >
+                                                      <div
+                                                        aria-label=" (1:00)"
+                                                        className="bx--video-player"
+                                                      >
+                                                        <div
+                                                          className="bx--video-player__video-container "
+                                                          data-autoid="dds--video-player__video-0_uka1msg4"
+                                                        >
+                                                          <div
+                                                            className="bx--video-player__video"
+                                                            id="bx--video-player__video-0_uka1msg4-62"
+                                                          >
+                                                            <VideoImageOverlay
+                                                              embedVideo={[Function]}
+                                                              videoData={
+                                                                Object {
+                                                                  "description": "",
+                                                                  "name": "",
+                                                                }
+                                                              }
+                                                              videoId="0_uka1msg4"
+                                                            >
+                                                              <button
+                                                                className="bx--video-player__image-overlay"
+                                                                data-autoid="dds--video-player__image-overlay"
+                                                                onClick={[Function]}
+                                                              >
+                                                                <Image
+                                                                  alt=""
+                                                                  defaultSrc="https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320"
+                                                                  icon={[Function]}
+                                                                />
+                                                              </button>
+                                                            </VideoImageOverlay>
+                                                          </div>
+                                                        </div>
+                                                      </div>
+                                                    </VideoPlayer>
+                                                  </div>
+                                                  <LinkList
+                                                    heading="Featured products"
+                                                    items={
+                                                      Array [
+                                                        Object {
+                                                          "copy": "IBM Cloud Continuous Delivery",
+                                                          "cta": Object {
+                                                            "href": "https://ibm.com",
+                                                          },
+                                                          "type": "local",
+                                                        },
+                                                        Object {
+                                                          "copy": "UrbanCode",
+                                                          "cta": Object {
+                                                            "href": "https://ibm.com",
+                                                          },
+                                                          "type": "local",
+                                                        },
+                                                        Object {
+                                                          "copy": "View all products",
+                                                          "cta": Object {
+                                                            "href": "https://ibm.com",
+                                                          },
+                                                          "type": "local",
+                                                        },
+                                                      ]
+                                                    }
+                                                    style="vertical-end"
+                                                  >
+                                                    <div
+                                                      className="bx--link-list"
+                                                      data-autoid="dds--link-list"
+                                                    >
+                                                      <h4
+                                                        className="bx--link-list__heading"
+                                                      >
+                                                        Featured products
+                                                      </h4>
+                                                      <ul
+                                                        className="bx--link-list__list bx--link-list__list--vertical-end"
+                                                      >
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                          key="0"
+                                                        >
+                                                          <CTA
+                                                            copy="IBM Cloud Continuous Delivery"
+                                                            cta={
+                                                              Object {
+                                                                "href": "https://ibm.com",
+                                                              }
+                                                            }
+                                                            disableImage={true}
+                                                            href=""
+                                                            style="text"
+                                                            type="local"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="IBM Cloud Continuous Delivery"
+                                                                cta={
+                                                                  Object {
+                                                                    "href": "https://ibm.com",
+                                                                  }
+                                                                }
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href=""
+                                                                iconPlacement="right"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="local"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://ibm.com"
+                                                                  iconPlacement="right"
+                                                                  onClick={[Function]}
+                                                                  target={null}
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://ibm.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://ibm.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <span>
+                                                                          IBM Cloud Continuous Delivery
+                                                                        </span>
+                                                                        <ForwardRef(ArrowRight20)>
+                                                                          <Icon
+                                                                            fill="currentColor"
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              fill="currentColor"
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(ArrowRight20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                          key="1"
+                                                        >
+                                                          <CTA
+                                                            copy="UrbanCode"
+                                                            cta={
+                                                              Object {
+                                                                "href": "https://ibm.com",
+                                                              }
+                                                            }
+                                                            disableImage={true}
+                                                            href=""
+                                                            style="text"
+                                                            type="local"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="UrbanCode"
+                                                                cta={
+                                                                  Object {
+                                                                    "href": "https://ibm.com",
+                                                                  }
+                                                                }
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href=""
+                                                                iconPlacement="right"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="local"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://ibm.com"
+                                                                  iconPlacement="right"
+                                                                  onClick={[Function]}
+                                                                  target={null}
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://ibm.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://ibm.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <span>
+                                                                          UrbanCode
+                                                                        </span>
+                                                                        <ForwardRef(ArrowRight20)>
+                                                                          <Icon
+                                                                            fill="currentColor"
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              fill="currentColor"
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(ArrowRight20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                        <li
+                                                          className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                          key="2"
+                                                        >
+                                                          <CTA
+                                                            copy="View all products"
+                                                            cta={
+                                                              Object {
+                                                                "href": "https://ibm.com",
+                                                              }
+                                                            }
+                                                            disableImage={true}
+                                                            href=""
+                                                            style="text"
+                                                            type="local"
+                                                          >
+                                                            <div>
+                                                              <TextCTA
+                                                                copy="View all products"
+                                                                cta={
+                                                                  Object {
+                                                                    "href": "https://ibm.com",
+                                                                  }
+                                                                }
+                                                                disableImage={true}
+                                                                formatCTAcopy={[Function]}
+                                                                href=""
+                                                                iconPlacement="right"
+                                                                openLightBox={[Function]}
+                                                                renderLightBox={false}
+                                                                style="text"
+                                                                type="local"
+                                                                videoTitle={
+                                                                  Array [
+                                                                    Object {
+                                                                      "duration": "",
+                                                                      "key": 0,
+                                                                      "title": "",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                              >
+                                                                <LinkWithIcon
+                                                                  href="https://ibm.com"
+                                                                  iconPlacement="right"
+                                                                  onClick={[Function]}
+                                                                  target={null}
+                                                                >
+                                                                  <div
+                                                                    className="bx--link-with-icon__container"
+                                                                    data-autoid="dds--link-with-icon"
+                                                                  >
+                                                                    <Link
+                                                                      className="bx--link-with-icon"
+                                                                      href="https://ibm.com"
+                                                                      onClick={[Function]}
+                                                                      target={null}
+                                                                    >
+                                                                      <a
+                                                                        className="bx--link bx--link-with-icon"
+                                                                        href="https://ibm.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <span>
+                                                                          View all products
+                                                                        </span>
+                                                                        <ForwardRef(ArrowRight20)>
+                                                                          <Icon
+                                                                            fill="currentColor"
+                                                                            height={20}
+                                                                            preserveAspectRatio="xMidYMid meet"
+                                                                            viewBox="0 0 20 20"
+                                                                            width={20}
+                                                                            xmlns="http://www.w3.org/2000/svg"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              fill="currentColor"
+                                                                              focusable="false"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <path
+                                                                                d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                              />
+                                                                            </svg>
+                                                                          </Icon>
+                                                                        </ForwardRef(ArrowRight20)>
+                                                                      </a>
+                                                                    </Link>
+                                                                  </div>
+                                                                </LinkWithIcon>
+                                                              </TextCTA>
+                                                            </div>
+                                                          </CTA>
+                                                        </li>
+                                                      </ul>
+                                                    </div>
+                                                  </LinkList>
+                                                  <CTA
+                                                    buttons={
+                                                      Array [
+                                                        Object {
+                                                          "copy": "Excepteur sint occaecat",
+                                                          "href": "https://example.com/",
+                                                          "iconDescription": "right arrow icon",
+                                                          "onClick": [Function],
+                                                          "renderIcon": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                          "target": null,
+                                                          "type": "local",
+                                                        },
+                                                      ]
+                                                    }
+                                                    copy=""
+                                                    customClassName="bx--leadspace-block__cta bx--leadspace-block__cta-col"
+                                                    href=""
+                                                    style="button"
+                                                    type="local"
+                                                  >
+                                                    <div
+                                                      className="bx--leadspace-block__cta bx--leadspace-block__cta-col"
+                                                    >
+                                                      <ButtonCTA
+                                                        buttons={
+                                                          Array [
+                                                            Object {
+                                                              "copy": "Excepteur sint occaecat",
+                                                              "href": "https://example.com/",
+                                                              "iconDescription": "right arrow icon",
+                                                              "onClick": [Function],
+                                                              "renderIcon": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                              "target": null,
+                                                              "type": "local",
+                                                            },
+                                                          ]
+                                                        }
+                                                        copy=""
+                                                        formatCTAcopy={[Function]}
+                                                        href=""
+                                                        openLightBox={[Function]}
+                                                        renderLightBox={false}
+                                                        style="button"
+                                                        type="local"
+                                                        videoTitle={
+                                                          Array [
+                                                            Object {
+                                                              "duration": "",
+                                                              "key": 0,
+                                                              "title": "",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <ButtonGroup
+                                                          buttons={
+                                                            Array [
+                                                              Object {
+                                                                "copy": "Excepteur sint occaecat",
+                                                                "href": "https://example.com/",
+                                                                "iconDescription": "right arrow icon",
+                                                                "onClick": [Function],
+                                                                "renderIcon": Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                },
+                                                                "target": null,
+                                                                "type": "local",
+                                                              },
+                                                            ]
+                                                          }
+                                                          enableSizeByContent={true}
+                                                        >
+                                                          <ol
+                                                            className="bx--buttongroup"
+                                                            data-autoid="dds--button-group"
+                                                          >
+                                                            <li
+                                                              className="bx--buttongroup-item"
+                                                            >
+                                                              <ForwardRef(Button)
+                                                                copy="Excepteur sint occaecat"
+                                                                data-autoid="dds--button-group-0"
+                                                                disabled={false}
+                                                                href="https://example.com/"
+                                                                iconDescription="right arrow icon"
+                                                                kind="primary"
+                                                                onClick={[Function]}
+                                                                renderIcon={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                tabIndex={0}
+                                                                target={null}
+                                                                type="button"
+                                                              >
+                                                                <a
+                                                                  className="bx--btn bx--btn--primary"
+                                                                  copy="Excepteur sint occaecat"
+                                                                  data-autoid="dds--button-group-0"
+                                                                  href="https://example.com/"
+                                                                  onClick={[Function]}
+                                                                  tabIndex={0}
+                                                                  target={null}
+                                                                >
+                                                                  Excepteur sint occaecat
+                                                                  <ForwardRef(ArrowRight20)
+                                                                    aria-hidden="true"
+                                                                    aria-label="right arrow icon"
+                                                                    className="bx--btn__icon"
+                                                                  >
+                                                                    <Icon
+                                                                      aria-hidden="true"
+                                                                      aria-label="right arrow icon"
+                                                                      className="bx--btn__icon"
+                                                                      fill="currentColor"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden="true"
+                                                                        aria-label="right arrow icon"
+                                                                        className="bx--btn__icon"
+                                                                        fill="currentColor"
+                                                                        focusable="false"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        role="img"
+                                                                        viewBox="0 0 20 20"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                        />
+                                                                      </svg>
+                                                                    </Icon>
+                                                                  </ForwardRef(ArrowRight20)>
+                                                                </a>
+                                                              </ForwardRef(Button)>
+                                                            </li>
+                                                          </ol>
+                                                        </ButtonGroup>
+                                                      </ButtonCTA>
+                                                    </div>
+                                                  </CTA>
+                                                </div>
+                                              </div>
+                                            </ContentBlock>
+                                            <HorizontalRule>
+                                              <hr
+                                                className="bx--hr"
+                                                data-autoid="dds--hr"
+                                              />
+                                            </HorizontalRule>
+                                          </div>
+                                        </LeadSpaceBlock>
+                                      </div>
+                                    </div>
+                                  </section>
+                                </Layout>
+                                <a
+                                  data-title="Pharetra pharetra massa massa ultricies mi quis."
+                                  name="section-2"
+                                />
+                                <ContentBlockSegmented
+                                  heading="Pharetra pharetra massa massa ultricies mi quis."
+                                  items={
+                                    Array [
+                                      Object {
+                                        "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                        "cta": Object {
+                                          "copy": "Lorem Ipsum dolor sit",
+                                          "href": "https://example.com",
+                                          "type": "local",
+                                        },
+                                        "heading": "A scelerisque purus semper eget duis at tellus.",
+                                      },
+                                      Object {
+                                        "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                        "heading": "A scelerisque purus semper eget duis at tellus.",
+                                      },
+                                      Object {
+                                        "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                        "cta": Object {
+                                          "copy": "Lorem Ipsum dolor sit",
+                                          "href": "https://example.com",
+                                          "type": "local",
+                                        },
+                                        "heading": "A scelerisque purus semper eget duis at tellus.",
+                                      },
+                                      Object {
+                                        "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                        "heading": "A scelerisque purus semper eget duis at tellus.",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div
+                                    className="bx--content-block-segmented"
+                                    data-autoid="dds--content-block-segmented"
+                                  >
+                                    <ContentBlock
+                                      border={false}
+                                      heading="Pharetra pharetra massa massa ultricies mi quis."
+                                    >
+                                      <div
+                                        className="bx--content-block"
+                                        data-autoid="dds--content-block"
+                                      >
+                                        <div>
+                                          <h2
+                                            className="bx--content-block__heading"
+                                            data-autoid="dds--content-block__heading"
+                                          >
+                                            Pharetra pharetra massa massa ultricies mi quis.
+                                          </h2>
+                                        </div>
+                                        <div
+                                          className="bx--content-block__children"
+                                          data-autoid="dds--content-block__children"
+                                        >
+                                          <ContentGroup
+                                            cta={
+                                              Object {
+                                                "copy": "Lorem Ipsum dolor sit",
+                                                "href": "https://example.com",
+                                                "style": "text",
+                                                "type": "local",
+                                              }
+                                            }
+                                            heading="A scelerisque purus semper eget duis at tellus."
+                                            key="0"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                A scelerisque purus semper eget duis at tellus.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__content-group"
+                                                >
+                                                  <ContentItem
+                                                    copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                    key="0"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item"
+                                                      data-autoid="dds--content-item"
+                                                    >
+                                                      <div
+                                                        className="bx--content-item__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          }
+                                                        }
+                                                        data-autoid="dds--content-item__copy"
+                                                      />
+                                                    </div>
+                                                  </ContentItem>
+                                                </div>
+                                              </div>
+                                              <div
+                                                className="bx--content-group__cta-row"
+                                                data-autoid="dds--content-group__cta"
+                                              >
+                                                <CTA
+                                                  copy="Lorem Ipsum dolor sit"
+                                                  customClassName="bx--content-group__cta"
+                                                  href="https://example.com"
+                                                  style="text"
+                                                  type="local"
+                                                >
+                                                  <div
+                                                    className="bx--content-group__cta"
+                                                  >
+                                                    <TextCTA
+                                                      copy="Lorem Ipsum dolor sit"
+                                                      formatCTAcopy={[Function]}
+                                                      href="https://example.com"
+                                                      iconPlacement="right"
+                                                      openLightBox={[Function]}
+                                                      renderLightBox={false}
+                                                      style="text"
+                                                      type="local"
+                                                      videoTitle={
+                                                        Array [
+                                                          Object {
+                                                            "duration": "",
+                                                            "key": 0,
+                                                            "title": "",
+                                                          },
+                                                        ]
+                                                      }
+                                                    >
+                                                      <LinkWithIcon
+                                                        href="https://example.com"
+                                                        iconPlacement="right"
+                                                        onClick={[Function]}
+                                                        target={null}
+                                                      >
+                                                        <div
+                                                          className="bx--link-with-icon__container"
+                                                          data-autoid="dds--link-with-icon"
+                                                        >
+                                                          <Link
+                                                            className="bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <a
+                                                              className="bx--link bx--link-with-icon"
+                                                              href="https://example.com"
+                                                              onClick={[Function]}
+                                                              target={null}
+                                                            >
+                                                              <span>
+                                                                Lorem Ipsum dolor sit
+                                                              </span>
+                                                              <ForwardRef(ArrowRight20)>
+                                                                <Icon
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowRight20)>
+                                                            </a>
+                                                          </Link>
+                                                        </div>
+                                                      </LinkWithIcon>
+                                                    </TextCTA>
+                                                  </div>
+                                                </CTA>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                          <ContentGroup
+                                            heading="A scelerisque purus semper eget duis at tellus."
+                                            key="1"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                A scelerisque purus semper eget duis at tellus.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__content-group"
+                                                >
+                                                  <ContentItem
+                                                    copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                    key="1"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item"
+                                                      data-autoid="dds--content-item"
+                                                    >
+                                                      <div
+                                                        className="bx--content-item__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          }
+                                                        }
+                                                        data-autoid="dds--content-item__copy"
+                                                      />
+                                                    </div>
+                                                  </ContentItem>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                          <ContentGroup
+                                            cta={
+                                              Object {
+                                                "copy": "Lorem Ipsum dolor sit",
+                                                "href": "https://example.com",
+                                                "style": "text",
+                                                "type": "local",
+                                              }
+                                            }
+                                            heading="A scelerisque purus semper eget duis at tellus."
+                                            key="2"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                A scelerisque purus semper eget duis at tellus.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__content-group"
+                                                >
+                                                  <ContentItem
+                                                    copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                    key="2"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item"
+                                                      data-autoid="dds--content-item"
+                                                    >
+                                                      <div
+                                                        className="bx--content-item__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          }
+                                                        }
+                                                        data-autoid="dds--content-item__copy"
+                                                      />
+                                                    </div>
+                                                  </ContentItem>
+                                                </div>
+                                              </div>
+                                              <div
+                                                className="bx--content-group__cta-row"
+                                                data-autoid="dds--content-group__cta"
+                                              >
+                                                <CTA
+                                                  copy="Lorem Ipsum dolor sit"
+                                                  customClassName="bx--content-group__cta"
+                                                  href="https://example.com"
+                                                  style="text"
+                                                  type="local"
+                                                >
+                                                  <div
+                                                    className="bx--content-group__cta"
+                                                  >
+                                                    <TextCTA
+                                                      copy="Lorem Ipsum dolor sit"
+                                                      formatCTAcopy={[Function]}
+                                                      href="https://example.com"
+                                                      iconPlacement="right"
+                                                      openLightBox={[Function]}
+                                                      renderLightBox={false}
+                                                      style="text"
+                                                      type="local"
+                                                      videoTitle={
+                                                        Array [
+                                                          Object {
+                                                            "duration": "",
+                                                            "key": 0,
+                                                            "title": "",
+                                                          },
+                                                        ]
+                                                      }
+                                                    >
+                                                      <LinkWithIcon
+                                                        href="https://example.com"
+                                                        iconPlacement="right"
+                                                        onClick={[Function]}
+                                                        target={null}
+                                                      >
+                                                        <div
+                                                          className="bx--link-with-icon__container"
+                                                          data-autoid="dds--link-with-icon"
+                                                        >
+                                                          <Link
+                                                            className="bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <a
+                                                              className="bx--link bx--link-with-icon"
+                                                              href="https://example.com"
+                                                              onClick={[Function]}
+                                                              target={null}
+                                                            >
+                                                              <span>
+                                                                Lorem Ipsum dolor sit
+                                                              </span>
+                                                              <ForwardRef(ArrowRight20)>
+                                                                <Icon
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowRight20)>
+                                                            </a>
+                                                          </Link>
+                                                        </div>
+                                                      </LinkWithIcon>
+                                                    </TextCTA>
+                                                  </div>
+                                                </CTA>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                          <ContentGroup
+                                            heading="A scelerisque purus semper eget duis at tellus."
+                                            key="3"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                A scelerisque purus semper eget duis at tellus.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__content-group"
+                                                >
+                                                  <ContentItem
+                                                    copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                    key="3"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item"
+                                                      data-autoid="dds--content-item"
+                                                    >
+                                                      <div
+                                                        className="bx--content-item__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          }
+                                                        }
+                                                        data-autoid="dds--content-item__copy"
+                                                      />
+                                                    </div>
+                                                  </ContentItem>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </div>
+                                      </div>
+                                    </ContentBlock>
+                                  </div>
+                                </ContentBlockSegmented>
+                                <FeatureCardBlockLarge
+                                  copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
+                                  cta={
+                                    Object {
+                                      "href": "https://example.com",
+                                      "icon": Object {
+                                        "src": Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "render": [Function],
+                                        },
+                                      },
+                                    }
+                                  }
+                                  eyebrow="scelerisque purus"
+                                  heading="Elementum nibh tellus molestie nunc?"
+                                  image={
+                                    Object {
+                                      "alt": "Image alt text",
+                                      "defaultSrc": "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
+                                    }
+                                  }
+                                >
+                                  <section
+                                    className="bx--feature-card-block-large"
+                                    data-autoid="dds--feature-card-block-large"
+                                  >
+                                    <div
+                                      className="bx--feature-card-block-large__container"
+                                    >
+                                      <Card
+                                        copy="Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique."
+                                        cta={
+                                          Object {
+                                            "href": "https://example.com",
+                                            "icon": Object {
+                                              "src": Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "render": [Function],
+                                              },
+                                            },
+                                          }
+                                        }
+                                        customClassName="bx--feature-card-block-large__card"
+                                        eyebrow="scelerisque purus"
+                                        heading="Elementum nibh tellus molestie nunc?"
+                                        image={
+                                          Object {
+                                            "alt": "Image alt text",
+                                            "defaultSrc": "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
+                                          }
+                                        }
+                                        inverse={true}
+                                      >
+                                        <ClickableTile
+                                          className="bx--card bx--card--inverse bx--feature-card-block-large__card"
+                                          clicked={false}
+                                          data-autoid="dds--card"
+                                          handleClick={[Function]}
+                                          handleKeyDown={[Function]}
+                                          href="https://example.com"
+                                          light={false}
+                                          onClick={[Function]}
+                                          target={null}
+                                        >
+                                          <a
+                                            className="bx--tile bx--tile--clickable bx--card bx--card--inverse bx--feature-card-block-large__card"
+                                            data-autoid="dds--card"
+                                            href="https://example.com"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            target={null}
+                                          >
+                                            <Image
+                                              alt="Image alt text"
+                                              classname="bx--card__img"
+                                              defaultSrc="https://dummyimage.com/600x600/ee5396/161616&text=1:1"
+                                            >
+                                              <div
+                                                className="bx--image"
+                                                data-autoid="dds--image__longdescription"
+                                              >
+                                                <picture>
+                                                  <img
+                                                    alt="Image alt text"
+                                                    className="bx--image__img bx--card__img"
+                                                    src="https://dummyimage.com/600x600/ee5396/161616&text=1:1"
+                                                  />
+                                                </picture>
+                                              </div>
+                                            </Image>
+                                            <div
+                                              className="bx--card__wrapper"
+                                            >
+                                              <p
+                                                className="bx--card__eyebrow"
+                                              >
+                                                scelerisque purus
+                                              </p>
+                                              <h3
+                                                className="bx--card__heading"
+                                              >
+                                                Elementum nibh tellus molestie nunc?
+                                              </h3>
+                                              <div
+                                                className="bx--card__copy"
+                                                dangerouslySetInnerHTML={
+                                                  Object {
+                                                    "__html": "<p>Habitant morbi tristique senectus et netus et malesuada fames. Habitant morbi tristique.</p> ",
+                                                  }
+                                                }
+                                              />
+                                              <div
+                                                className="bx--card__footer"
+                                              >
+                                                <ForwardRef(ArrowRight20)
+                                                  className="bx--card__cta"
+                                                  src={
+                                                    Object {
+                                                      "$$typeof": Symbol(react.forward_ref),
+                                                      "render": [Function],
+                                                    }
+                                                  }
+                                                >
+                                                  <Icon
+                                                    className="bx--card__cta"
+                                                    fill="currentColor"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    src={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "render": [Function],
+                                                      }
+                                                    }
+                                                    viewBox="0 0 20 20"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="bx--card__cta"
+                                                      fill="currentColor"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      src={
+                                                        Object {
+                                                          "$$typeof": Symbol(react.forward_ref),
+                                                          "render": [Function],
+                                                        }
+                                                      }
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ArrowRight20)>
+                                              </div>
+                                            </div>
+                                          </a>
+                                        </ClickableTile>
+                                      </Card>
+                                    </div>
+                                  </section>
+                                </FeatureCardBlockLarge>
+                                <a
+                                  data-title="Elementum nibh tellus molestie nunc non"
+                                  name="section-3"
+                                />
+                                <ContentBlockSegmented
+                                  cta={
+                                    Object {
+                                      "disableImage": true,
+                                      "media": Object {
+                                        "src": "0_uka1msg4",
+                                        "type": "video",
+                                      },
+                                      "style": "card",
+                                      "type": "video",
+                                    }
+                                  }
+                                  heading="Elementum nibh tellus molestie nunc non."
+                                  items={
+                                    Array [
+                                      Object {
+                                        "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                        "cta": Object {
+                                          "copy": "Lorem Ipsum dolor sit",
+                                          "href": "https://example.com",
+                                          "type": "local",
+                                        },
+                                        "heading": "A scelerisque purus semper eget duis at tellus.",
+                                        "image": Object {
+                                          "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                                          "image": Object {
+                                            "alt": "Image alt text",
+                                            "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                            "sources": Array [
+                                              Object {
+                                                "breakpoint": 320,
+                                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                              },
+                                              Object {
+                                                "breakpoint": 400,
+                                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                              },
+                                              Object {
+                                                "breakpoint": 672,
+                                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                              },
+                                            ],
+                                          },
+                                        },
+                                      },
+                                      Object {
+                                        "copy": "Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.",
+                                        "heading": "A scelerisque purus semper eget duis at tellus.",
+                                        "image": Object {
+                                          "heading": "Mauris iaculis eget dolor nec hendrerit.",
+                                          "image": Object {
+                                            "alt": "Image alt text",
+                                            "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                            "sources": Array [
+                                              Object {
+                                                "breakpoint": 320,
+                                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                              },
+                                              Object {
+                                                "breakpoint": 400,
+                                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                              },
+                                              Object {
+                                                "breakpoint": 672,
+                                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                              },
+                                            ],
+                                          },
+                                        },
+                                      },
+                                    ]
+                                  }
+                                  mediaType="image"
+                                >
+                                  <div
+                                    className="bx--content-block-segmented"
+                                    data-autoid="dds--content-block-segmented"
+                                  >
+                                    <ContentBlock
+                                      border={false}
+                                      cta={
+                                        Object {
+                                          "disableImage": true,
+                                          "media": Object {
+                                            "src": "0_uka1msg4",
+                                            "type": "video",
+                                          },
+                                          "style": "card",
+                                          "type": "video",
+                                        }
+                                      }
+                                      heading="Elementum nibh tellus molestie nunc non."
+                                    >
+                                      <div
+                                        className="bx--content-block"
+                                        data-autoid="dds--content-block"
+                                      >
+                                        <div>
+                                          <h2
+                                            className="bx--content-block__heading"
+                                            data-autoid="dds--content-block__heading"
+                                          >
+                                            Elementum nibh tellus molestie nunc non.
+                                          </h2>
+                                        </div>
+                                        <div
+                                          className="bx--content-block__children"
+                                          data-autoid="dds--content-block__children"
+                                        >
+                                          <ContentGroup
+                                            cta={
+                                              Object {
+                                                "copy": "Lorem Ipsum dolor sit",
+                                                "href": "https://example.com",
+                                                "style": "text",
+                                                "type": "local",
+                                              }
+                                            }
+                                            heading="A scelerisque purus semper eget duis at tellus."
+                                            key="0"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                A scelerisque purus semper eget duis at tellus.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__content-group"
+                                                >
+                                                  <ContentItem
+                                                    copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                    key="0"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item"
+                                                      data-autoid="dds--content-item"
+                                                    >
+                                                      <div
+                                                        className="bx--content-item__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          }
+                                                        }
+                                                        data-autoid="dds--content-item__copy"
+                                                      />
+                                                    </div>
+                                                  </ContentItem>
+                                                  <div
+                                                    data-autoid="dds--content-block-segmented__media"
+                                                  >
+                                                    <ImageWithCaption
+                                                      copy=""
+                                                      heading="Mauris iaculis eget dolor nec hendrerit."
+                                                      image={
+                                                        Object {
+                                                          "alt": "Image alt text",
+                                                          "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                          "sources": Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ],
+                                                        }
+                                                      }
+                                                      inverse={false}
+                                                      lightbox={false}
+                                                    >
+                                                      <div
+                                                        className="bx--image-with-caption"
+                                                        data-autoid="dds--image-with-caption"
+                                                      >
+                                                        <Image
+                                                          alt="Image alt text"
+                                                          defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          sources={
+                                                            Array [
+                                                              Object {
+                                                                "breakpoint": 320,
+                                                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                              },
+                                                              Object {
+                                                                "breakpoint": 400,
+                                                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                              },
+                                                              Object {
+                                                                "breakpoint": 672,
+                                                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                              },
+                                                            ]
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="bx--image"
+                                                            data-autoid="dds--image__longdescription"
+                                                          >
+                                                            <picture>
+                                                              <source
+                                                                key="0"
+                                                                media="(min-width: 672px)"
+                                                                srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                              />
+                                                              <source
+                                                                key="1"
+                                                                media="(min-width: 400px)"
+                                                                srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                              />
+                                                              <source
+                                                                key="2"
+                                                                media="(min-width: 320px)"
+                                                                srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                              />
+                                                              <img
+                                                                alt="Image alt text"
+                                                                className="bx--image__img"
+                                                                src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                              />
+                                                            </picture>
+                                                          </div>
+                                                        </Image>
+                                                        <p
+                                                          className="bx--image__caption--inverse"
+                                                          data-autoid="dds--image__caption"
+                                                        >
+                                                          Mauris iaculis eget dolor nec hendrerit.
+                                                        </p>
+                                                      </div>
+                                                    </ImageWithCaption>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                              <div
+                                                className="bx--content-group__cta-row"
+                                                data-autoid="dds--content-group__cta"
+                                              >
+                                                <CTA
+                                                  copy="Lorem Ipsum dolor sit"
+                                                  customClassName="bx--content-group__cta"
+                                                  href="https://example.com"
+                                                  style="text"
+                                                  type="local"
+                                                >
+                                                  <div
+                                                    className="bx--content-group__cta"
+                                                  >
+                                                    <TextCTA
+                                                      copy="Lorem Ipsum dolor sit"
+                                                      formatCTAcopy={[Function]}
+                                                      href="https://example.com"
+                                                      iconPlacement="right"
+                                                      openLightBox={[Function]}
+                                                      renderLightBox={false}
+                                                      style="text"
+                                                      type="local"
+                                                      videoTitle={
+                                                        Array [
+                                                          Object {
+                                                            "duration": "",
+                                                            "key": 0,
+                                                            "title": "",
+                                                          },
+                                                        ]
+                                                      }
+                                                    >
+                                                      <LinkWithIcon
+                                                        href="https://example.com"
+                                                        iconPlacement="right"
+                                                        onClick={[Function]}
+                                                        target={null}
+                                                      >
+                                                        <div
+                                                          className="bx--link-with-icon__container"
+                                                          data-autoid="dds--link-with-icon"
+                                                        >
+                                                          <Link
+                                                            className="bx--link-with-icon"
+                                                            href="https://example.com"
+                                                            onClick={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <a
+                                                              className="bx--link bx--link-with-icon"
+                                                              href="https://example.com"
+                                                              onClick={[Function]}
+                                                              target={null}
+                                                            >
+                                                              <span>
+                                                                Lorem Ipsum dolor sit
+                                                              </span>
+                                                              <ForwardRef(ArrowRight20)>
+                                                                <Icon
+                                                                  fill="currentColor"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  viewBox="0 0 20 20"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    fill="currentColor"
+                                                                    focusable="false"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                    />
+                                                                  </svg>
+                                                                </Icon>
+                                                              </ForwardRef(ArrowRight20)>
+                                                            </a>
+                                                          </Link>
+                                                        </div>
+                                                      </LinkWithIcon>
+                                                    </TextCTA>
+                                                  </div>
+                                                </CTA>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                          <ContentGroup
+                                            heading="A scelerisque purus semper eget duis at tellus."
+                                            key="1"
+                                          >
+                                            <div
+                                              className="bx--content-group"
+                                              data-autoid="dds--content-group"
+                                            >
+                                              <h3
+                                                className="bx--content-group__title"
+                                                data-autoid="dds--content-group__title"
+                                              >
+                                                A scelerisque purus semper eget duis at tellus.
+                                              </h3>
+                                              <div
+                                                className="bx--content-group__col bx--content-group__children"
+                                                data-autoid="dds--content-group__children"
+                                              >
+                                                <div
+                                                  data-autoid="dds--content-block-segmented__content-group"
+                                                >
+                                                  <ContentItem
+                                                    copy="Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames."
+                                                    key="1"
+                                                  >
+                                                    <div
+                                                      className="bx--content-item"
+                                                      data-autoid="dds--content-item"
+                                                    >
+                                                      <div
+                                                        className="bx--content-item__copy"
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>Elementum nibh tellus molestie nunc non. Habitant morbi tristique senectus et netus et malesuada fames.</p> ",
+                                                          }
+                                                        }
+                                                        data-autoid="dds--content-item__copy"
+                                                      />
+                                                    </div>
+                                                  </ContentItem>
+                                                  <div
+                                                    data-autoid="dds--content-block-segmented__media"
+                                                  >
+                                                    <ImageWithCaption
+                                                      copy=""
+                                                      heading="Mauris iaculis eget dolor nec hendrerit."
+                                                      image={
+                                                        Object {
+                                                          "alt": "Image alt text",
+                                                          "defaultSrc": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                          "sources": Array [
+                                                            Object {
+                                                              "breakpoint": 320,
+                                                              "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 400,
+                                                              "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                            },
+                                                            Object {
+                                                              "breakpoint": 672,
+                                                              "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                            },
+                                                          ],
+                                                        }
+                                                      }
+                                                      inverse={false}
+                                                      lightbox={false}
+                                                    >
+                                                      <div
+                                                        className="bx--image-with-caption"
+                                                        data-autoid="dds--image-with-caption"
+                                                      >
+                                                        <Image
+                                                          alt="Image alt text"
+                                                          defaultSrc="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                          sources={
+                                                            Array [
+                                                              Object {
+                                                                "breakpoint": 320,
+                                                                "src": "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                                                              },
+                                                              Object {
+                                                                "breakpoint": 400,
+                                                                "src": "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                                                              },
+                                                              Object {
+                                                                "breakpoint": 672,
+                                                                "src": "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                                                              },
+                                                            ]
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="bx--image"
+                                                            data-autoid="dds--image__longdescription"
+                                                          >
+                                                            <picture>
+                                                              <source
+                                                                key="0"
+                                                                media="(min-width: 672px)"
+                                                                srcSet="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                              />
+                                                              <source
+                                                                key="1"
+                                                                media="(min-width: 400px)"
+                                                                srcSet="https://dummyimage.com/400x225/ee5396/161616&text=16:9"
+                                                              />
+                                                              <source
+                                                                key="2"
+                                                                media="(min-width: 320px)"
+                                                                srcSet="https://dummyimage.com/320x180/ee5396/161616&text=16:9"
+                                                              />
+                                                              <img
+                                                                alt="Image alt text"
+                                                                className="bx--image__img"
+                                                                src="https://dummyimage.com/672x378/ee5396/161616&text=16:9"
+                                                              />
+                                                            </picture>
+                                                          </div>
+                                                        </Image>
+                                                        <p
+                                                          className="bx--image__caption--inverse"
+                                                          data-autoid="dds--image__caption"
+                                                        >
+                                                          Mauris iaculis eget dolor nec hendrerit.
+                                                        </p>
+                                                      </div>
+                                                    </ImageWithCaption>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </ContentGroup>
+                                        </div>
+                                        <div
+                                          className="bx--content-block__cta-row"
+                                          data-autoid="dds--content-block__cta"
+                                        >
+                                          <CTA
+                                            copy=""
+                                            customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                            disableImage={true}
+                                            href=""
+                                            media={
+                                              Object {
+                                                "src": "0_uka1msg4",
+                                                "type": "video",
+                                              }
+                                            }
+                                            style="card"
+                                            type="video"
+                                          >
+                                            <div
+                                              aria-label=""
+                                              className="bx--content-block__cta bx--content-block__cta-col"
+                                              role="region"
+                                            >
+                                              <CardCTA
+                                                copy=""
+                                                cta={null}
+                                                disableImage={true}
+                                                href=""
+                                                media={
+                                                  Object {
+                                                    "src": "0_uka1msg4",
+                                                    "type": "video",
+                                                  }
+                                                }
+                                                openLightBox={[Function]}
+                                                renderLightBox={false}
+                                                style="card"
+                                                type="video"
+                                                videoTitle={
+                                                  Array [
+                                                    Object {
+                                                      "duration": "",
+                                                      "key": 0,
+                                                      "title": "",
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                <CardLink
+                                                  card={
+                                                    Object {
+                                                      "copy": "",
+                                                      "cta": Object {
+                                                        "copy": "",
+                                                        "href": "#",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                        "iconPlacement": "left",
+                                                      },
+                                                      "handleClick": [Function],
+                                                      "href": "",
+                                                      "image": undefined,
+                                                      "media": Object {
+                                                        "src": "0_uka1msg4",
+                                                        "type": "video",
+                                                      },
+                                                    }
+                                                  }
+                                                  customClassName="bx--card__video"
+                                                  disabled={false}
+                                                >
+                                                  <Card
+                                                    copy=""
+                                                    cta={
+                                                      Object {
+                                                        "copy": "",
+                                                        "href": "#",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                        "iconPlacement": "left",
+                                                      }
+                                                    }
+                                                    customClassName="bx--card__CTA bx--card__video"
+                                                    handleClick={[Function]}
+                                                    href=""
+                                                    media={
+                                                      Object {
+                                                        "src": "0_uka1msg4",
+                                                        "type": "video",
+                                                      }
+                                                    }
+                                                  >
+                                                    <ClickableTile
+                                                      className="bx--card bx--card__CTA bx--card__video"
+                                                      clicked={false}
+                                                      data-autoid="dds--card"
+                                                      handleClick={[Function]}
+                                                      handleKeyDown={[Function]}
+                                                      href=""
+                                                      light={false}
+                                                      media={
+                                                        Object {
+                                                          "src": "0_uka1msg4",
+                                                          "type": "video",
+                                                        }
+                                                      }
+                                                      onClick={[Function]}
+                                                      target={null}
+                                                    >
+                                                      <a
+                                                        className="bx--tile bx--tile--clickable bx--card bx--card__CTA bx--card__video"
+                                                        data-autoid="dds--card"
+                                                        href=""
+                                                        media={
+                                                          Object {
+                                                            "src": "0_uka1msg4",
+                                                            "type": "video",
+                                                          }
+                                                        }
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        target={null}
+                                                      >
+                                                        <div
+                                                          className="bx--card__wrapper"
+                                                        >
+                                                          <div
+                                                            className="bx--card__footer bx--card__footer__icon-left"
+                                                          >
+                                                            <ForwardRef(PlayOutline20)
+                                                              className="bx--card__cta"
+                                                              src={
+                                                                Object {
+                                                                  "$$typeof": Symbol(react.forward_ref),
+                                                                  "render": [Function],
+                                                                }
+                                                              }
+                                                            >
+                                                              <Icon
+                                                                className="bx--card__cta"
+                                                                fill="currentColor"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                src={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  }
+                                                                }
+                                                                viewBox="0 0 32 32"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="bx--card__cta"
+                                                                  fill="currentColor"
+                                                                  focusable="false"
+                                                                  height={20}
+                                                                  preserveAspectRatio="xMidYMid meet"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                  viewBox="0 0 32 32"
+                                                                  width={20}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M16,4A12,12,0,1,1,4,16,12,12,0,0,1,16,4m0-2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Z"
+                                                                  />
+                                                                  <path
+                                                                    d="M12,23a1,1,0,0,1-.51-.14A1,1,0,0,1,11,22V10a1,1,0,0,1,.49-.86,1,1,0,0,1,1,0l11,6a1,1,0,0,1,0,1.76l-11,6A1,1,0,0,1,12,23Zm1-11.32v8.64L20.91,16Z"
+                                                                  />
+                                                                </svg>
+                                                              </Icon>
+                                                            </ForwardRef(PlayOutline20)>
+                                                          </div>
+                                                        </div>
+                                                      </a>
+                                                    </ClickableTile>
+                                                  </Card>
+                                                </CardLink>
+                                              </CardCTA>
+                                            </div>
+                                          </CTA>
+                                        </div>
+                                      </div>
+                                    </ContentBlock>
+                                  </div>
+                                </ContentBlockSegmented>
+                                <CalloutWithMedia
+                                  copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
+                                  heading="Mauris ultrices eros in cursus"
+                                  mediaData={
+                                    Object {
+                                      "videoId": "0_uka1msg4",
+                                    }
+                                  }
+                                  mediaType="video"
+                                >
+                                  <div
+                                    className="bx--callout-with-media"
+                                    data-autoid="dds--callout-with-media"
+                                  >
+                                    <Callout>
+                                      <section
+                                        className="bx--callout__container"
+                                        data-autoid="dds--callout__container"
+                                      >
+                                        <div
+                                          className="bx--callout__column"
+                                          data-autoid="dds--callout__column"
+                                        >
+                                          <div
+                                            className="bx--callout__content"
+                                            data-autoid="dds--callout__content"
+                                          >
+                                            <ContentBlockSimple
+                                              copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
+                                              heading="Mauris ultrices eros in cursus"
+                                              inverse={true}
+                                              mediaData={
+                                                Object {
+                                                  "videoId": "0_uka1msg4",
+                                                }
+                                              }
+                                              mediaType="video"
+                                            >
+                                              <div
+                                                className="bx--content-block-simple"
+                                                data-autoid="dds--content-block-simple"
+                                              >
+                                                <ContentBlock
+                                                  border={false}
+                                                  heading="Mauris ultrices eros in cursus"
+                                                  inverse={true}
+                                                >
+                                                  <div
+                                                    className="bx--content-block bx--content-block--inverse"
+                                                    data-autoid="dds--content-block"
+                                                  >
+                                                    <div>
+                                                      <h2
+                                                        className="bx--content-block__heading"
+                                                        data-autoid="dds--content-block__heading"
+                                                      >
+                                                        Mauris ultrices eros in cursus
+                                                      </h2>
+                                                    </div>
+                                                    <div
+                                                      className="bx--content-block__children"
+                                                      data-autoid="dds--content-block__children"
+                                                    >
+                                                      <div
+                                                        className="bx--content-block-simple__content"
+                                                      >
+                                                        <ContentItem
+                                                          copy="Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui."
+                                                          inverse={true}
+                                                        >
+                                                          <div
+                                                            className="bx--content-item bx--content-item--inverse"
+                                                            data-autoid="dds--content-item"
+                                                          >
+                                                            <div
+                                                              className="bx--content-item__copy"
+                                                              dangerouslySetInnerHTML={
+                                                                Object {
+                                                                  "__html": "<p>Porttitor eget dolor morbi non arcu. Et ligula ullamcorper malesuada proin libero nunc consequat. In est ante in nibh mauris cursus mattis. Turpis tincidunt id aliquet risus feugiat in. Vel facilisis volutpat est velit egestas dui.</p> ",
+                                                                }
+                                                              }
+                                                              data-autoid="dds--content-item__copy"
+                                                            />
+                                                          </div>
+                                                        </ContentItem>
+                                                        <div
+                                                          className="bx--content-block-simple__media-video"
+                                                          data-autoid="dds--content-block-simple__media"
+                                                        >
+                                                          <VideoPlayer
+                                                            autoPlay={false}
+                                                            inverse={true}
+                                                            videoId="0_uka1msg4"
+                                                          >
+                                                            <div
+                                                              aria-label=" (1:00)"
+                                                              className="bx--video-player bx--video-player--inverse"
+                                                            >
+                                                              <div
+                                                                className="bx--video-player__video-container "
+                                                                data-autoid="dds--video-player__video-0_uka1msg4"
+                                                              >
+                                                                <div
+                                                                  className="bx--video-player__video"
+                                                                  id="bx--video-player__video-0_uka1msg4-67"
+                                                                >
+                                                                  <VideoImageOverlay
+                                                                    embedVideo={[Function]}
+                                                                    videoData={
+                                                                      Object {
+                                                                        "description": "",
+                                                                        "name": "",
+                                                                      }
+                                                                    }
+                                                                    videoId="0_uka1msg4"
+                                                                  >
+                                                                    <button
+                                                                      className="bx--video-player__image-overlay"
+                                                                      data-autoid="dds--video-player__image-overlay"
+                                                                      onClick={[Function]}
+                                                                    >
+                                                                      <Image
+                                                                        alt=""
+                                                                        defaultSrc="https://cdnsecakmi.kaltura.com/p/123456/thumbnail/entry_id/0_uka1msg4/width/320"
+                                                                        icon={[Function]}
+                                                                      />
+                                                                    </button>
+                                                                  </VideoImageOverlay>
+                                                                </div>
+                                                              </div>
+                                                            </div>
+                                                          </VideoPlayer>
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </ContentBlock>
+                                              </div>
+                                            </ContentBlockSimple>
+                                          </div>
+                                        </div>
+                                      </section>
+                                    </Callout>
+                                  </div>
+                                </CalloutWithMedia>
+                                <a
+                                  data-title="Tincidunt ornare massa"
+                                  name="section-4"
+                                />
+                                <ContentGroupHorizontal
+                                  heading="Tincidunt ornare massa"
+                                  items={
+                                    Array [
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
+                                        "cta": Object {
+                                          "heading": "Aliquam condimentum",
+                                          "items": Array [
+                                            Object {
+                                              "copy": "Link text",
+                                              "href": "https://example.com",
+                                              "type": "local",
+                                            },
+                                            Object {
+                                              "copy": "External link text",
+                                              "href": "https://example.com",
+                                              "type": "external",
+                                            },
+                                          ],
+                                        },
+                                        "eyebrow": "Lorem ipsum",
+                                        "heading": "Aliquam condimentum",
+                                      },
+                                      Object {
+                                        "copy": "Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.",
+                                        "cta": Object {
+                                          "heading": "Aliquam condimentum",
+                                          "items": Array [
+                                            Object {
+                                              "copy": "Link text",
+                                              "href": "https://example.com",
+                                              "type": "local",
+                                            },
+                                            Object {
+                                              "copy": "External link text",
+                                              "href": "https://example.com",
+                                              "type": "external",
+                                            },
+                                          ],
+                                        },
+                                        "eyebrow": "Lorem ipsum",
+                                        "heading": "Aliquam condimentum",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <div
+                                    className="bx--content-group-horizontal"
+                                    data-autoid="dds--content-group-horizontal"
+                                  >
+                                    <ContentBlock
+                                      border={true}
+                                      heading="Tincidunt ornare massa"
+                                    >
+                                      <div
+                                        className="bx--content-block"
+                                        data-autoid="dds--content-block"
+                                      >
+                                        <div>
+                                          <h2
+                                            className="bx--content-block__heading"
+                                            data-autoid="dds--content-block__heading"
+                                          >
+                                            Tincidunt ornare massa
+                                          </h2>
+                                        </div>
+                                        <div
+                                          className="bx--content-block__children"
+                                          data-autoid="dds--content-block__children"
+                                        >
+                                          <ContentItemHorizontal
+                                            copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
+                                            cta={
+                                              Object {
+                                                "heading": "Aliquam condimentum",
+                                                "items": Array [
+                                                  Object {
+                                                    "copy": "Link text",
+                                                    "href": "https://example.com",
+                                                    "type": "local",
+                                                  },
+                                                  Object {
+                                                    "copy": "External link text",
+                                                    "href": "https://example.com",
+                                                    "type": "external",
+                                                  },
+                                                ],
+                                              }
+                                            }
+                                            eyebrow="Lorem ipsum"
+                                            heading="Aliquam condimentum"
+                                            key="0"
+                                          >
+                                            <div
+                                              className="bx--content-item-horizontal__item "
+                                              data-autoid="dds--content-item-horizontal__item"
+                                            >
+                                              <div
+                                                className="bx--content-item-horizontal__row"
+                                              >
+                                                <div
+                                                  className="bx--content-item-horizontal__col"
+                                                >
+                                                  <p
+                                                    className="bx--content-item-horizontal__item--eyebrow"
+                                                    data-autoid="dds--content-item-horizontal__item--eyebrow"
+                                                  >
+                                                    Lorem ipsum
+                                                  </p>
+                                                  <h3
+                                                    className="bx--content-item-horizontal__item--heading"
+                                                    data-autoid="dds--content-item-horizontal__item--heading"
+                                                  >
+                                                    Aliquam condimentum
+                                                  </h3>
+                                                </div>
+                                                <div
+                                                  className="bx--content-item-horizontal__col"
+                                                >
+                                                  <div
+                                                    className="bx--content-item-horizontal__item--copy"
+                                                    dangerouslySetInnerHTML={
+                                                      Object {
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
+                                                      }
+                                                    }
+                                                    data-autoid="dds--content-item-horizontal__item--copy"
+                                                  />
+                                                  <div
+                                                    className="bx--content-item-horizontal__item--cta"
+                                                    data-autoid="dds--content-item-horizontal__item--cta"
+                                                  >
+                                                    <LinkList
+                                                      heading="Aliquam condimentum"
+                                                      items={
+                                                        Array [
+                                                          Object {
+                                                            "copy": "Link text",
+                                                            "href": "https://example.com",
+                                                            "type": "local",
+                                                          },
+                                                          Object {
+                                                            "copy": "External link text",
+                                                            "href": "https://example.com",
+                                                            "type": "external",
+                                                          },
+                                                        ]
+                                                      }
+                                                      style="vertical"
+                                                    >
+                                                      <div
+                                                        className="bx--link-list"
+                                                        data-autoid="dds--link-list"
+                                                      >
+                                                        <h4
+                                                          className="bx--link-list__heading"
+                                                        >
+                                                          Aliquam condimentum
+                                                        </h4>
+                                                        <ul
+                                                          className="bx--link-list__list bx--link-list__list--vertical"
+                                                        >
+                                                          <li
+                                                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                            key="0"
+                                                          >
+                                                            <CTA
+                                                              copy="Link text"
+                                                              disableImage={true}
+                                                              href="https://example.com"
+                                                              style="text"
+                                                              type="local"
+                                                            >
+                                                              <div>
+                                                                <TextCTA
+                                                                  copy="Link text"
+                                                                  disableImage={true}
+                                                                  formatCTAcopy={[Function]}
+                                                                  href="https://example.com"
+                                                                  iconPlacement="right"
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  style="text"
+                                                                  type="local"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "duration": "",
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://example.com"
+                                                                    iconPlacement="right"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://example.com"
+                                                                          onClick={[Function]}
+                                                                          target={null}
+                                                                        >
+                                                                          <span>
+                                                                            Link text
+                                                                          </span>
+                                                                          <ForwardRef(ArrowRight20)>
+                                                                            <Icon
+                                                                              fill="currentColor"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                fill="currentColor"
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                viewBox="0 0 20 20"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(ArrowRight20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </li>
+                                                          <li
+                                                            className="bx--link-list__list__CTA bx--link-list__list--external"
+                                                            key="1"
+                                                          >
+                                                            <CTA
+                                                              copy="External link text"
+                                                              disableImage={true}
+                                                              href="https://example.com"
+                                                              style="text"
+                                                              type="external"
+                                                            >
+                                                              <div>
+                                                                <TextCTA
+                                                                  copy="External link text"
+                                                                  disableImage={true}
+                                                                  formatCTAcopy={[Function]}
+                                                                  href="https://example.com"
+                                                                  iconPlacement="right"
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  style="text"
+                                                                  type="external"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "duration": "",
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://example.com"
+                                                                    iconPlacement="right"
+                                                                    onClick={[Function]}
+                                                                    target="_blank"
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target="_blank"
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://example.com"
+                                                                          onClick={[Function]}
+                                                                          target="_blank"
+                                                                        >
+                                                                          <span>
+                                                                            External link text
+                                                                          </span>
+                                                                          <ForwardRef(Launch20)>
+                                                                            <Icon
+                                                                              fill="currentColor"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 32 32"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                fill="currentColor"
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                viewBox="0 0 32 32"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                                />
+                                                                                <path
+                                                                                  d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(Launch20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </li>
+                                                        </ul>
+                                                      </div>
+                                                    </LinkList>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </ContentItemHorizontal>
+                                          <ContentItemHorizontal
+                                            copy="Lorem ipsum dolor sit amet, _consectetur_ adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin."
+                                            cta={
+                                              Object {
+                                                "heading": "Aliquam condimentum",
+                                                "items": Array [
+                                                  Object {
+                                                    "copy": "Link text",
+                                                    "href": "https://example.com",
+                                                    "type": "local",
+                                                  },
+                                                  Object {
+                                                    "copy": "External link text",
+                                                    "href": "https://example.com",
+                                                    "type": "external",
+                                                  },
+                                                ],
+                                              }
+                                            }
+                                            eyebrow="Lorem ipsum"
+                                            heading="Aliquam condimentum"
+                                            key="1"
+                                          >
+                                            <div
+                                              className="bx--content-item-horizontal__item "
+                                              data-autoid="dds--content-item-horizontal__item"
+                                            >
+                                              <div
+                                                className="bx--content-item-horizontal__row"
+                                              >
+                                                <div
+                                                  className="bx--content-item-horizontal__col"
+                                                >
+                                                  <p
+                                                    className="bx--content-item-horizontal__item--eyebrow"
+                                                    data-autoid="dds--content-item-horizontal__item--eyebrow"
+                                                  >
+                                                    Lorem ipsum
+                                                  </p>
+                                                  <h3
+                                                    className="bx--content-item-horizontal__item--heading"
+                                                    data-autoid="dds--content-item-horizontal__item--heading"
+                                                  >
+                                                    Aliquam condimentum
+                                                  </h3>
+                                                </div>
+                                                <div
+                                                  className="bx--content-item-horizontal__col"
+                                                >
+                                                  <div
+                                                    className="bx--content-item-horizontal__item--copy"
+                                                    dangerouslySetInnerHTML={
+                                                      Object {
+                                                        "__html": "<p>Lorem ipsum dolor sit amet, <em>consectetur</em> adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin.</p> ",
+                                                      }
+                                                    }
+                                                    data-autoid="dds--content-item-horizontal__item--copy"
+                                                  />
+                                                  <div
+                                                    className="bx--content-item-horizontal__item--cta"
+                                                    data-autoid="dds--content-item-horizontal__item--cta"
+                                                  >
+                                                    <LinkList
+                                                      heading="Aliquam condimentum"
+                                                      items={
+                                                        Array [
+                                                          Object {
+                                                            "copy": "Link text",
+                                                            "href": "https://example.com",
+                                                            "type": "local",
+                                                          },
+                                                          Object {
+                                                            "copy": "External link text",
+                                                            "href": "https://example.com",
+                                                            "type": "external",
+                                                          },
+                                                        ]
+                                                      }
+                                                      style="vertical"
+                                                    >
+                                                      <div
+                                                        className="bx--link-list"
+                                                        data-autoid="dds--link-list"
+                                                      >
+                                                        <h4
+                                                          className="bx--link-list__heading"
+                                                        >
+                                                          Aliquam condimentum
+                                                        </h4>
+                                                        <ul
+                                                          className="bx--link-list__list bx--link-list__list--vertical"
+                                                        >
+                                                          <li
+                                                            className="bx--link-list__list__CTA bx--link-list__list--local"
+                                                            key="0"
+                                                          >
+                                                            <CTA
+                                                              copy="Link text"
+                                                              disableImage={true}
+                                                              href="https://example.com"
+                                                              style="text"
+                                                              type="local"
+                                                            >
+                                                              <div>
+                                                                <TextCTA
+                                                                  copy="Link text"
+                                                                  disableImage={true}
+                                                                  formatCTAcopy={[Function]}
+                                                                  href="https://example.com"
+                                                                  iconPlacement="right"
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  style="text"
+                                                                  type="local"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "duration": "",
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://example.com"
+                                                                    iconPlacement="right"
+                                                                    onClick={[Function]}
+                                                                    target={null}
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target={null}
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://example.com"
+                                                                          onClick={[Function]}
+                                                                          target={null}
+                                                                        >
+                                                                          <span>
+                                                                            Link text
+                                                                          </span>
+                                                                          <ForwardRef(ArrowRight20)>
+                                                                            <Icon
+                                                                              fill="currentColor"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 20 20"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                fill="currentColor"
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                viewBox="0 0 20 20"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(ArrowRight20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </li>
+                                                          <li
+                                                            className="bx--link-list__list__CTA bx--link-list__list--external"
+                                                            key="1"
+                                                          >
+                                                            <CTA
+                                                              copy="External link text"
+                                                              disableImage={true}
+                                                              href="https://example.com"
+                                                              style="text"
+                                                              type="external"
+                                                            >
+                                                              <div>
+                                                                <TextCTA
+                                                                  copy="External link text"
+                                                                  disableImage={true}
+                                                                  formatCTAcopy={[Function]}
+                                                                  href="https://example.com"
+                                                                  iconPlacement="right"
+                                                                  openLightBox={[Function]}
+                                                                  renderLightBox={false}
+                                                                  style="text"
+                                                                  type="external"
+                                                                  videoTitle={
+                                                                    Array [
+                                                                      Object {
+                                                                        "duration": "",
+                                                                        "key": 0,
+                                                                        "title": "",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                >
+                                                                  <LinkWithIcon
+                                                                    href="https://example.com"
+                                                                    iconPlacement="right"
+                                                                    onClick={[Function]}
+                                                                    target="_blank"
+                                                                  >
+                                                                    <div
+                                                                      className="bx--link-with-icon__container"
+                                                                      data-autoid="dds--link-with-icon"
+                                                                    >
+                                                                      <Link
+                                                                        className="bx--link-with-icon"
+                                                                        href="https://example.com"
+                                                                        onClick={[Function]}
+                                                                        target="_blank"
+                                                                      >
+                                                                        <a
+                                                                          className="bx--link bx--link-with-icon"
+                                                                          href="https://example.com"
+                                                                          onClick={[Function]}
+                                                                          target="_blank"
+                                                                        >
+                                                                          <span>
+                                                                            External link text
+                                                                          </span>
+                                                                          <ForwardRef(Launch20)>
+                                                                            <Icon
+                                                                              fill="currentColor"
+                                                                              height={20}
+                                                                              preserveAspectRatio="xMidYMid meet"
+                                                                              viewBox="0 0 32 32"
+                                                                              width={20}
+                                                                              xmlns="http://www.w3.org/2000/svg"
+                                                                            >
+                                                                              <svg
+                                                                                aria-hidden={true}
+                                                                                fill="currentColor"
+                                                                                focusable="false"
+                                                                                height={20}
+                                                                                preserveAspectRatio="xMidYMid meet"
+                                                                                viewBox="0 0 32 32"
+                                                                                width={20}
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                              >
+                                                                                <path
+                                                                                  d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4h9V6H6V26H26V17h2v9A2,2,0,0,1,26,28Z"
+                                                                                />
+                                                                                <path
+                                                                                  d="M21 2L21 4 26.59 4 18 12.59 19.41 14 28 5.41 28 11 30 11 30 2 21 2z"
+                                                                                />
+                                                                              </svg>
+                                                                            </Icon>
+                                                                          </ForwardRef(Launch20)>
+                                                                        </a>
+                                                                      </Link>
+                                                                    </div>
+                                                                  </LinkWithIcon>
+                                                                </TextCTA>
+                                                              </div>
+                                                            </CTA>
+                                                          </li>
+                                                        </ul>
+                                                      </div>
+                                                    </LinkList>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </ContentItemHorizontal>
+                                        </div>
+                                        <HorizontalRule>
+                                          <hr
+                                            className="bx--hr"
+                                            data-autoid="dds--hr"
+                                          />
+                                        </HorizontalRule>
+                                      </div>
+                                    </ContentBlock>
+                                  </div>
+                                </ContentGroupHorizontal>
+                                <a
+                                  data-title="Lobortis elementum nibh tellus"
+                                  name="section-5"
+                                />
+                                <LogoGrid
+                                  ctaCopy="Amet justo donec"
+                                  ctaHref="https://www.example.com"
+                                  heading="Lobortis elementum nibh tellus"
+                                  logosGroup={
+                                    Array [
+                                      Object {
+                                        "altText": "Image alt text",
+                                        "href": "http://example.com/",
+                                        "imgSrc": "https://dummyimage.com/140x140",
+                                        "title": "Company A",
+                                      },
+                                      Object {
+                                        "altText": "Image alt text",
+                                        "href": "http://example.com/",
+                                        "imgSrc": "https://dummyimage.com/140x140",
+                                        "title": "Company B",
+                                      },
+                                      Object {
+                                        "altText": "Image alt text",
+                                        "href": "http://example.com/",
+                                        "imgSrc": "https://dummyimage.com/140x140",
+                                        "title": "Company C",
+                                      },
+                                      Object {
+                                        "altText": "Image alt text",
+                                        "href": "http://example.com/",
+                                        "imgSrc": "https://dummyimage.com/140x140",
+                                        "title": "Company D",
+                                      },
+                                      Object {
+                                        "altText": "Image alt text",
+                                        "href": "http://example.com/",
+                                        "imgSrc": "https://dummyimage.com/140x140",
+                                        "title": "Company E",
+                                      },
+                                      Object {
+                                        "altText": "Image alt text",
+                                        "href": "http://example.com/",
+                                        "imgSrc": "https://dummyimage.com/140x140",
+                                        "title": "Company F",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <section
+                                    className="bx--logo-grid"
+                                    data-autoid="dds--logo-grid"
+                                  >
+                                    <div
+                                      className="bx--logo-grid__container"
+                                    >
+                                      <div
+                                        className="bx--logo-grid__wrapper bx--grid bx--grid--full-width"
+                                      >
+                                        <ContentBlock
+                                          border={false}
+                                          cta={
+                                            Object {
+                                              "copy": "Amet justo donec",
+                                              "cta": Object {
+                                                "href": "https://www.example.com",
+                                              },
+                                              "style": "card",
+                                              "type": "local",
+                                            }
+                                          }
+                                          heading="Lobortis elementum nibh tellus"
+                                        >
+                                          <div
+                                            className="bx--content-block"
+                                            data-autoid="dds--content-block"
+                                          >
+                                            <div>
+                                              <h2
+                                                className="bx--content-block__heading"
+                                                data-autoid="dds--content-block__heading"
+                                              >
+                                                Lobortis elementum nibh tellus
+                                              </h2>
+                                            </div>
+                                            <div
+                                              className="bx--content-block__children"
+                                              data-autoid="dds--content-block__children"
+                                            >
+                                              <div
+                                                className="bx--logo-grid__row"
+                                              >
+                                                <div
+                                                  className="bx--logo-grid__col"
+                                                  key="0"
+                                                >
+                                                  <a
+                                                    className="bx--logo-grid__link"
+                                                    href="http://example.com/"
+                                                  >
+                                                    <div
+                                                      className="bx--logo-grid__logo"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--logo-grid_img"
+                                                        defaultSrc="https://dummyimage.com/140x140"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--logo-grid_img"
+                                                              src="https://dummyimage.com/140x140"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                    </div>
+                                                  </a>
+                                                </div>
+                                                <div
+                                                  className="bx--logo-grid__col"
+                                                  key="1"
+                                                >
+                                                  <a
+                                                    className="bx--logo-grid__link"
+                                                    href="http://example.com/"
+                                                  >
+                                                    <div
+                                                      className="bx--logo-grid__logo"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--logo-grid_img"
+                                                        defaultSrc="https://dummyimage.com/140x140"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--logo-grid_img"
+                                                              src="https://dummyimage.com/140x140"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                    </div>
+                                                  </a>
+                                                </div>
+                                                <div
+                                                  className="bx--logo-grid__col"
+                                                  key="2"
+                                                >
+                                                  <a
+                                                    className="bx--logo-grid__link"
+                                                    href="http://example.com/"
+                                                  >
+                                                    <div
+                                                      className="bx--logo-grid__logo"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--logo-grid_img"
+                                                        defaultSrc="https://dummyimage.com/140x140"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--logo-grid_img"
+                                                              src="https://dummyimage.com/140x140"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                    </div>
+                                                  </a>
+                                                </div>
+                                                <div
+                                                  className="bx--logo-grid__col"
+                                                  key="3"
+                                                >
+                                                  <a
+                                                    className="bx--logo-grid__link"
+                                                    href="http://example.com/"
+                                                  >
+                                                    <div
+                                                      className="bx--logo-grid__logo"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--logo-grid_img"
+                                                        defaultSrc="https://dummyimage.com/140x140"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--logo-grid_img"
+                                                              src="https://dummyimage.com/140x140"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                    </div>
+                                                  </a>
+                                                </div>
+                                                <div
+                                                  className="bx--logo-grid__col"
+                                                  key="4"
+                                                >
+                                                  <a
+                                                    className="bx--logo-grid__link"
+                                                    href="http://example.com/"
+                                                  >
+                                                    <div
+                                                      className="bx--logo-grid__logo"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--logo-grid_img"
+                                                        defaultSrc="https://dummyimage.com/140x140"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--logo-grid_img"
+                                                              src="https://dummyimage.com/140x140"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                    </div>
+                                                  </a>
+                                                </div>
+                                                <div
+                                                  className="bx--logo-grid__col"
+                                                  key="5"
+                                                >
+                                                  <a
+                                                    className="bx--logo-grid__link"
+                                                    href="http://example.com/"
+                                                  >
+                                                    <div
+                                                      className="bx--logo-grid__logo"
+                                                    >
+                                                      <Image
+                                                        alt="Image alt text"
+                                                        classname="bx--logo-grid_img"
+                                                        defaultSrc="https://dummyimage.com/140x140"
+                                                      >
+                                                        <div
+                                                          className="bx--image"
+                                                          data-autoid="dds--image__longdescription"
+                                                        >
+                                                          <picture>
+                                                            <img
+                                                              alt="Image alt text"
+                                                              className="bx--image__img bx--logo-grid_img"
+                                                              src="https://dummyimage.com/140x140"
+                                                            />
+                                                          </picture>
+                                                        </div>
+                                                      </Image>
+                                                    </div>
+                                                  </a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                            <div
+                                              className="bx--content-block__cta-row"
+                                              data-autoid="dds--content-block__cta"
+                                            >
+                                              <CTA
+                                                copy="Amet justo donec"
+                                                cta={
+                                                  Object {
+                                                    "href": "https://www.example.com",
+                                                  }
+                                                }
+                                                customClassName="bx--content-block__cta bx--content-block__cta-col"
+                                                href=""
+                                                style="card"
+                                                type="local"
+                                              >
+                                                <div
+                                                  aria-label="Amet justo donec"
+                                                  className="bx--content-block__cta bx--content-block__cta-col"
+                                                  role="region"
+                                                >
+                                                  <CardCTA
+                                                    copy="Amet justo donec"
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://www.example.com",
+                                                      }
+                                                    }
+                                                    disableImage={false}
+                                                    href=""
+                                                    media={null}
+                                                    openLightBox={[Function]}
+                                                    renderLightBox={false}
+                                                    style="card"
+                                                    type="local"
+                                                    videoTitle={
+                                                      Array [
+                                                        Object {
+                                                          "duration": "",
+                                                          "key": 0,
+                                                          "title": "",
+                                                        },
+                                                      ]
+                                                    }
+                                                  >
+                                                    <CardLink
+                                                      card={
+                                                        Object {
+                                                          "copy": "Amet justo donec",
+                                                          "cta": Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                            "type": "local",
+                                                          },
+                                                          "href": "https://www.example.com",
+                                                          "media": null,
+                                                          "target": null,
+                                                        }
+                                                      }
+                                                      disabled={false}
+                                                    >
+                                                      <Card
+                                                        copy="Amet justo donec"
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                            "type": "local",
+                                                          }
+                                                        }
+                                                        customClassName="bx--card__CTA"
+                                                        href="https://www.example.com"
+                                                        media={null}
+                                                        target={null}
+                                                      >
+                                                        <ClickableTile
+                                                          className="bx--card bx--card__CTA"
+                                                          clicked={false}
+                                                          data-autoid="dds--card"
+                                                          handleClick={[Function]}
+                                                          handleKeyDown={[Function]}
+                                                          href="https://www.example.com"
+                                                          light={false}
+                                                          media={null}
+                                                          onClick={[Function]}
+                                                          target={null}
+                                                        >
+                                                          <a
+                                                            className="bx--tile bx--tile--clickable bx--card bx--card__CTA"
+                                                            data-autoid="dds--card"
+                                                            href="https://www.example.com"
+                                                            media={null}
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            target={null}
+                                                          >
+                                                            <div
+                                                              className="bx--card__wrapper"
+                                                            >
+                                                              <div
+                                                                className="bx--card__copy"
+                                                                dangerouslySetInnerHTML={
+                                                                  Object {
+                                                                    "__html": "<p>Amet justo donec</p> ",
+                                                                  }
+                                                                }
+                                                              />
+                                                              <div
+                                                                className="bx--card__footer"
+                                                              >
+                                                                <ForwardRef(ArrowRight20)
+                                                                  className="bx--card__cta"
+                                                                  src={
+                                                                    Object {
+                                                                      "$$typeof": Symbol(react.forward_ref),
+                                                                      "render": [Function],
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <Icon
+                                                                    className="bx--card__cta"
+                                                                    fill="currentColor"
+                                                                    height={20}
+                                                                    preserveAspectRatio="xMidYMid meet"
+                                                                    src={
+                                                                      Object {
+                                                                        "$$typeof": Symbol(react.forward_ref),
+                                                                        "render": [Function],
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 20 20"
+                                                                    width={20}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="bx--card__cta"
+                                                                      fill="currentColor"
+                                                                      focusable="false"
+                                                                      height={20}
+                                                                      preserveAspectRatio="xMidYMid meet"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                      viewBox="0 0 20 20"
+                                                                      width={20}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                      />
+                                                                    </svg>
+                                                                  </Icon>
+                                                                </ForwardRef(ArrowRight20)>
+                                                              </div>
+                                                            </div>
+                                                          </a>
+                                                        </ClickableTile>
+                                                      </Card>
+                                                    </CardLink>
+                                                  </CardCTA>
+                                                </div>
+                                              </CTA>
+                                            </div>
+                                          </div>
+                                        </ContentBlock>
+                                      </div>
+                                    </div>
+                                  </section>
+                                </LogoGrid>
+                                <a
+                                  data-title="Aliquam condimentum interdum"
+                                  name="section-6"
+                                />
+                                <ContentBlockCards
+                                  cards={
+                                    Array [
+                                      Object {
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "eyebrow": "Topic",
+                                        "heading": "Natural language processing.",
+                                        "image": Object {
+                                          "alt": "Image alt text",
+                                          "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                        },
+                                      },
+                                      Object {
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "eyebrow": "Topic",
+                                        "heading": "Natural language processing.",
+                                        "image": Object {
+                                          "alt": "Image alt text",
+                                          "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                        },
+                                      },
+                                      Object {
+                                        "cta": Object {
+                                          "href": "https://www.example.com",
+                                        },
+                                        "eyebrow": "Topic",
+                                        "heading": "Natural language processing.",
+                                        "image": Object {
+                                          "alt": "Image alt text",
+                                          "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                        },
+                                      },
+                                    ]
+                                  }
+                                  heading="Aliquam condimentum interdum"
+                                >
+                                  <div
+                                    className="bx--content-block-cards"
+                                    data-autoid="dds--content-block-cards"
+                                  >
+                                    <ContentBlock
+                                      border={false}
+                                      heading="Aliquam condimentum interdum"
+                                    >
+                                      <div
+                                        className="bx--content-block"
+                                        data-autoid="dds--content-block"
+                                      >
+                                        <div>
+                                          <h2
+                                            className="bx--content-block__heading"
+                                            data-autoid="dds--content-block__heading"
+                                          >
+                                            Aliquam condimentum interdum
+                                          </h2>
+                                        </div>
+                                        <div
+                                          className="bx--content-block__children"
+                                          data-autoid="dds--content-block__children"
+                                        >
+                                          <div
+                                            className="bx--content-block-cards__content"
+                                          >
+                                            <CardGroup
+                                              cards={
+                                                Array [
+                                                  Object {
+                                                    "cta": Object {
+                                                      "href": "https://www.example.com",
+                                                    },
+                                                    "eyebrow": "Topic",
+                                                    "heading": "Natural language processing.",
+                                                    "image": Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                    },
+                                                  },
+                                                  Object {
+                                                    "cta": Object {
+                                                      "href": "https://www.example.com",
+                                                    },
+                                                    "eyebrow": "Topic",
+                                                    "heading": "Natural language processing.",
+                                                    "image": Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                    },
+                                                  },
+                                                  Object {
+                                                    "cta": Object {
+                                                      "href": "https://www.example.com",
+                                                    },
+                                                    "eyebrow": "Topic",
+                                                    "heading": "Natural language processing.",
+                                                    "image": Object {
+                                                      "alt": "Image alt text",
+                                                      "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                    },
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <div
+                                                className="bx--card-group__cards__row bx--row--condensed"
+                                                data-autoid="dds--card-group"
+                                              >
+                                                <div
+                                                  aria-label="Natural language processing."
+                                                  className="bx--card-group__cards__col"
+                                                  key="0"
+                                                  role="region"
+                                                >
+                                                  <CTA
+                                                    copy=""
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://www.example.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card-group__card"
+                                                    eyebrow="Topic"
+                                                    heading="Natural language processing."
+                                                    href=""
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                      }
+                                                    }
+                                                    key="0"
+                                                    style="card"
+                                                    type="link"
+                                                  >
+                                                    <div
+                                                      aria-label=""
+                                                      className="bx--card-group__card"
+                                                      role="region"
+                                                    >
+                                                      <CardCTA
+                                                        copy=""
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        disableImage={false}
+                                                        eyebrow="Topic"
+                                                        heading="Natural language processing."
+                                                        href=""
+                                                        image={
+                                                          Object {
+                                                            "alt": "Image alt text",
+                                                            "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                          }
+                                                        }
+                                                        media={null}
+                                                        openLightBox={[Function]}
+                                                        renderLightBox={false}
+                                                        style="card"
+                                                        type="link"
+                                                        videoTitle={
+                                                          Array [
+                                                            Object {
+                                                              "duration": "",
+                                                              "key": 0,
+                                                              "title": "",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <CardLink
+                                                          card={
+                                                            Object {
+                                                              "copy": "",
+                                                              "cta": Object {
+                                                                "href": "https://www.example.com",
+                                                                "icon": Object {
+                                                                  "src": Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  },
+                                                                },
+                                                                "type": "link",
+                                                              },
+                                                              "eyebrow": "Topic",
+                                                              "heading": "Natural language processing.",
+                                                              "href": "https://www.example.com",
+                                                              "image": Object {
+                                                                "alt": "Image alt text",
+                                                                "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                              },
+                                                              "media": null,
+                                                              "target": null,
+                                                            }
+                                                          }
+                                                          disabled={false}
+                                                        >
+                                                          <Card
+                                                            copy=""
+                                                            cta={
+                                                              Object {
+                                                                "href": "https://www.example.com",
+                                                                "icon": Object {
+                                                                  "src": Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  },
+                                                                },
+                                                                "type": "link",
+                                                              }
+                                                            }
+                                                            customClassName="bx--card__CTA"
+                                                            eyebrow="Topic"
+                                                            heading="Natural language processing."
+                                                            href="https://www.example.com"
+                                                            image={
+                                                              Object {
+                                                                "alt": "Image alt text",
+                                                                "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                              }
+                                                            }
+                                                            media={null}
+                                                            target={null}
+                                                          >
+                                                            <ClickableTile
+                                                              className="bx--card bx--card__CTA"
+                                                              clicked={false}
+                                                              data-autoid="dds--card"
+                                                              handleClick={[Function]}
+                                                              handleKeyDown={[Function]}
+                                                              href="https://www.example.com"
+                                                              light={false}
+                                                              media={null}
+                                                              onClick={[Function]}
+                                                              target={null}
+                                                            >
+                                                              <a
+                                                                className="bx--tile bx--tile--clickable bx--card bx--card__CTA"
+                                                                data-autoid="dds--card"
+                                                                href="https://www.example.com"
+                                                                media={null}
+                                                                onClick={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                target={null}
+                                                              >
+                                                                <Image
+                                                                  alt="Image alt text"
+                                                                  classname="bx--card__img"
+                                                                  defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                                >
+                                                                  <div
+                                                                    className="bx--image"
+                                                                    data-autoid="dds--image__longdescription"
+                                                                  >
+                                                                    <picture>
+                                                                      <img
+                                                                        alt="Image alt text"
+                                                                        className="bx--image__img bx--card__img"
+                                                                        src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                                      />
+                                                                    </picture>
+                                                                  </div>
+                                                                </Image>
+                                                                <div
+                                                                  className="bx--card__wrapper"
+                                                                >
+                                                                  <p
+                                                                    className="bx--card__eyebrow"
+                                                                  >
+                                                                    Topic
+                                                                  </p>
+                                                                  <h3
+                                                                    className="bx--card__heading"
+                                                                  >
+                                                                    Natural language processing.
+                                                                  </h3>
+                                                                  <div
+                                                                    className="bx--card__footer"
+                                                                  >
+                                                                    <ForwardRef(ArrowRight20)
+                                                                      className="bx--card__cta"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--card__cta"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        src={
+                                                                          Object {
+                                                                            "$$typeof": Symbol(react.forward_ref),
+                                                                            "render": [Function],
+                                                                          }
+                                                                        }
+                                                                        viewBox="0 0 20 20"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--card__cta"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          src={
+                                                                            Object {
+                                                                              "$$typeof": Symbol(react.forward_ref),
+                                                                              "render": [Function],
+                                                                            }
+                                                                          }
+                                                                          viewBox="0 0 20 20"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowRight20)>
+                                                                  </div>
+                                                                </div>
+                                                              </a>
+                                                            </ClickableTile>
+                                                          </Card>
+                                                        </CardLink>
+                                                      </CardCTA>
+                                                    </div>
+                                                  </CTA>
+                                                </div>
+                                                <div
+                                                  aria-label="Natural language processing."
+                                                  className="bx--card-group__cards__col"
+                                                  key="1"
+                                                  role="region"
+                                                >
+                                                  <CTA
+                                                    copy=""
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://www.example.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card-group__card"
+                                                    eyebrow="Topic"
+                                                    heading="Natural language processing."
+                                                    href=""
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                      }
+                                                    }
+                                                    key="1"
+                                                    style="card"
+                                                    type="link"
+                                                  >
+                                                    <div
+                                                      aria-label=""
+                                                      className="bx--card-group__card"
+                                                      role="region"
+                                                    >
+                                                      <CardCTA
+                                                        copy=""
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        disableImage={false}
+                                                        eyebrow="Topic"
+                                                        heading="Natural language processing."
+                                                        href=""
+                                                        image={
+                                                          Object {
+                                                            "alt": "Image alt text",
+                                                            "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                          }
+                                                        }
+                                                        media={null}
+                                                        openLightBox={[Function]}
+                                                        renderLightBox={false}
+                                                        style="card"
+                                                        type="link"
+                                                        videoTitle={
+                                                          Array [
+                                                            Object {
+                                                              "duration": "",
+                                                              "key": 0,
+                                                              "title": "",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <CardLink
+                                                          card={
+                                                            Object {
+                                                              "copy": "",
+                                                              "cta": Object {
+                                                                "href": "https://www.example.com",
+                                                                "icon": Object {
+                                                                  "src": Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  },
+                                                                },
+                                                                "type": "link",
+                                                              },
+                                                              "eyebrow": "Topic",
+                                                              "heading": "Natural language processing.",
+                                                              "href": "https://www.example.com",
+                                                              "image": Object {
+                                                                "alt": "Image alt text",
+                                                                "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                              },
+                                                              "media": null,
+                                                              "target": null,
+                                                            }
+                                                          }
+                                                          disabled={false}
+                                                        >
+                                                          <Card
+                                                            copy=""
+                                                            cta={
+                                                              Object {
+                                                                "href": "https://www.example.com",
+                                                                "icon": Object {
+                                                                  "src": Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  },
+                                                                },
+                                                                "type": "link",
+                                                              }
+                                                            }
+                                                            customClassName="bx--card__CTA"
+                                                            eyebrow="Topic"
+                                                            heading="Natural language processing."
+                                                            href="https://www.example.com"
+                                                            image={
+                                                              Object {
+                                                                "alt": "Image alt text",
+                                                                "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                              }
+                                                            }
+                                                            media={null}
+                                                            target={null}
+                                                          >
+                                                            <ClickableTile
+                                                              className="bx--card bx--card__CTA"
+                                                              clicked={false}
+                                                              data-autoid="dds--card"
+                                                              handleClick={[Function]}
+                                                              handleKeyDown={[Function]}
+                                                              href="https://www.example.com"
+                                                              light={false}
+                                                              media={null}
+                                                              onClick={[Function]}
+                                                              target={null}
+                                                            >
+                                                              <a
+                                                                className="bx--tile bx--tile--clickable bx--card bx--card__CTA"
+                                                                data-autoid="dds--card"
+                                                                href="https://www.example.com"
+                                                                media={null}
+                                                                onClick={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                target={null}
+                                                              >
+                                                                <Image
+                                                                  alt="Image alt text"
+                                                                  classname="bx--card__img"
+                                                                  defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                                >
+                                                                  <div
+                                                                    className="bx--image"
+                                                                    data-autoid="dds--image__longdescription"
+                                                                  >
+                                                                    <picture>
+                                                                      <img
+                                                                        alt="Image alt text"
+                                                                        className="bx--image__img bx--card__img"
+                                                                        src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                                      />
+                                                                    </picture>
+                                                                  </div>
+                                                                </Image>
+                                                                <div
+                                                                  className="bx--card__wrapper"
+                                                                >
+                                                                  <p
+                                                                    className="bx--card__eyebrow"
+                                                                  >
+                                                                    Topic
+                                                                  </p>
+                                                                  <h3
+                                                                    className="bx--card__heading"
+                                                                  >
+                                                                    Natural language processing.
+                                                                  </h3>
+                                                                  <div
+                                                                    className="bx--card__footer"
+                                                                  >
+                                                                    <ForwardRef(ArrowRight20)
+                                                                      className="bx--card__cta"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--card__cta"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        src={
+                                                                          Object {
+                                                                            "$$typeof": Symbol(react.forward_ref),
+                                                                            "render": [Function],
+                                                                          }
+                                                                        }
+                                                                        viewBox="0 0 20 20"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--card__cta"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          src={
+                                                                            Object {
+                                                                              "$$typeof": Symbol(react.forward_ref),
+                                                                              "render": [Function],
+                                                                            }
+                                                                          }
+                                                                          viewBox="0 0 20 20"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowRight20)>
+                                                                  </div>
+                                                                </div>
+                                                              </a>
+                                                            </ClickableTile>
+                                                          </Card>
+                                                        </CardLink>
+                                                      </CardCTA>
+                                                    </div>
+                                                  </CTA>
+                                                </div>
+                                                <div
+                                                  aria-label="Natural language processing."
+                                                  className="bx--card-group__cards__col"
+                                                  key="2"
+                                                  role="region"
+                                                >
+                                                  <CTA
+                                                    copy=""
+                                                    cta={
+                                                      Object {
+                                                        "href": "https://www.example.com",
+                                                        "icon": Object {
+                                                          "src": Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "render": [Function],
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                    customClassName="bx--card-group__card"
+                                                    eyebrow="Topic"
+                                                    heading="Natural language processing."
+                                                    href=""
+                                                    image={
+                                                      Object {
+                                                        "alt": "Image alt text",
+                                                        "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                      }
+                                                    }
+                                                    key="2"
+                                                    style="card"
+                                                    type="link"
+                                                  >
+                                                    <div
+                                                      aria-label=""
+                                                      className="bx--card-group__card"
+                                                      role="region"
+                                                    >
+                                                      <CardCTA
+                                                        copy=""
+                                                        cta={
+                                                          Object {
+                                                            "href": "https://www.example.com",
+                                                            "icon": Object {
+                                                              "src": Object {
+                                                                "$$typeof": Symbol(react.forward_ref),
+                                                                "render": [Function],
+                                                              },
+                                                            },
+                                                          }
+                                                        }
+                                                        disableImage={false}
+                                                        eyebrow="Topic"
+                                                        heading="Natural language processing."
+                                                        href=""
+                                                        image={
+                                                          Object {
+                                                            "alt": "Image alt text",
+                                                            "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                          }
+                                                        }
+                                                        media={null}
+                                                        openLightBox={[Function]}
+                                                        renderLightBox={false}
+                                                        style="card"
+                                                        type="link"
+                                                        videoTitle={
+                                                          Array [
+                                                            Object {
+                                                              "duration": "",
+                                                              "key": 0,
+                                                              "title": "",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <CardLink
+                                                          card={
+                                                            Object {
+                                                              "copy": "",
+                                                              "cta": Object {
+                                                                "href": "https://www.example.com",
+                                                                "icon": Object {
+                                                                  "src": Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  },
+                                                                },
+                                                                "type": "link",
+                                                              },
+                                                              "eyebrow": "Topic",
+                                                              "heading": "Natural language processing.",
+                                                              "href": "https://www.example.com",
+                                                              "image": Object {
+                                                                "alt": "Image alt text",
+                                                                "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                              },
+                                                              "media": null,
+                                                              "target": null,
+                                                            }
+                                                          }
+                                                          disabled={false}
+                                                        >
+                                                          <Card
+                                                            copy=""
+                                                            cta={
+                                                              Object {
+                                                                "href": "https://www.example.com",
+                                                                "icon": Object {
+                                                                  "src": Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "render": [Function],
+                                                                  },
+                                                                },
+                                                                "type": "link",
+                                                              }
+                                                            }
+                                                            customClassName="bx--card__CTA"
+                                                            eyebrow="Topic"
+                                                            heading="Natural language processing."
+                                                            href="https://www.example.com"
+                                                            image={
+                                                              Object {
+                                                                "alt": "Image alt text",
+                                                                "defaultSrc": "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                                                              }
+                                                            }
+                                                            media={null}
+                                                            target={null}
+                                                          >
+                                                            <ClickableTile
+                                                              className="bx--card bx--card__CTA"
+                                                              clicked={false}
+                                                              data-autoid="dds--card"
+                                                              handleClick={[Function]}
+                                                              handleKeyDown={[Function]}
+                                                              href="https://www.example.com"
+                                                              light={false}
+                                                              media={null}
+                                                              onClick={[Function]}
+                                                              target={null}
+                                                            >
+                                                              <a
+                                                                className="bx--tile bx--tile--clickable bx--card bx--card__CTA"
+                                                                data-autoid="dds--card"
+                                                                href="https://www.example.com"
+                                                                media={null}
+                                                                onClick={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                target={null}
+                                                              >
+                                                                <Image
+                                                                  alt="Image alt text"
+                                                                  classname="bx--card__img"
+                                                                  defaultSrc="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                                >
+                                                                  <div
+                                                                    className="bx--image"
+                                                                    data-autoid="dds--image__longdescription"
+                                                                  >
+                                                                    <picture>
+                                                                      <img
+                                                                        alt="Image alt text"
+                                                                        className="bx--image__img bx--card__img"
+                                                                        src="https://dummyimage.com/1056x792/ee5396/161616%26text=4:3"
+                                                                      />
+                                                                    </picture>
+                                                                  </div>
+                                                                </Image>
+                                                                <div
+                                                                  className="bx--card__wrapper"
+                                                                >
+                                                                  <p
+                                                                    className="bx--card__eyebrow"
+                                                                  >
+                                                                    Topic
+                                                                  </p>
+                                                                  <h3
+                                                                    className="bx--card__heading"
+                                                                  >
+                                                                    Natural language processing.
+                                                                  </h3>
+                                                                  <div
+                                                                    className="bx--card__footer"
+                                                                  >
+                                                                    <ForwardRef(ArrowRight20)
+                                                                      className="bx--card__cta"
+                                                                      src={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "render": [Function],
+                                                                        }
+                                                                      }
+                                                                    >
+                                                                      <Icon
+                                                                        className="bx--card__cta"
+                                                                        fill="currentColor"
+                                                                        height={20}
+                                                                        preserveAspectRatio="xMidYMid meet"
+                                                                        src={
+                                                                          Object {
+                                                                            "$$typeof": Symbol(react.forward_ref),
+                                                                            "render": [Function],
+                                                                          }
+                                                                        }
+                                                                        viewBox="0 0 20 20"
+                                                                        width={20}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="bx--card__cta"
+                                                                          fill="currentColor"
+                                                                          focusable="false"
+                                                                          height={20}
+                                                                          preserveAspectRatio="xMidYMid meet"
+                                                                          src={
+                                                                            Object {
+                                                                              "$$typeof": Symbol(react.forward_ref),
+                                                                              "render": [Function],
+                                                                            }
+                                                                          }
+                                                                          viewBox="0 0 20 20"
+                                                                          width={20}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                          />
+                                                                        </svg>
+                                                                      </Icon>
+                                                                    </ForwardRef(ArrowRight20)>
+                                                                  </div>
+                                                                </div>
+                                                              </a>
+                                                            </ClickableTile>
+                                                          </Card>
+                                                        </CardLink>
+                                                      </CardCTA>
+                                                    </div>
+                                                  </CTA>
+                                                </div>
+                                              </div>
+                                            </CardGroup>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </ContentBlock>
+                                  </div>
+                                </ContentBlockCards>
+                                <a
+                                  data-title="Duis aute irure dolor in reprehenderit"
+                                  name="section-7"
+                                />
+                                <CalloutQuote
+                                  quote={
+                                    Object {
+                                      "copy": "Duis aute irure dolor in reprehenderit",
+                                      "cta": Object {
+                                        "copy": "Link with Icon",
+                                        "href": "https://example.com",
+                                        "type": "local",
+                                      },
+                                      "source": Object {
+                                        "copy": "dolor sit amet",
+                                        "heading": "Lorem ipsum",
+                                      },
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="bx--callout-quote"
+                                    data-autoid="dds--callout-quote"
+                                  >
+                                    <Callout>
+                                      <section
+                                        className="bx--callout__container"
+                                        data-autoid="dds--callout__container"
+                                      >
+                                        <div
+                                          className="bx--callout__column"
+                                          data-autoid="dds--callout__column"
+                                        >
+                                          <div
+                                            className="bx--callout__content"
+                                            data-autoid="dds--callout__content"
+                                          >
+                                            <Quote
+                                              copy="Duis aute irure dolor in reprehenderit"
+                                              cta={
+                                                Object {
+                                                  "copy": "Link with Icon",
+                                                  "href": "https://example.com",
+                                                  "type": "local",
+                                                }
+                                              }
+                                              inverse={true}
+                                              source={
+                                                Object {
+                                                  "copy": "dolor sit amet",
+                                                  "heading": "Lorem ipsum",
+                                                }
+                                              }
+                                            >
+                                              <div
+                                                className="bx--quote bx--quote__inverse"
+                                                data-autoid="dds--quote"
+                                              >
+                                                <div
+                                                  className="bx--quote__container"
+                                                >
+                                                  <div
+                                                    className="bx--quote__wrapper"
+                                                    data-autoid="dds--quote__copy"
+                                                  >
+                                                    <span
+                                                      className="bx--quote__mark"
+                                                    >
+                                                      “
+                                                    </span>
+                                                    <blockquote
+                                                      className="bx--quote__copy"
+                                                    >
+                                                      Duis aute irure dolor in reprehenderit
+                                                      ”
+                                                    </blockquote>
+                                                  </div>
+                                                  <div
+                                                    className="bx--quote__source"
+                                                    data-autoid="dds--quote__source"
+                                                  >
+                                                    <p
+                                                      className="bx--quote__source-heading"
+                                                    >
+                                                      Lorem ipsum
+                                                    </p>
+                                                    <p
+                                                      className="bx--quote__source-body"
+                                                    >
+                                                      dolor sit amet
+                                                    </p>
+                                                  </div>
+                                                </div>
+                                                <div
+                                                  className="bx--quote__footer"
+                                                >
+                                                  <HorizontalRule>
+                                                    <hr
+                                                      className="bx--hr"
+                                                      data-autoid="dds--hr"
+                                                    />
+                                                  </HorizontalRule>
+                                                  <LinkWithIcon
+                                                    href="https://example.com"
+                                                    iconPlacement="right"
+                                                  >
+                                                    <div
+                                                      className="bx--link-with-icon__container"
+                                                      data-autoid="dds--link-with-icon"
+                                                    >
+                                                      <Link
+                                                        className="bx--link-with-icon"
+                                                        href="https://example.com"
+                                                      >
+                                                        <a
+                                                          className="bx--link bx--link-with-icon"
+                                                          href="https://example.com"
+                                                        >
+                                                          <span>
+                                                            Link with Icon
+                                                          </span>
+                                                          <ForwardRef(ArrowRight20)>
+                                                            <Icon
+                                                              fill="currentColor"
+                                                              height={20}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 20 20"
+                                                              width={20}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                fill="currentColor"
+                                                                focusable="false"
+                                                                height={20}
+                                                                preserveAspectRatio="xMidYMid meet"
+                                                                viewBox="0 0 20 20"
+                                                                width={20}
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                              >
+                                                                <path
+                                                                  d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                                />
+                                                              </svg>
+                                                            </Icon>
+                                                          </ForwardRef(ArrowRight20)>
+                                                        </a>
+                                                      </Link>
+                                                    </div>
+                                                  </LinkWithIcon>
+                                                </div>
+                                              </div>
+                                            </Quote>
+                                          </div>
+                                        </div>
+                                      </section>
+                                    </Callout>
+                                  </div>
+                                </CalloutQuote>
+                              </div>
+                            </div>
+                          </div>
+                        </section>
+                      </Layout>
+                    </section>
+                  </TableOfContents>
+                  <div
+                    className="bx--grid"
+                    style={
+                      Object {
+                        "backgroundColor": "#f4f4f4",
+                      }
+                    }
+                  >
+                    <div
+                      className="bx--row"
+                    >
+                      <div
+                        className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-4"
+                      >
+                        <CTASection
+                          copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
+                          cta={
+                            Object {
+                              "buttons": Array [
+                                Object {
+                                  "copy": "Contact sales",
+                                  "href": "https://example.com/",
+                                  "iconDescription": "right arrow icon",
+                                  "onClick": [Function],
+                                  "renderIcon": Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "render": [Function],
+                                  },
+                                  "target": null,
+                                  "type": "local",
+                                },
+                              ],
+                              "style": "button",
+                              "type": "local",
+                            }
+                          }
+                          heading="Take the next step"
+                          items={
+                            Array [
+                              Object {
+                                "copy": "IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.",
+                                "cta": Object {
+                                  "copy": "Find a partner",
+                                  "href": "https://example.com/",
+                                  "type": "local",
+                                },
+                                "heading": "Get connected",
+                              },
+                              Object {
+                                "copy": "Dig into more self-directed learning about DevOps methodologies.",
+                                "cta": Object {
+                                  "copy": "Browse tutorials",
+                                  "href": "https://example.com/",
+                                  "type": "local",
+                                },
+                                "heading": "Learn how",
+                              },
+                            ]
+                          }
+                          theme="g10"
+                        >
+                          <section
+                            className="bx--cta-section bx--cta-section__has-items bx--cta-section--g10"
+                            data-autoid="dds--cta-section"
+                          >
+                            <ContentBlock
+                              border={false}
+                              copy="Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs."
+                              heading="Take the next step"
+                            >
+                              <div
+                                className="bx--content-block"
+                                data-autoid="dds--content-block"
+                              >
+                                <div>
+                                  <h2
+                                    className="bx--content-block__heading"
+                                    data-autoid="dds--content-block__heading"
+                                  >
+                                    Take the next step
+                                  </h2>
+                                </div>
+                                <div
+                                  className="bx--content-block__copy"
+                                  dangerouslySetInnerHTML={
+                                    Object {
+                                      "__html": "<p>Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.</p> ",
+                                    }
+                                  }
+                                />
+                                <div
+                                  className="bx--content-block__children"
+                                  data-autoid="dds--content-block__children"
+                                />
+                              </div>
+                            </ContentBlock>
+                            <CTA
+                              buttons={
+                                Array [
+                                  Object {
+                                    "copy": "Contact sales",
+                                    "href": "https://example.com/",
+                                    "iconDescription": "right arrow icon",
+                                    "onClick": [Function],
+                                    "renderIcon": Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "render": [Function],
+                                    },
+                                    "target": null,
+                                    "type": "local",
+                                  },
+                                ]
+                              }
+                              copy=""
+                              customClassName="bx--cta-section__cta"
+                              href=""
+                              style="button"
+                              type="local"
+                            >
+                              <div
+                                className="bx--cta-section__cta"
+                              >
+                                <ButtonCTA
+                                  buttons={
+                                    Array [
+                                      Object {
+                                        "copy": "Contact sales",
+                                        "href": "https://example.com/",
+                                        "iconDescription": "right arrow icon",
+                                        "onClick": [Function],
+                                        "renderIcon": Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "render": [Function],
+                                        },
+                                        "target": null,
+                                        "type": "local",
+                                      },
+                                    ]
+                                  }
+                                  copy=""
+                                  formatCTAcopy={[Function]}
+                                  href=""
+                                  openLightBox={[Function]}
+                                  renderLightBox={false}
+                                  style="button"
+                                  type="local"
+                                  videoTitle={
+                                    Array [
+                                      Object {
+                                        "duration": "",
+                                        "key": 0,
+                                        "title": "",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <ButtonGroup
+                                    buttons={
+                                      Array [
+                                        Object {
+                                          "copy": "Contact sales",
+                                          "href": "https://example.com/",
+                                          "iconDescription": "right arrow icon",
+                                          "onClick": [Function],
+                                          "renderIcon": Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "render": [Function],
+                                          },
+                                          "target": null,
+                                          "type": "local",
+                                        },
+                                      ]
+                                    }
+                                    enableSizeByContent={true}
+                                  >
+                                    <ol
+                                      className="bx--buttongroup"
+                                      data-autoid="dds--button-group"
+                                    >
+                                      <li
+                                        className="bx--buttongroup-item"
+                                      >
+                                        <ForwardRef(Button)
+                                          copy="Contact sales"
+                                          data-autoid="dds--button-group-0"
+                                          disabled={false}
+                                          href="https://example.com/"
+                                          iconDescription="right arrow icon"
+                                          kind="primary"
+                                          onClick={[Function]}
+                                          renderIcon={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "render": [Function],
+                                            }
+                                          }
+                                          tabIndex={0}
+                                          target={null}
+                                          type="button"
+                                        >
+                                          <a
+                                            className="bx--btn bx--btn--primary"
+                                            copy="Contact sales"
+                                            data-autoid="dds--button-group-0"
+                                            href="https://example.com/"
+                                            onClick={[Function]}
+                                            tabIndex={0}
+                                            target={null}
+                                          >
+                                            Contact sales
+                                            <ForwardRef(ArrowRight20)
+                                              aria-hidden="true"
+                                              aria-label="right arrow icon"
+                                              className="bx--btn__icon"
+                                            >
+                                              <Icon
+                                                aria-hidden="true"
+                                                aria-label="right arrow icon"
+                                                className="bx--btn__icon"
+                                                fill="currentColor"
+                                                height={20}
+                                                preserveAspectRatio="xMidYMid meet"
+                                                viewBox="0 0 20 20"
+                                                width={20}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <svg
+                                                  aria-hidden="true"
+                                                  aria-label="right arrow icon"
+                                                  className="bx--btn__icon"
+                                                  fill="currentColor"
+                                                  focusable="false"
+                                                  height={20}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  role="img"
+                                                  viewBox="0 0 20 20"
+                                                  width={20}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                  />
+                                                </svg>
+                                              </Icon>
+                                            </ForwardRef(ArrowRight20)>
+                                          </a>
+                                        </ForwardRef(Button)>
+                                      </li>
+                                    </ol>
+                                  </ButtonGroup>
+                                </ButtonCTA>
+                              </div>
+                            </CTA>
+                            <div
+                              className="bx--helper-wrapper"
+                            >
+                              <div
+                                className="bx--content-item-wrapper"
+                              >
+                                <ContentItem
+                                  copy="IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you."
+                                  cta={
+                                    Object {
+                                      "copy": "Find a partner",
+                                      "href": "https://example.com/",
+                                      "type": "local",
+                                    }
+                                  }
+                                  heading="Get connected"
+                                  key="0"
+                                >
+                                  <div
+                                    className="bx--content-item"
+                                    data-autoid="dds--content-item"
+                                  >
+                                    <h4
+                                      className="bx--content-item__heading"
+                                      data-autoid="dds--content-item__heading"
+                                    >
+                                      Get connected
+                                    </h4>
+                                    <div
+                                      className="bx--content-item__copy"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p> ",
+                                        }
+                                      }
+                                      data-autoid="dds--content-item__copy"
+                                    />
+                                    <CTA
+                                      copy="Find a partner"
+                                      customClassName="bx--content-item__cta"
+                                      href="https://example.com/"
+                                      style="text"
+                                      type="local"
+                                    >
+                                      <div
+                                        className="bx--content-item__cta"
+                                      >
+                                        <TextCTA
+                                          copy="Find a partner"
+                                          formatCTAcopy={[Function]}
+                                          href="https://example.com/"
+                                          iconPlacement="right"
+                                          openLightBox={[Function]}
+                                          renderLightBox={false}
+                                          style="text"
+                                          type="local"
+                                          videoTitle={
+                                            Array [
+                                              Object {
+                                                "duration": "",
+                                                "key": 0,
+                                                "title": "",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <LinkWithIcon
+                                            href="https://example.com/"
+                                            iconPlacement="right"
+                                            onClick={[Function]}
+                                            target={null}
+                                          >
+                                            <div
+                                              className="bx--link-with-icon__container"
+                                              data-autoid="dds--link-with-icon"
+                                            >
+                                              <Link
+                                                className="bx--link-with-icon"
+                                                href="https://example.com/"
+                                                onClick={[Function]}
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--link-with-icon"
+                                                  href="https://example.com/"
+                                                  onClick={[Function]}
+                                                  target={null}
+                                                >
+                                                  <span>
+                                                    Find a partner
+                                                  </span>
+                                                  <ForwardRef(ArrowRight20)>
+                                                    <Icon
+                                                      fill="currentColor"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        fill="currentColor"
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ArrowRight20)>
+                                                </a>
+                                              </Link>
+                                            </div>
+                                          </LinkWithIcon>
+                                        </TextCTA>
+                                      </div>
+                                    </CTA>
+                                  </div>
+                                </ContentItem>
+                                <ContentItem
+                                  copy="Dig into more self-directed learning about DevOps methodologies."
+                                  cta={
+                                    Object {
+                                      "copy": "Browse tutorials",
+                                      "href": "https://example.com/",
+                                      "type": "local",
+                                    }
+                                  }
+                                  heading="Learn how"
+                                  key="1"
+                                >
+                                  <div
+                                    className="bx--content-item"
+                                    data-autoid="dds--content-item"
+                                  >
+                                    <h4
+                                      className="bx--content-item__heading"
+                                      data-autoid="dds--content-item__heading"
+                                    >
+                                      Learn how
+                                    </h4>
+                                    <div
+                                      className="bx--content-item__copy"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>Dig into more self-directed learning about DevOps methodologies.</p> ",
+                                        }
+                                      }
+                                      data-autoid="dds--content-item__copy"
+                                    />
+                                    <CTA
+                                      copy="Browse tutorials"
+                                      customClassName="bx--content-item__cta"
+                                      href="https://example.com/"
+                                      style="text"
+                                      type="local"
+                                    >
+                                      <div
+                                        className="bx--content-item__cta"
+                                      >
+                                        <TextCTA
+                                          copy="Browse tutorials"
+                                          formatCTAcopy={[Function]}
+                                          href="https://example.com/"
+                                          iconPlacement="right"
+                                          openLightBox={[Function]}
+                                          renderLightBox={false}
+                                          style="text"
+                                          type="local"
+                                          videoTitle={
+                                            Array [
+                                              Object {
+                                                "duration": "",
+                                                "key": 0,
+                                                "title": "",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <LinkWithIcon
+                                            href="https://example.com/"
+                                            iconPlacement="right"
+                                            onClick={[Function]}
+                                            target={null}
+                                          >
+                                            <div
+                                              className="bx--link-with-icon__container"
+                                              data-autoid="dds--link-with-icon"
+                                            >
+                                              <Link
+                                                className="bx--link-with-icon"
+                                                href="https://example.com/"
+                                                onClick={[Function]}
+                                                target={null}
+                                              >
+                                                <a
+                                                  className="bx--link bx--link-with-icon"
+                                                  href="https://example.com/"
+                                                  onClick={[Function]}
+                                                  target={null}
+                                                >
+                                                  <span>
+                                                    Browse tutorials
+                                                  </span>
+                                                  <ForwardRef(ArrowRight20)>
+                                                    <Icon
+                                                      fill="currentColor"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 20 20"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        fill="currentColor"
+                                                        focusable="false"
+                                                        height={20}
+                                                        preserveAspectRatio="xMidYMid meet"
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                                        />
+                                                      </svg>
+                                                    </Icon>
+                                                  </ForwardRef(ArrowRight20)>
+                                                </a>
+                                              </Link>
+                                            </div>
+                                          </LinkWithIcon>
+                                        </TextCTA>
+                                      </div>
+                                    </CTA>
+                                  </div>
+                                </ContentItem>
+                              </div>
+                            </div>
+                          </section>
+                        </CTASection>
+                      </div>
+                    </div>
+                  </div>
+                </Content>
+              </div>
+            </main>
+          </div>
+        </div>
+        <Footer
+          disableLocaleButton={false}
+          footerProps={null}
+          isCustom={false}
+          languageCallback={[Function]}
+          languageInitialItem={
+            Object {
+              "id": "en",
+              "text": "English",
+            }
+          }
+          languageOnly={false}
+          mastheadProps={null}
+          navigation={null}
+        >
+          <footer
+            className="bx--footer"
+            data-autoid="dds--footer"
+          >
+            <section
+              className="bx--footer__main"
+            >
+              <div
+                className="bx--footer__main-container"
+              >
+                <Logo>
+                  <div
+                    className="bx--footer-logo"
+                    data-autoid="dds--footer-logo"
+                  >
+                    <a
+                      className="bx--footer-logo__link"
+                      data-autoid="dds--footer-logo__link"
+                      href="https://www.ibm.com/"
+                    >
+                      <FooterLogo
+                        className="bx--footer-logo__logo"
+                        viewBox="0 0 157 65"
+                      >
+                        <svg
+                          className="bx--footer-logo__logo"
+                          viewBox="0 0 157 65"
+                        >
+                          <title>
+                            IBM Logo
+                          </title>
+                          <path
+                            d="M30.444 60.208v4.03H0v-4.03h30.444zm78.291-.001v4.03H86.983v-4.03h21.752zm47.858 0v4.03H134.84v-4.03h21.753zm-33.416 0l-1.398 4.03-1.38-4.03h2.778zm-88.384 0h42.775c-2.797 2.426-6.39 3.925-10.327 4.025l-.423.006H34.793v-4.03h42.775zm-4.35-8.46v4.03H0v-4.03h30.444zm52.402 0c-.332 1.248-.8 2.44-1.389 3.555l-.259.474H34.793v-4.029h48.052zm73.748-.005v4.031H134.84v-4.03h21.753zm-47.858 0v4.031H86.983v-4.03h21.752zm17.375 0l-1.398 4.031h-5.85l-1.395-4.03h8.643zM21.745 43.285v4.03H8.698v-4.03h13.047zm61.195 0a17.32 17.32 0 0 1 .476 3.51l.008.52H68.796v-4.03H82.94zm-26.401 0v4.03H43.491v-4.03H56.54zm72.502-.007l-1.396 4.03H115.93l-1.397-4.03h14.507zm18.85 0v4.03h-13.05v-4.03h13.05zm-39.156 0v4.03H95.684v-4.03h13.051zm-86.99-8.454v4.03H8.698v-4.03h13.047zm56.117 0a16.945 16.945 0 0 1 2.926 3.582l.264.447h-37.56v-4.03h34.37zm30.873-.01v4.03H95.684v-4.03h13.051zm39.157 0v4.03H134.84v-4.03h13.052zm-15.919 0l-1.396 4.03h-17.579l-1.396-4.03h20.371zm-50.778-8.452a16.963 16.963 0 0 1-2.82 3.674l-.37.355H43.49v-4.029h37.704zm-59.45 0v4.03H8.698v-4.03h13.047zm126.147-.013v4.031H134.84v-3.839l-1.33 3.839h-11.456l1.373-4.03h24.465zm-27.743 0l1.372 4.031h-11.456l-1.33-3.839v3.84H95.684v-4.032h24.465zm-98.404-8.448v4.03H8.698V17.9h13.047zm61.68 0c0 1.215-.134 2.399-.375 3.542l-.11.487H68.796V17.9h14.628zM56.538 17.9v4.03H43.491V17.9H56.54zm91.352-.015v4.03h-22.954l1.37-4.03h21.584zm-30.624 0l1.372 4.03H95.684v-4.03h21.583zM30.444 9.437v4.03H0v-4.03h30.444zm50.753 0a17.048 17.048 0 0 1 1.498 3.499l.15.531H34.794v-4.03h46.403zm75.396-.018v4.03h-28.776l1.373-4.03h27.403zm-42.207 0l1.372 4.031H86.982V9.42h27.404zM30.444.978v4.03H0V.977h30.444zm36.374 0c3.96 0 7.594 1.415 10.448 3.772l.303.257H34.794V.977h32.024zm89.775-.022v4.031h-25.894l1.372-4.03h24.522zm-45.098 0l1.372 4.03H86.982V.955h24.513z"
+                          />
+                        </svg>
+                      </FooterLogo>
+                    </a>
+                  </div>
+                </Logo>
+                <FooterNav
+                  groups={Array []}
+                />
+                <LocaleButton
+                  aria=""
+                  displayLang=""
+                >
+                  <div
+                    className="bx--locale-btn__container"
+                  >
+                    <ForwardRef(Button)
+                      aria-label=""
+                      className="bx--locale-btn"
+                      data-autoid="dds--locale-btn"
+                      disabled={false}
+                      iconDescription="Earth Filled Icon"
+                      kind="secondary"
+                      onClick={[Function]}
+                      renderIcon={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <button
+                        aria-label=""
+                        className="bx--locale-btn bx--btn bx--btn--secondary"
+                        data-autoid="dds--locale-btn"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        <ForwardRef(EarthFilled20)
+                          aria-hidden="true"
+                          aria-label="Earth Filled Icon"
+                          className="bx--btn__icon"
+                        >
+                          <Icon
+                            aria-hidden="true"
+                            aria-label="Earth Filled Icon"
+                            className="bx--btn__icon"
+                            fill="currentColor"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Earth Filled Icon"
+                              className="bx--btn__icon"
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M16,2A14,14,0,1,0,30,16,14.0158,14.0158,0,0,0,16,2ZM4.02,16.394l1.3384.4458L7,19.3027v1.2831a1,1,0,0,0,.2929.7071L10,24v2.3765A11.9941,11.9941,0,0,1,4.02,16.394ZM16,28a11.9682,11.9682,0,0,1-2.5718-.2847L14,26l1.8046-4.5116a1,1,0,0,0-.0964-.9261l-1.4113-2.117A1,1,0,0,0,13.4648,18h-4.93L7.2866,16.1274,9.4141,14H11v2h2V13.2656l3.8682-6.7695-1.7364-.9922L14.2769,7H11.5352l-1.086-1.6289A11.861,11.861,0,0,1,20,4.7V8a1,1,0,0,0,1,1h1.4648a1,1,0,0,0,.8321-.4453l.8769-1.3154A12.0331,12.0331,0,0,1,26.8945,11H22.82a1,1,0,0,0-.9806.8039l-.7221,4.4708a1,1,0,0,0,.54,1.0539L25,19l.6851,4.0557A11.9793,11.9793,0,0,1,16,28Z"
+                              />
+                            </svg>
+                          </Icon>
+                        </ForwardRef(EarthFilled20)>
+                      </button>
+                    </ForwardRef(Button)>
+                  </div>
+                </LocaleButton>
+              </div>
+            </section>
+            <LegalNav
+              links={Array []}
+            />
+          </footer>
+        </Footer>
+      </DotcomShell>
+    </Default>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Components|Expressive Modal Default 1`] = `
 <Container
   story={[Function]}
@@ -42438,7 +51398,7 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                           >
                             <div
                               className="bx--video-player__video"
-                              id="bx--video-player__video-0_uka1msg4-70"
+                              id="bx--video-player__video-0_uka1msg4-86"
                             >
                               <VideoImageOverlay
                                 embedVideo={[Function]}
@@ -43361,7 +52321,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                                 >
                                   <div
                                     className="bx--video-player__video"
-                                    id="bx--video-player__video-0_uka1msg4-73"
+                                    id="bx--video-player__video-0_uka1msg4-89"
                                   />
                                 </div>
                               </div>
@@ -47304,14 +56264,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-74"
+                                        aria-describedby="bx--image-90"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-74"
+                                      id="bx--image-90"
                                     >
                                       Company A
                                     </div>
@@ -47345,14 +56305,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-75"
+                                        aria-describedby="bx--image-91"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-75"
+                                      id="bx--image-91"
                                     >
                                       Company B
                                     </div>
@@ -47386,14 +56346,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-76"
+                                        aria-describedby="bx--image-92"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-76"
+                                      id="bx--image-92"
                                     >
                                       Company C
                                     </div>
@@ -47427,14 +56387,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-77"
+                                        aria-describedby="bx--image-93"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-77"
+                                      id="bx--image-93"
                                     >
                                       Company D
                                     </div>
@@ -47468,14 +56428,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-78"
+                                        aria-describedby="bx--image-94"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-78"
+                                      id="bx--image-94"
                                     >
                                       Company E
                                     </div>
@@ -47509,14 +56469,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-79"
+                                        aria-describedby="bx--image-95"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-79"
+                                      id="bx--image-95"
                                     >
                                       Company F
                                     </div>
@@ -47550,14 +56510,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-80"
+                                        aria-describedby="bx--image-96"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-80"
+                                      id="bx--image-96"
                                     >
                                       Company G
                                     </div>
@@ -47591,14 +56551,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-81"
+                                        aria-describedby="bx--image-97"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-81"
+                                      id="bx--image-97"
                                     >
                                       Company H
                                     </div>
@@ -47632,14 +56592,14 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                     <picture>
                                       <img
                                         alt="Image alt text"
-                                        aria-describedby="bx--image-82"
+                                        aria-describedby="bx--image-98"
                                         className="bx--image__img bx--logo-grid_img"
                                         src="https://dummyimage.com/288x216/ee5396/161616&text=1:1"
                                       />
                                     </picture>
                                     <div
                                       className="bx--image__longdescription"
-                                      id="bx--image-82"
+                                      id="bx--image-98"
                                     >
                                       Company I
                                     </div>
@@ -47861,7 +56821,7 @@ exports[`Storyshots Components|Masthead Default 1`] = `
     <Masthead
       hasProfile={true}
       hasSearch={true}
-      mastheadL1Data={false}
+      mastheadL1Data={null}
       navigation="default"
       placeHolderText="Search all of IBM"
       platform={null}
@@ -48301,7 +57261,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
     <Masthead
       hasProfile={true}
       hasSearch={true}
-      mastheadL1Data={false}
+      mastheadL1Data={null}
       navigation="default"
       placeHolderText="Search all of IBM"
       platform={null}
@@ -48886,6 +57846,2984 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
         </render>
       </HeaderContainer>
     </Masthead>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
+exports[`Storyshots Components|Masthead With L 1 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <Default
+      parameters={
+        Object {
+          "__id": "components-masthead--with-l-1",
+          "carbon-theme": Object {
+            "disabled": true,
+          },
+          "component": undefined,
+          "docs": Object {},
+          "fileName": "./components/Masthead/__stories__/Masthead.stories.js",
+          "framework": "react",
+          "knobs": Object {
+            "Masthead": [Function],
+          },
+          "options": Object {
+            "name": "IBM.com Library React",
+            "storySort": [Function],
+            "url": "https://github.com/carbon-design-system/ibm-dotcom-library",
+          },
+          "props": Object {
+            "Masthead": Object {
+              "hasProfile": true,
+              "hasSearch": true,
+              "mastheadL1Data": Object {
+                "eyebrowLink": "#",
+                "eyebrowText": "Eyebrow",
+                "navigationL1": Array [
+                  Object {
+                    "hasMegapanel": true,
+                    "hasMenu": true,
+                    "menuSections": Array [
+                      Object {
+                        "heading": "Explore",
+                        "menuItems": Array [
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "",
+                              "feature": Object {
+                                "heading": "",
+                                "imageUrl": "",
+                                "linkTitle": "",
+                                "linkUrl": "",
+                              },
+                              "headingTitle": "",
+                              "headingUrl": "",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Subnav 1",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 2",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 3",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 4",
+                                    "url": "",
+                                  },
+                                ],
+                                "title": "Title",
+                              },
+                            },
+                            "title": "Link 1",
+                            "url": "",
+                          },
+                        ],
+                      },
+                    ],
+                    "title": "Link 1",
+                    "url": "",
+                  },
+                  Object {
+                    "hasMegapanel": true,
+                    "hasMenu": true,
+                    "menuSections": Array [
+                      Object {
+                        "heading": "",
+                        "menuItems": Array [
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                              "feature": Object {
+                                "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                                "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                                "linkTitle": "Explore all our business consulting and technology services",
+                                "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                              },
+                              "headingTitle": "Services",
+                              "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Subnav 1",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 2",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 3",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 4",
+                                    "url": "",
+                                  },
+                                ],
+                                "title": "Quicklinks",
+                              },
+                            },
+                            "title": "Link 2",
+                            "url": "",
+                          },
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "Funding options that fit your business",
+                              "feature": Object {
+                                "heading": "Cloud financing strategies that work for your business",
+                                "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                                "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                                "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                              },
+                              "headingTitle": "Financing",
+                              "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Subnav 1",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 2",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 3",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 4",
+                                    "url": "",
+                                  },
+                                ],
+                                "title": "Quicklinks",
+                              },
+                            },
+                            "title": "Financing",
+                            "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                          },
+                        ],
+                      },
+                    ],
+                    "title": "Link 2",
+                    "url": "",
+                  },
+                  Object {
+                    "hasMegapanel": false,
+                    "hasMenu": false,
+                    "menuSections": Array [],
+                    "title": "Industries",
+                    "url": "https://www.ibm.com/industries?lnk=min",
+                  },
+                  Object {
+                    "hasMegapanel": true,
+                    "hasMenu": true,
+                    "menuSections": Array [
+                      Object {
+                        "heading": "",
+                        "menuItems": Array [
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "",
+                              "feature": Object {
+                                "heading": "IBM Developer newsletters",
+                                "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                                "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                                "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              "headingTitle": "IBM Developer",
+                              "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Subnav 1",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 2",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 3",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 4",
+                                    "url": "",
+                                  },
+                                ],
+                                "title": "Quicklinks",
+                              },
+                            },
+                            "title": "IBM Developer",
+                            "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "",
+                              "feature": Object {
+                                "heading": "Blockchain 101",
+                                "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                                "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                                "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              "headingTitle": "Blockchain",
+                              "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Subnav 1",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 2",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 3",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "title": "Subnav 4",
+                                    "url": "",
+                                  },
+                                ],
+                                "title": "Quicklinks",
+                              },
+                            },
+                            "title": "Blockchain",
+                            "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "",
+                              "feature": Object {
+                                "heading": "Make sense of Kubernetes",
+                                "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                                "linkTitle": "Deploy a simple Python application with Kubernetes",
+                                "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              "headingTitle": "Containers",
+                              "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Code patterns",
+                                    "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "title": "Tutorials",
+                                    "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "title": "Events",
+                                    "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                ],
+                                "title": "Quicklinks",
+                              },
+                            },
+                            "title": "Containers",
+                            "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          Object {
+                            "megapanelContent": Object {
+                              "description": "",
+                              "feature": Object {
+                                "heading": "Train your data no matter where it lives",
+                                "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                                "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                                "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              "headingTitle": "Analytics",
+                              "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                              "quickLinks": Object {
+                                "links": Array [
+                                  Object {
+                                    "title": "Code patterns",
+                                    "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "title": "Tutorials",
+                                    "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "title": "Events",
+                                    "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "title": "Developer community",
+                                    "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                ],
+                                "title": "Quicklinks",
+                              },
+                            },
+                            "title": "Analytics",
+                            "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                        ],
+                      },
+                    ],
+                    "title": "Link 3",
+                    "url": "",
+                  },
+                  Object {
+                    "hasMegapanel": false,
+                    "hasMenu": false,
+                    "menuSections": Array [],
+                    "title": "Support",
+                    "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                  },
+                ],
+                "title": "Stock Charts",
+                "titleLink": "https://www.example.com",
+              },
+              "placeHolderText": "Search all of IBM",
+            },
+          },
+          "subcomponents": undefined,
+        }
+      }
+    >
+      <Masthead
+        hasProfile={true}
+        hasSearch={true}
+        mastheadL1Data={
+          Object {
+            "eyebrowLink": "#",
+            "eyebrowText": "Eyebrow",
+            "navigationL1": Array [
+              Object {
+                "hasMegapanel": true,
+                "hasMenu": true,
+                "menuSections": Array [
+                  Object {
+                    "heading": "Explore",
+                    "menuItems": Array [
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "",
+                          "feature": Object {
+                            "heading": "",
+                            "imageUrl": "",
+                            "linkTitle": "",
+                            "linkUrl": "",
+                          },
+                          "headingTitle": "",
+                          "headingUrl": "",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Subnav 1",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 2",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 3",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 4",
+                                "url": "",
+                              },
+                            ],
+                            "title": "Title",
+                          },
+                        },
+                        "title": "Link 1",
+                        "url": "",
+                      },
+                    ],
+                  },
+                ],
+                "title": "Link 1",
+                "url": "",
+              },
+              Object {
+                "hasMegapanel": true,
+                "hasMenu": true,
+                "menuSections": Array [
+                  Object {
+                    "heading": "",
+                    "menuItems": Array [
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                          "feature": Object {
+                            "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                            "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                            "linkTitle": "Explore all our business consulting and technology services",
+                            "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                          },
+                          "headingTitle": "Services",
+                          "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Subnav 1",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 2",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 3",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 4",
+                                "url": "",
+                              },
+                            ],
+                            "title": "Quicklinks",
+                          },
+                        },
+                        "title": "Link 2",
+                        "url": "",
+                      },
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "Funding options that fit your business",
+                          "feature": Object {
+                            "heading": "Cloud financing strategies that work for your business",
+                            "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                            "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                            "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                          },
+                          "headingTitle": "Financing",
+                          "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Subnav 1",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 2",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 3",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 4",
+                                "url": "",
+                              },
+                            ],
+                            "title": "Quicklinks",
+                          },
+                        },
+                        "title": "Financing",
+                        "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                      },
+                    ],
+                  },
+                ],
+                "title": "Link 2",
+                "url": "",
+              },
+              Object {
+                "hasMegapanel": false,
+                "hasMenu": false,
+                "menuSections": Array [],
+                "title": "Industries",
+                "url": "https://www.ibm.com/industries?lnk=min",
+              },
+              Object {
+                "hasMegapanel": true,
+                "hasMenu": true,
+                "menuSections": Array [
+                  Object {
+                    "heading": "",
+                    "menuItems": Array [
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "",
+                          "feature": Object {
+                            "heading": "IBM Developer newsletters",
+                            "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                            "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                            "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          "headingTitle": "IBM Developer",
+                          "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Subnav 1",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 2",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 3",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 4",
+                                "url": "",
+                              },
+                            ],
+                            "title": "Quicklinks",
+                          },
+                        },
+                        "title": "IBM Developer",
+                        "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                      },
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "",
+                          "feature": Object {
+                            "heading": "Blockchain 101",
+                            "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                            "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                            "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          "headingTitle": "Blockchain",
+                          "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Subnav 1",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 2",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 3",
+                                "url": "",
+                              },
+                              Object {
+                                "title": "Subnav 4",
+                                "url": "",
+                              },
+                            ],
+                            "title": "Quicklinks",
+                          },
+                        },
+                        "title": "Blockchain",
+                        "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                      },
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "",
+                          "feature": Object {
+                            "heading": "Make sense of Kubernetes",
+                            "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                            "linkTitle": "Deploy a simple Python application with Kubernetes",
+                            "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          "headingTitle": "Containers",
+                          "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Code patterns",
+                                "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "title": "Tutorials",
+                                "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "title": "Events",
+                                "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                            ],
+                            "title": "Quicklinks",
+                          },
+                        },
+                        "title": "Containers",
+                        "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                      },
+                      Object {
+                        "megapanelContent": Object {
+                          "description": "",
+                          "feature": Object {
+                            "heading": "Train your data no matter where it lives",
+                            "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                            "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                            "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                          },
+                          "headingTitle": "Analytics",
+                          "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                          "quickLinks": Object {
+                            "links": Array [
+                              Object {
+                                "title": "Code patterns",
+                                "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "title": "Tutorials",
+                                "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "title": "Events",
+                                "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "title": "Developer community",
+                                "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                            ],
+                            "title": "Quicklinks",
+                          },
+                        },
+                        "title": "Analytics",
+                        "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                      },
+                    ],
+                  },
+                ],
+                "title": "Link 3",
+                "url": "",
+              },
+              Object {
+                "hasMegapanel": false,
+                "hasMenu": false,
+                "menuSections": Array [],
+                "title": "Support",
+                "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+              },
+            ],
+            "title": "Stock Charts",
+            "titleLink": "https://www.example.com",
+          }
+        }
+        placeHolderText="Search all of IBM"
+        platform={null}
+        searchOpenOnload={false}
+      >
+        <HeaderContainer
+          isSideNavExpanded={false}
+          render={[Function]}
+        >
+          <render
+            isSideNavExpanded={false}
+            onClickSideNavExpand={[Function]}
+          >
+            <div
+              className="bx--masthead "
+            >
+              <div
+                className="bx--masthead__l0"
+              >
+                <Header
+                  aria-label="IBM"
+                  data-autoid="dds--masthead"
+                >
+                  <header
+                    aria-label="IBM"
+                    className="bx--header"
+                    data-autoid="dds--masthead"
+                  >
+                    <SkipToContent
+                      href="#main-content"
+                      tabIndex="0"
+                    >
+                      <a
+                        className="bx--skip-to-content"
+                        href="#main-content"
+                        tabIndex="0"
+                      >
+                        Skip to main content
+                      </a>
+                    </SkipToContent>
+                    <HeaderMenuButton
+                      aria-label="Open menu"
+                      data-autoid="dds--masthead__hamburger"
+                      isActive={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        aria-label="Open menu"
+                        className="bx--header__action bx--header__menu-trigger bx--header__menu-toggle bx--header__menu-toggle__hidden"
+                        data-autoid="dds--masthead__hamburger"
+                        onClick={[Function]}
+                        title="Open menu"
+                        type="button"
+                      >
+                        <ForwardRef(Menu20)>
+                          <Icon
+                            fill="currentColor"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 20 20"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={20}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 20 20"
+                              width={20}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M2 14.8H18V16H2zM2 11.2H18V12.399999999999999H2zM2 7.6H18V8.799999999999999H2zM2 4H18V5.2H2z"
+                              />
+                            </svg>
+                          </Icon>
+                        </ForwardRef(Menu20)>
+                      </button>
+                    </HeaderMenuButton>
+                    <IbmLogo>
+                      <div
+                        className="bx--header__logo"
+                        data-autoid="dds--masthead-logo"
+                      >
+                        <a
+                          aria-label="IBM®"
+                          data-autoid="dds--masthead-logo__link"
+                          href="https://www.ibm.com/"
+                        >
+                          <MastheadLogo
+                            height="23"
+                            viewBox="0 0 58 23"
+                            width="58"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <svg
+                              height="23"
+                              viewBox="0 0 58 23"
+                              width="58"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M58 21.467V23h-7.632v-1.533H58zm-18.316 0V23h-7.631v-1.533h7.631zm5.955 0L45.025 23l-.606-1.533h1.22zm-17.097 0A6.285 6.285 0 0 1 24.391 23H12.21v-1.533zm-17.858 0V23H0v-1.533h10.684zm29-3.067v1.533h-7.631V18.4h7.631zm7.148 0l-.594 1.533H43.82l-.598-1.533h3.609zm-16.764 0a5.719 5.719 0 0 1-.64 1.533H12.21V18.4zm-19.384 0v1.533H0V18.4h10.684zM58 18.4v1.533h-7.632V18.4H58zm-3.053-3.067v1.534h-4.579v-1.534h4.58zm-15.263 0v1.534h-4.579v-1.534h4.58zm8.345 0l-.6 1.534h-4.806l-.604-1.534h6.01zm-18.174 0c.137.49.213 1.003.213 1.534h-5.647v-1.534zm-10.013 0v1.534h-4.579v-1.534h4.58zm-12.21 0v1.534h-4.58v-1.534h4.58zm47.315-3.066V13.8h-4.579v-1.533h4.58zm-15.263 0V13.8h-4.579v-1.533h4.58zm9.541 0l-.597 1.533h-7.22l-.591-1.533h8.408zm-21.248 0c.527.432.98.951 1.328 1.533H15.263v-1.533zm-20.345 0V13.8h-4.58v-1.533h4.58zM44.599 9.2l.427 1.24.428-1.24h9.493v1.533h-4.579V9.324l-.519 1.41h-9.661l-.504-1.41v1.41h-4.579V9.2H44.6zm-36.967 0v1.533h-4.58V9.2h4.58zm21.673 0a5.95 5.95 0 0 1-1.328 1.533H15.263V9.2zm25.642-3.067v1.534h-8.964l.54-1.534h8.424zm-11.413 0l.54 1.534h-8.969V6.133h8.43zm-13.466 0c0 .531-.076 1.045-.213 1.534H24.42V6.133zm-10.226 0v1.534h-4.579V6.133h4.58zm-12.21 0v1.534h-4.58V6.133h4.58zm34.845-3.066l.53 1.533H32.054V3.067h10.424zm15.523 0V4.6H47.04l.55-1.533H58zm-28.573 0c.284.473.504.988.641 1.533H12.211V3.067zm-18.743 0V4.6H0V3.067h10.684zM41.406 0l.54 1.533h-9.893V0h9.353zM58 0v1.533h-9.881L48.647 0H58zM24.39 0c1.601 0 3.057.581 4.152 1.533H12.211V0zM10.685 0v1.533H0V0h10.684z"
+                                fill="#161616"
+                                fillRule="evenodd"
+                              />
+                            </svg>
+                          </MastheadLogo>
+                        </a>
+                      </div>
+                    </IbmLogo>
+                    <div
+                      className="bx--header__search "
+                    >
+                      <MastheadSearch
+                        placeHolderText="Search all of IBM"
+                        renderValue={3}
+                        searchOpenOnload={false}
+                      >
+                        <div
+                          className="bx--masthead__search"
+                          data-autoid="dds--masthead__search"
+                        >
+                          <div
+                            className="bx--header__search--actions"
+                          >
+                            <HeaderGlobalAction
+                              aria-label="Open IBM search field"
+                              className="bx--header__search--search"
+                              data-autoid="dds--header__search--search"
+                              onClick={[Function]}
+                              tabIndex="0"
+                            >
+                              <button
+                                aria-label="Open IBM search field"
+                                className="bx--header__search--search bx--header__action"
+                                data-autoid="dds--header__search--search"
+                                onClick={[Function]}
+                                tabIndex="0"
+                                type="button"
+                              >
+                                <ForwardRef(Search20)>
+                                  <Icon
+                                    fill="currentColor"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M30,28.59,22.45,21A11,11,0,1,0,21,22.45L28.59,30ZM5,14a9,9,0,1,1,9,9A9,9,0,0,1,5,14Z"
+                                      />
+                                    </svg>
+                                  </Icon>
+                                </ForwardRef(Search20)>
+                              </button>
+                            </HeaderGlobalAction>
+                            <HeaderGlobalAction
+                              aria-label="Close"
+                              className="bx--header__search--close"
+                              data-autoid="dds--header__search--close"
+                              onClick={[Function]}
+                            >
+                              <button
+                                aria-label="Close"
+                                className="bx--header__search--close bx--header__action"
+                                data-autoid="dds--header__search--close"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <ForwardRef(Close20)>
+                                  <Icon
+                                    fill="currentColor"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 32 32"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height={20}
+                                      preserveAspectRatio="xMidYMid meet"
+                                      viewBox="0 0 32 32"
+                                      width={20}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                                      />
+                                    </svg>
+                                  </Icon>
+                                </ForwardRef(Close20)>
+                              </button>
+                            </HeaderGlobalAction>
+                          </div>
+                        </div>
+                      </MastheadSearch>
+                    </div>
+                    <HeaderGlobalBar>
+                      <div
+                        className="bx--header__global"
+                      >
+                        <MastheadProfile
+                          overflowMenuItemProps={
+                            Object {
+                              "wrapperClassName": "bx--masthead__profile-item",
+                            }
+                          }
+                          overflowMenuProps={
+                            Object {
+                              "ariaLabel": "User Profile",
+                              "data-autoid": "dds--masthead__profile",
+                              "flipped": true,
+                              "onOpen": [Function],
+                              "renderIcon": [Function],
+                              "style": Object {
+                                "width": "3rem",
+                              },
+                            }
+                          }
+                          profileMenu={Array []}
+                        >
+                          <ForwardRef(OverflowMenu)
+                            ariaLabel="User Profile"
+                            className="bx--header__action"
+                            data-autoid="dds--masthead__profile"
+                            flipped={true}
+                            onOpen={[Function]}
+                            renderIcon={[Function]}
+                            style={
+                              Object {
+                                "width": "3rem",
+                              }
+                            }
+                          >
+                            <OverflowMenu
+                              ariaLabel="User Profile"
+                              className="bx--header__action"
+                              data-autoid="dds--masthead__profile"
+                              direction="bottom"
+                              flipped={true}
+                              iconDescription="open and close list of options"
+                              innerRef={null}
+                              light={false}
+                              menuOffset={[Function]}
+                              menuOffsetFlip={[Function]}
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              onOpen={[Function]}
+                              open={false}
+                              renderIcon={[Function]}
+                              selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+                              style={
+                                Object {
+                                  "width": "3rem",
+                                }
+                              }
+                              tabIndex={0}
+                            >
+                              <ClickListener
+                                onClickOutside={[Function]}
+                              >
+                                <button
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  aria-label="User Profile"
+                                  className="bx--header__action bx--overflow-menu"
+                                  data-autoid="dds--masthead__profile"
+                                  onClick={[Function]}
+                                  onClose={[Function]}
+                                  onKeyDown={[Function]}
+                                  open={false}
+                                  style={
+                                    Object {
+                                      "width": "3rem",
+                                    }
+                                  }
+                                  tabIndex={0}
+                                >
+                                  <renderIcon
+                                    aria-label="open and close list of options"
+                                    className="bx--overflow-menu__icon"
+                                    focusable="false"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                  >
+                                    <ForwardRef(User20)>
+                                      <Icon
+                                        fill="currentColor"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="currentColor"
+                                          focusable="false"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M16 4a5 5 0 11-5 5 5 5 0 015-5m0-2a7 7 0 107 7A7 7 0 0016 2zM26 30H24V25a5 5 0 00-5-5H13a5 5 0 00-5 5v5H6V25a7 7 0 017-7h6a7 7 0 017 7z"
+                                          />
+                                        </svg>
+                                      </Icon>
+                                    </ForwardRef(User20)>
+                                  </renderIcon>
+                                </button>
+                              </ClickListener>
+                            </OverflowMenu>
+                          </ForwardRef(OverflowMenu)>
+                        </MastheadProfile>
+                      </div>
+                    </HeaderGlobalBar>
+                    <MastheadLeftNav
+                      isSideNavExpanded={false}
+                      navigation={
+                        Array [
+                          Object {
+                            "hasMegapanel": true,
+                            "hasMenu": true,
+                            "menuSections": Array [
+                              Object {
+                                "heading": "Explore",
+                                "menuItems": Array [
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "",
+                                      "feature": Object {
+                                        "heading": "",
+                                        "imageUrl": "",
+                                        "linkTitle": "",
+                                        "linkUrl": "",
+                                      },
+                                      "headingTitle": "",
+                                      "headingUrl": "",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Subnav 1",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 2",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 3",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 4",
+                                            "url": "",
+                                          },
+                                        ],
+                                        "title": "Title",
+                                      },
+                                    },
+                                    "title": "Link 1",
+                                    "url": "",
+                                  },
+                                ],
+                              },
+                            ],
+                            "title": "Link 1",
+                            "url": "",
+                          },
+                          Object {
+                            "hasMegapanel": true,
+                            "hasMenu": true,
+                            "menuSections": Array [
+                              Object {
+                                "heading": "",
+                                "menuItems": Array [
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                                      "feature": Object {
+                                        "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                                        "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                                        "linkTitle": "Explore all our business consulting and technology services",
+                                        "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                      },
+                                      "headingTitle": "Services",
+                                      "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Subnav 1",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 2",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 3",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 4",
+                                            "url": "",
+                                          },
+                                        ],
+                                        "title": "Quicklinks",
+                                      },
+                                    },
+                                    "title": "Link 2",
+                                    "url": "",
+                                  },
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "Funding options that fit your business",
+                                      "feature": Object {
+                                        "heading": "Cloud financing strategies that work for your business",
+                                        "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                                        "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                                        "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                                      },
+                                      "headingTitle": "Financing",
+                                      "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Subnav 1",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 2",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 3",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 4",
+                                            "url": "",
+                                          },
+                                        ],
+                                        "title": "Quicklinks",
+                                      },
+                                    },
+                                    "title": "Financing",
+                                    "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                  },
+                                ],
+                              },
+                            ],
+                            "title": "Link 2",
+                            "url": "",
+                          },
+                          Object {
+                            "hasMegapanel": false,
+                            "hasMenu": false,
+                            "menuSections": Array [],
+                            "title": "Industries",
+                            "url": "https://www.ibm.com/industries?lnk=min",
+                          },
+                          Object {
+                            "hasMegapanel": true,
+                            "hasMenu": true,
+                            "menuSections": Array [
+                              Object {
+                                "heading": "",
+                                "menuItems": Array [
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "",
+                                      "feature": Object {
+                                        "heading": "IBM Developer newsletters",
+                                        "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                                        "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                                        "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      "headingTitle": "IBM Developer",
+                                      "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Subnav 1",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 2",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 3",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 4",
+                                            "url": "",
+                                          },
+                                        ],
+                                        "title": "Quicklinks",
+                                      },
+                                    },
+                                    "title": "IBM Developer",
+                                    "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "",
+                                      "feature": Object {
+                                        "heading": "Blockchain 101",
+                                        "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                                        "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                                        "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      "headingTitle": "Blockchain",
+                                      "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Subnav 1",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 2",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 3",
+                                            "url": "",
+                                          },
+                                          Object {
+                                            "title": "Subnav 4",
+                                            "url": "",
+                                          },
+                                        ],
+                                        "title": "Quicklinks",
+                                      },
+                                    },
+                                    "title": "Blockchain",
+                                    "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "",
+                                      "feature": Object {
+                                        "heading": "Make sense of Kubernetes",
+                                        "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                                        "linkTitle": "Deploy a simple Python application with Kubernetes",
+                                        "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      "headingTitle": "Containers",
+                                      "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Code patterns",
+                                            "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                          Object {
+                                            "title": "Tutorials",
+                                            "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                          Object {
+                                            "title": "Events",
+                                            "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                        ],
+                                        "title": "Quicklinks",
+                                      },
+                                    },
+                                    "title": "Containers",
+                                    "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  Object {
+                                    "megapanelContent": Object {
+                                      "description": "",
+                                      "feature": Object {
+                                        "heading": "Train your data no matter where it lives",
+                                        "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                                        "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                                        "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      "headingTitle": "Analytics",
+                                      "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                      "quickLinks": Object {
+                                        "links": Array [
+                                          Object {
+                                            "title": "Code patterns",
+                                            "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                          Object {
+                                            "title": "Tutorials",
+                                            "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                          Object {
+                                            "title": "Events",
+                                            "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                          Object {
+                                            "title": "Developer community",
+                                            "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                          },
+                                        ],
+                                        "title": "Quicklinks",
+                                      },
+                                    },
+                                    "title": "Analytics",
+                                    "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                ],
+                              },
+                            ],
+                            "title": "Link 3",
+                            "url": "",
+                          },
+                          Object {
+                            "hasMegapanel": false,
+                            "hasMenu": false,
+                            "menuSections": Array [],
+                            "title": "Support",
+                            "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                          },
+                        ]
+                      }
+                      platform={null}
+                    >
+                      <ForwardRef(SideNav)
+                        addFocusListeners={true}
+                        addMouseListeners={true}
+                        aria-label="Side navigation"
+                        defaultExpanded={false}
+                        expanded={false}
+                        isChildOfHeader={true}
+                        isFixedNav={false}
+                        isPersistent={false}
+                        translateById={[Function]}
+                      >
+                        <div
+                          className="bx--side-nav__overlay"
+                        />
+                        <nav
+                          aria-label="Side navigation"
+                          className="bx--side-nav__navigation bx--side-nav bx--side-nav--ux bx--side-nav--hidden"
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                        >
+                          <nav
+                            data-autoid="dds--masthead__l0-sidenav"
+                          >
+                            <SideNavItems>
+                              <ul
+                                className="bx--side-nav__items"
+                              >
+                                <HeaderSideNavItems
+                                  hasDivider={false}
+                                  key=".0"
+                                >
+                                  <div
+                                    className="bx--side-nav__header-navigation"
+                                  >
+                                    <ForwardRef
+                                      key="0"
+                                      title="Link 1"
+                                    >
+                                      <SideNavMenu
+                                        buttonRef={null}
+                                        defaultExpanded={false}
+                                        isActive={false}
+                                        large={false}
+                                        title="Link 1"
+                                      >
+                                        <li
+                                          className="bx--side-nav__item"
+                                        >
+                                          <button
+                                            aria-expanded={false}
+                                            aria-haspopup="true"
+                                            className="bx--side-nav__submenu"
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="bx--side-nav__submenu-title"
+                                            >
+                                              Link 1
+                                            </span>
+                                            <SideNavIcon
+                                              className="bx--side-nav__submenu-chevron"
+                                              small={true}
+                                            >
+                                              <div
+                                                className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+                                              >
+                                                <ForwardRef(ChevronDown20)>
+                                                  <Icon
+                                                    fill="currentColor"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    viewBox="0 0 32 32"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      fill="currentColor"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 32 32"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ChevronDown20)>
+                                              </div>
+                                            </SideNavIcon>
+                                          </button>
+                                          <ul
+                                            className="bx--side-nav__menu"
+                                            role="menu"
+                                          >
+                                            <ForwardRef(SideNavMenuItem)
+                                              className="bx--masthead__side-nav--submemu-back"
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-back-0"
+                                              isbackbutton="true"
+                                              key=".$0"
+                                              onClick={[Function]}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item bx--masthead__side-nav--submemu-back"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-back-0"
+                                                  element="a"
+                                                  isbackbutton="true"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-back-0"
+                                                    isbackbutton="true"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        <ForwardRef(ArrowLeft16)>
+                                                          <Icon
+                                                            fill="currentColor"
+                                                            height={16}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              fill="currentColor"
+                                                              focusable="false"
+                                                              height={16}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(ArrowLeft16)>
+                                                        Back
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <li
+                                              className="bx--masthead__side-nav--submemu-title"
+                                              key=".1"
+                                              onClick={null}
+                                            >
+                                              Link 1
+                                            </li>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                              href=""
+                                              key=".2:$Link 1"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                  element="a"
+                                                  href=""
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                    href=""
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        Link 1
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                          </ul>
+                                        </li>
+                                      </SideNavMenu>
+                                    </ForwardRef>
+                                    <ForwardRef
+                                      key="1"
+                                      title="Link 2"
+                                    >
+                                      <SideNavMenu
+                                        buttonRef={null}
+                                        defaultExpanded={false}
+                                        isActive={false}
+                                        large={false}
+                                        title="Link 2"
+                                      >
+                                        <li
+                                          className="bx--side-nav__item"
+                                        >
+                                          <button
+                                            aria-expanded={false}
+                                            aria-haspopup="true"
+                                            className="bx--side-nav__submenu"
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="bx--side-nav__submenu-title"
+                                            >
+                                              Link 2
+                                            </span>
+                                            <SideNavIcon
+                                              className="bx--side-nav__submenu-chevron"
+                                              small={true}
+                                            >
+                                              <div
+                                                className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+                                              >
+                                                <ForwardRef(ChevronDown20)>
+                                                  <Icon
+                                                    fill="currentColor"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    viewBox="0 0 32 32"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      fill="currentColor"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 32 32"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ChevronDown20)>
+                                              </div>
+                                            </SideNavIcon>
+                                          </button>
+                                          <ul
+                                            className="bx--side-nav__menu"
+                                            role="menu"
+                                          >
+                                            <ForwardRef(SideNavMenuItem)
+                                              className="bx--masthead__side-nav--submemu-back"
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-back-1"
+                                              isbackbutton="true"
+                                              key=".$1"
+                                              onClick={[Function]}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item bx--masthead__side-nav--submemu-back"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-back-1"
+                                                  element="a"
+                                                  isbackbutton="true"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-back-1"
+                                                    isbackbutton="true"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        <ForwardRef(ArrowLeft16)>
+                                                          <Icon
+                                                            fill="currentColor"
+                                                            height={16}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              fill="currentColor"
+                                                              focusable="false"
+                                                              height={16}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(ArrowLeft16)>
+                                                        Back
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <li
+                                              className="bx--masthead__side-nav--submemu-title"
+                                              key=".1"
+                                              onClick={null}
+                                            >
+                                              Link 2
+                                            </li>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                              href=""
+                                              key=".2:$Link 2"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                  element="a"
+                                                  href=""
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                    href=""
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        Link 2
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                              href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                              key=".2:$Financing"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                  element="a"
+                                                  href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                    href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        Financing
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                          </ul>
+                                        </li>
+                                      </SideNavMenu>
+                                    </ForwardRef>
+                                    <SideNavLink
+                                      data-autoid="dds--masthead__l0-sidenav--nav-2"
+                                      element="a"
+                                      href="https://www.ibm.com/industries?lnk=min"
+                                      key="2"
+                                      large={false}
+                                    >
+                                      <SideNavItem
+                                        large={false}
+                                      >
+                                        <li
+                                          className="bx--side-nav__item"
+                                        >
+                                          <Link
+                                            className="bx--side-nav__link"
+                                            data-autoid="dds--masthead__l0-sidenav--nav-2"
+                                            element="a"
+                                            href="https://www.ibm.com/industries?lnk=min"
+                                          >
+                                            <a
+                                              className="bx--side-nav__link"
+                                              data-autoid="dds--masthead__l0-sidenav--nav-2"
+                                              href="https://www.ibm.com/industries?lnk=min"
+                                            >
+                                              <SideNavLinkText>
+                                                <span
+                                                  className="bx--side-nav__link-text"
+                                                >
+                                                  Industries
+                                                </span>
+                                              </SideNavLinkText>
+                                            </a>
+                                          </Link>
+                                        </li>
+                                      </SideNavItem>
+                                    </SideNavLink>
+                                    <ForwardRef
+                                      key="3"
+                                      title="Link 3"
+                                    >
+                                      <SideNavMenu
+                                        buttonRef={null}
+                                        defaultExpanded={false}
+                                        isActive={false}
+                                        large={false}
+                                        title="Link 3"
+                                      >
+                                        <li
+                                          className="bx--side-nav__item"
+                                        >
+                                          <button
+                                            aria-expanded={false}
+                                            aria-haspopup="true"
+                                            className="bx--side-nav__submenu"
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="bx--side-nav__submenu-title"
+                                            >
+                                              Link 3
+                                            </span>
+                                            <SideNavIcon
+                                              className="bx--side-nav__submenu-chevron"
+                                              small={true}
+                                            >
+                                              <div
+                                                className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+                                              >
+                                                <ForwardRef(ChevronDown20)>
+                                                  <Icon
+                                                    fill="currentColor"
+                                                    height={20}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    viewBox="0 0 32 32"
+                                                    width={20}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      fill="currentColor"
+                                                      focusable="false"
+                                                      height={20}
+                                                      preserveAspectRatio="xMidYMid meet"
+                                                      viewBox="0 0 32 32"
+                                                      width={20}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                                      />
+                                                    </svg>
+                                                  </Icon>
+                                                </ForwardRef(ChevronDown20)>
+                                              </div>
+                                            </SideNavIcon>
+                                          </button>
+                                          <ul
+                                            className="bx--side-nav__menu"
+                                            role="menu"
+                                          >
+                                            <ForwardRef(SideNavMenuItem)
+                                              className="bx--masthead__side-nav--submemu-back"
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-back-3"
+                                              isbackbutton="true"
+                                              key=".$3"
+                                              onClick={[Function]}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item bx--masthead__side-nav--submemu-back"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-back-3"
+                                                  element="a"
+                                                  isbackbutton="true"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-back-3"
+                                                    isbackbutton="true"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        <ForwardRef(ArrowLeft16)>
+                                                          <Icon
+                                                            fill="currentColor"
+                                                            height={16}
+                                                            preserveAspectRatio="xMidYMid meet"
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              fill="currentColor"
+                                                              focusable="false"
+                                                              height={16}
+                                                              preserveAspectRatio="xMidYMid meet"
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                                                              />
+                                                            </svg>
+                                                          </Icon>
+                                                        </ForwardRef(ArrowLeft16)>
+                                                        Back
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <li
+                                              className="bx--masthead__side-nav--submemu-title"
+                                              key=".1"
+                                              onClick={null}
+                                            >
+                                              Link 3
+                                            </li>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                              href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                              key=".2:$IBM Developer"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                  element="a"
+                                                  href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item0"
+                                                    href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        IBM Developer
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                              href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                              key=".2:$Blockchain"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                  element="a"
+                                                  href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item1"
+                                                    href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        Blockchain
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item2"
+                                              href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                              key=".2:$Containers"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item2"
+                                                  element="a"
+                                                  href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item2"
+                                                    href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        Containers
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                            <ForwardRef(SideNavMenuItem)
+                                              data-autoid="dds--masthead__l0-sidenav--subnav-col0-item3"
+                                              href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                              key=".2:$Analytics"
+                                              onClick={null}
+                                            >
+                                              <li
+                                                className="bx--side-nav__menu-item"
+                                                role="none"
+                                              >
+                                                <Link
+                                                  className="bx--side-nav__link"
+                                                  data-autoid="dds--masthead__l0-sidenav--subnav-col0-item3"
+                                                  element="a"
+                                                  href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                                  onClick={null}
+                                                  role="menuitem"
+                                                >
+                                                  <a
+                                                    className="bx--side-nav__link"
+                                                    data-autoid="dds--masthead__l0-sidenav--subnav-col0-item3"
+                                                    href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                                    onClick={null}
+                                                    role="menuitem"
+                                                  >
+                                                    <SideNavLinkText>
+                                                      <span
+                                                        className="bx--side-nav__link-text"
+                                                      >
+                                                        Analytics
+                                                      </span>
+                                                    </SideNavLinkText>
+                                                  </a>
+                                                </Link>
+                                              </li>
+                                            </ForwardRef(SideNavMenuItem)>
+                                          </ul>
+                                        </li>
+                                      </SideNavMenu>
+                                    </ForwardRef>
+                                    <SideNavLink
+                                      data-autoid="dds--masthead__l0-sidenav--nav-4"
+                                      element="a"
+                                      href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                      key="4"
+                                      large={false}
+                                    >
+                                      <SideNavItem
+                                        large={false}
+                                      >
+                                        <li
+                                          className="bx--side-nav__item"
+                                        >
+                                          <Link
+                                            className="bx--side-nav__link"
+                                            data-autoid="dds--masthead__l0-sidenav--nav-4"
+                                            element="a"
+                                            href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                          >
+                                            <a
+                                              className="bx--side-nav__link"
+                                              data-autoid="dds--masthead__l0-sidenav--nav-4"
+                                              href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                            >
+                                              <SideNavLinkText>
+                                                <span
+                                                  className="bx--side-nav__link-text"
+                                                >
+                                                  Support
+                                                </span>
+                                              </SideNavLinkText>
+                                            </a>
+                                          </Link>
+                                        </li>
+                                      </SideNavItem>
+                                    </SideNavLink>
+                                  </div>
+                                </HeaderSideNavItems>
+                              </ul>
+                            </SideNavItems>
+                          </nav>
+                        </nav>
+                      </ForwardRef(SideNav)>
+                    </MastheadLeftNav>
+                  </header>
+                </Header>
+              </div>
+              <div>
+                <MastheadL1
+                  eyebrowLink="#"
+                  eyebrowText="Eyebrow"
+                  isShort={false}
+                  navigationL1={
+                    Array [
+                      Object {
+                        "hasMegapanel": true,
+                        "hasMenu": true,
+                        "menuSections": Array [
+                          Object {
+                            "heading": "Explore",
+                            "menuItems": Array [
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "",
+                                  "feature": Object {
+                                    "heading": "",
+                                    "imageUrl": "",
+                                    "linkTitle": "",
+                                    "linkUrl": "",
+                                  },
+                                  "headingTitle": "",
+                                  "headingUrl": "",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Subnav 1",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 2",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 3",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 4",
+                                        "url": "",
+                                      },
+                                    ],
+                                    "title": "Title",
+                                  },
+                                },
+                                "title": "Link 1",
+                                "url": "",
+                              },
+                            ],
+                          },
+                        ],
+                        "title": "Link 1",
+                        "url": "",
+                      },
+                      Object {
+                        "hasMegapanel": true,
+                        "hasMenu": true,
+                        "menuSections": Array [
+                          Object {
+                            "heading": "",
+                            "menuItems": Array [
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "Reimagine your business, designing and building the platforms necessary for growth",
+                                  "feature": Object {
+                                    "heading": "IBM Services, your Digital Reinvention â„¢ partner",
+                                    "imageUrl": "https://www.ibm.com/images/portal/U609055Q90660U49/windmills.jpg",
+                                    "linkTitle": "Explore all our business consulting and technology services",
+                                    "linkUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                  },
+                                  "headingTitle": "Services",
+                                  "headingUrl": "https://www.ibm.com/services?lnk=hpmse_ts&lnk2=learn",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Subnav 1",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 2",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 3",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 4",
+                                        "url": "",
+                                      },
+                                    ],
+                                    "title": "Quicklinks",
+                                  },
+                                },
+                                "title": "Link 2",
+                                "url": "",
+                              },
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "Funding options that fit your business",
+                                  "feature": Object {
+                                    "heading": "Cloud financing strategies that work for your business",
+                                    "imageUrl": "https://www.ibm.com/images/portal/F774737R30303N19/Skyline-Card-cloud-feature380x160.jpg?1=1",
+                                    "linkTitle": "Committed to cloud? Make the most of your cash flow.",
+                                    "linkUrl": "https://www.ibm.com/financing/solutions/cloud-financing?lnk=hpmse_fin&lnk2=learn",
+                                  },
+                                  "headingTitle": "Financing",
+                                  "headingUrl": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Subnav 1",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 2",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 3",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 4",
+                                        "url": "",
+                                      },
+                                    ],
+                                    "title": "Quicklinks",
+                                  },
+                                },
+                                "title": "Financing",
+                                "url": "https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn",
+                              },
+                            ],
+                          },
+                        ],
+                        "title": "Link 2",
+                        "url": "",
+                      },
+                      Object {
+                        "hasMegapanel": false,
+                        "hasMenu": false,
+                        "menuSections": Array [],
+                        "title": "Industries",
+                        "url": "https://www.ibm.com/industries?lnk=min",
+                      },
+                      Object {
+                        "hasMegapanel": true,
+                        "hasMenu": true,
+                        "menuSections": Array [
+                          Object {
+                            "heading": "",
+                            "menuItems": Array [
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "",
+                                  "feature": Object {
+                                    "heading": "IBM Developer newsletters",
+                                    "imageUrl": "https://1.dam.s81c.com/m/5908c17b26b9dd19/original/news-ibmdevnewsletters-600x245.jpg",
+                                    "linkTitle": "Technical info on popular software development topics, including AI, Blockchain, Java and more",
+                                    "linkUrl": "https://developer.ibm.com/newsletters/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  "headingTitle": "IBM Developer",
+                                  "headingUrl": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Subnav 1",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 2",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 3",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 4",
+                                        "url": "",
+                                      },
+                                    ],
+                                    "title": "Quicklinks",
+                                  },
+                                },
+                                "title": "IBM Developer",
+                                "url": "https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "",
+                                  "feature": Object {
+                                    "heading": "Blockchain 101",
+                                    "imageUrl": "https://www.ibm.com/images/portal/E174255N41814O86/Blockchain2_600x245.jpg?1=3",
+                                    "linkTitle": "Build a kick-starter blockchain network and start coding with the IBM Blockchain Platform Starter Plan",
+                                    "linkUrl": "https://developer.ibm.com/tutorials/cl-ibm-blockchain-101-quick-start-guide-for-developers-bluemix-trs/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  "headingTitle": "Blockchain",
+                                  "headingUrl": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Subnav 1",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 2",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 3",
+                                        "url": "",
+                                      },
+                                      Object {
+                                        "title": "Subnav 4",
+                                        "url": "",
+                                      },
+                                    ],
+                                    "title": "Quicklinks",
+                                  },
+                                },
+                                "title": "Blockchain",
+                                "url": "https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "",
+                                  "feature": Object {
+                                    "heading": "Make sense of Kubernetes",
+                                    "imageUrl": "https://www.ibm.com/images/portal/E693054G76296P64/Kubernetes-Pythomn_600x245.jpg?1=2",
+                                    "linkTitle": "Deploy a simple Python application with Kubernetes",
+                                    "linkUrl": "https://developer.ibm.com/tutorials/scalable-python-app-with-kubernetes/?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  "headingTitle": "Containers",
+                                  "headingUrl": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Code patterns",
+                                        "url": "https://developer.ibm.com/patterns/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      Object {
+                                        "title": "Tutorials",
+                                        "url": "https://developer.ibm.com/tutorials/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      Object {
+                                        "title": "Events",
+                                        "url": "https://developer.ibm.com/events/category/containers/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                    ],
+                                    "title": "Quicklinks",
+                                  },
+                                },
+                                "title": "Containers",
+                                "url": "https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                              Object {
+                                "megapanelContent": Object {
+                                  "description": "",
+                                  "feature": Object {
+                                    "heading": "Train your data no matter where it lives",
+                                    "imageUrl": "https://1.dam.s81c.com/m/76c0ed6f3e6386c1/original/Train-data_600x245.jpg",
+                                    "linkTitle": "Easily and securely connect to your data source for initial model training and continuous learning",
+                                    "linkUrl": "https://developer.ibm.com/announcements/training-machine-learning-models-in-watson-studio?lnk=hpmdev_dw&lnk2=learn",
+                                  },
+                                  "headingTitle": "Analytics",
+                                  "headingUrl": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                  "quickLinks": Object {
+                                    "links": Array [
+                                      Object {
+                                        "title": "Code patterns",
+                                        "url": "https://developer.ibm.com/patterns/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      Object {
+                                        "title": "Tutorials",
+                                        "url": "https://developer.ibm.com/tutorials/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      Object {
+                                        "title": "Events",
+                                        "url": "https://developer.ibm.com/events/category/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                      Object {
+                                        "title": "Developer community",
+                                        "url": "https://developer.ibm.com/watson/?lnk=hpmdev_dw&lnk2=learn",
+                                      },
+                                    ],
+                                    "title": "Quicklinks",
+                                  },
+                                },
+                                "title": "Analytics",
+                                "url": "https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn",
+                              },
+                            ],
+                          },
+                        ],
+                        "title": "Link 3",
+                        "url": "",
+                      },
+                      Object {
+                        "hasMegapanel": false,
+                        "hasMenu": false,
+                        "menuSections": Array [],
+                        "title": "Support",
+                        "url": "https://www.ibm.com/support/home/?lnk=msu_usen",
+                      },
+                    ]
+                  }
+                  title="Stock Charts"
+                  titleLink="https://www.example.com"
+                >
+                  <div
+                    className="bx--masthead__l1"
+                  >
+                    <div
+                      className="bx--masthead__l1-name"
+                    >
+                      <span
+                        className="bx--masthead__l1-name-eyebrow"
+                      >
+                        <ForwardRef(ArrowLeft16)>
+                          <Icon
+                            fill="currentColor"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              fill="currentColor"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.7 12.3L2.9 8.5 15 8.5 15 7.5 2.9 7.5 6.7 3.7 6 3 1 8 6 13z"
+                              />
+                            </svg>
+                          </Icon>
+                        </ForwardRef(ArrowLeft16)>
+                        <a
+                          href="#"
+                        >
+                          Eyebrow
+                        </a>
+                      </span>
+                      <span
+                        className="bx--masthead__l1-name-title"
+                      >
+                        <a
+                          href="https://www.example.com"
+                        >
+                          Stock Charts
+                        </a>
+                      </span>
+                    </div>
+                    <HeaderNavigation
+                      aria-label=""
+                      className="bx--masthead__l1-nav"
+                    >
+                      <nav
+                        aria-label=""
+                        className="bx--header__nav bx--masthead__l1-nav"
+                      >
+                        <ul
+                          aria-label=""
+                          className="bx--header__menu-bar"
+                          role="menubar"
+                        >
+                          <ForwardRef
+                            aria-label="Link 1"
+                            data-autoid="dds--masthead__l0-nav--nav-0"
+                            key=".$0"
+                            menuLinkName="Link 1"
+                          >
+                            <HeaderMenu
+                              aria-label="Link 1"
+                              data-autoid="dds--masthead__l0-nav--nav-0"
+                              focusRef={[Function]}
+                              menuLinkName="Link 1"
+                              renderMenuContent={[Function]}
+                            >
+                              <li
+                                className="bx--header__submenu"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                              >
+                                <a
+                                  aria-expanded={false}
+                                  aria-haspopup="menu"
+                                  aria-label="Link 1"
+                                  className="bx--header__menu-item bx--header__menu-title"
+                                  href="#"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex={0}
+                                >
+                                  Link 1
+                                  <defaultRenderMenuContent>
+                                    <ForwardRef(ChevronDown20)
+                                      className="bx--header__menu-arrow"
+                                    >
+                                      <Icon
+                                        className="bx--header__menu-arrow"
+                                        fill="currentColor"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="bx--header__menu-arrow"
+                                          fill="currentColor"
+                                          focusable="false"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                          />
+                                        </svg>
+                                      </Icon>
+                                    </ForwardRef(ChevronDown20)>
+                                  </defaultRenderMenuContent>
+                                </a>
+                                <ul
+                                  aria-label="Link 1"
+                                  className="bx--header__menu"
+                                  role="menu"
+                                >
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                    href=""
+                                    key=".$Link 1"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                        element="a"
+                                        href=""
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                          href=""
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Link 1
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                </ul>
+                              </li>
+                            </HeaderMenu>
+                          </ForwardRef>
+                          <ForwardRef
+                            aria-label="Link 2"
+                            data-autoid="dds--masthead__l0-nav--nav-1"
+                            key=".$1"
+                            menuLinkName="Link 2"
+                          >
+                            <HeaderMenu
+                              aria-label="Link 2"
+                              data-autoid="dds--masthead__l0-nav--nav-1"
+                              focusRef={[Function]}
+                              menuLinkName="Link 2"
+                              renderMenuContent={[Function]}
+                            >
+                              <li
+                                className="bx--header__submenu"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                              >
+                                <a
+                                  aria-expanded={false}
+                                  aria-haspopup="menu"
+                                  aria-label="Link 2"
+                                  className="bx--header__menu-item bx--header__menu-title"
+                                  href="#"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex={0}
+                                >
+                                  Link 2
+                                  <defaultRenderMenuContent>
+                                    <ForwardRef(ChevronDown20)
+                                      className="bx--header__menu-arrow"
+                                    >
+                                      <Icon
+                                        className="bx--header__menu-arrow"
+                                        fill="currentColor"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="bx--header__menu-arrow"
+                                          fill="currentColor"
+                                          focusable="false"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                          />
+                                        </svg>
+                                      </Icon>
+                                    </ForwardRef(ChevronDown20)>
+                                  </defaultRenderMenuContent>
+                                </a>
+                                <ul
+                                  aria-label="Link 2"
+                                  className="bx--header__menu"
+                                  role="menu"
+                                >
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                    href=""
+                                    key=".$Link 2"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                        element="a"
+                                        href=""
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                          href=""
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Link 2
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                    href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                    key=".$Financing"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                        element="a"
+                                        href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                          href="https://www.ibm.com/financing?lnk=hpmse_fin&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Financing
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                </ul>
+                              </li>
+                            </HeaderMenu>
+                          </ForwardRef>
+                          <ForwardRef(HeaderMenuItem)
+                            data-autoid="dds--masthead__l1-nav--nav-2"
+                            href="https://www.ibm.com/industries?lnk=min"
+                            key=".$2"
+                          >
+                            <li>
+                              <Link
+                                className="bx--header__menu-item"
+                                data-autoid="dds--masthead__l1-nav--nav-2"
+                                element="a"
+                                href="https://www.ibm.com/industries?lnk=min"
+                                tabIndex={0}
+                              >
+                                <a
+                                  className="bx--header__menu-item"
+                                  data-autoid="dds--masthead__l1-nav--nav-2"
+                                  href="https://www.ibm.com/industries?lnk=min"
+                                  tabIndex={0}
+                                >
+                                  <span
+                                    className="bx--text-truncate--end"
+                                  >
+                                    Industries
+                                  </span>
+                                </a>
+                              </Link>
+                            </li>
+                          </ForwardRef(HeaderMenuItem)>
+                          <ForwardRef
+                            aria-label="Link 3"
+                            data-autoid="dds--masthead__l0-nav--nav-3"
+                            key=".$3"
+                            menuLinkName="Link 3"
+                          >
+                            <HeaderMenu
+                              aria-label="Link 3"
+                              data-autoid="dds--masthead__l0-nav--nav-3"
+                              focusRef={[Function]}
+                              menuLinkName="Link 3"
+                              renderMenuContent={[Function]}
+                            >
+                              <li
+                                className="bx--header__submenu"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                              >
+                                <a
+                                  aria-expanded={false}
+                                  aria-haspopup="menu"
+                                  aria-label="Link 3"
+                                  className="bx--header__menu-item bx--header__menu-title"
+                                  href="#"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex={0}
+                                >
+                                  Link 3
+                                  <defaultRenderMenuContent>
+                                    <ForwardRef(ChevronDown20)
+                                      className="bx--header__menu-arrow"
+                                    >
+                                      <Icon
+                                        className="bx--header__menu-arrow"
+                                        fill="currentColor"
+                                        height={20}
+                                        preserveAspectRatio="xMidYMid meet"
+                                        viewBox="0 0 32 32"
+                                        width={20}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="bx--header__menu-arrow"
+                                          fill="currentColor"
+                                          focusable="false"
+                                          height={20}
+                                          preserveAspectRatio="xMidYMid meet"
+                                          viewBox="0 0 32 32"
+                                          width={20}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                                          />
+                                        </svg>
+                                      </Icon>
+                                    </ForwardRef(ChevronDown20)>
+                                  </defaultRenderMenuContent>
+                                </a>
+                                <ul
+                                  aria-label="Link 3"
+                                  className="bx--header__menu"
+                                  role="menu"
+                                >
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                    href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                    key=".$IBM Developer"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                        element="a"
+                                        href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item0"
+                                          href="https://developer.ibm.com/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            IBM Developer
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                    href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                    key=".$Blockchain"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                        element="a"
+                                        href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item1"
+                                          href="https://developer.ibm.com/technologies/blockchain/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Blockchain
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item2"
+                                    href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                    key=".$Containers"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item2"
+                                        element="a"
+                                        href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item2"
+                                          href="https://developer.ibm.com/technologies/containers/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Containers
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                  <ForwardRef(HeaderMenuItem)
+                                    data-autoid="dds--masthead__l1-nav--subnav-col0-item3"
+                                    href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                    key=".$Analytics"
+                                    role="none"
+                                  >
+                                    <li
+                                      role="none"
+                                    >
+                                      <Link
+                                        className="bx--header__menu-item"
+                                        data-autoid="dds--masthead__l1-nav--subnav-col0-item3"
+                                        element="a"
+                                        href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                        tabIndex={0}
+                                      >
+                                        <a
+                                          className="bx--header__menu-item"
+                                          data-autoid="dds--masthead__l1-nav--subnav-col0-item3"
+                                          href="https://developer.ibm.com/technologies/analytics/?lnk=hpmdev_dw&lnk2=learn"
+                                          tabIndex={0}
+                                        >
+                                          <span
+                                            className="bx--text-truncate--end"
+                                          >
+                                            Analytics
+                                          </span>
+                                        </a>
+                                      </Link>
+                                    </li>
+                                  </ForwardRef(HeaderMenuItem)>
+                                </ul>
+                              </li>
+                            </HeaderMenu>
+                          </ForwardRef>
+                          <ForwardRef(HeaderMenuItem)
+                            data-autoid="dds--masthead__l1-nav--nav-4"
+                            href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                            key=".$4"
+                          >
+                            <li>
+                              <Link
+                                className="bx--header__menu-item"
+                                data-autoid="dds--masthead__l1-nav--nav-4"
+                                element="a"
+                                href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                tabIndex={0}
+                              >
+                                <a
+                                  className="bx--header__menu-item"
+                                  data-autoid="dds--masthead__l1-nav--nav-4"
+                                  href="https://www.ibm.com/support/home/?lnk=msu_usen"
+                                  tabIndex={0}
+                                >
+                                  <span
+                                    className="bx--text-truncate--end"
+                                  >
+                                    Support
+                                  </span>
+                                </a>
+                              </Link>
+                            </li>
+                          </ForwardRef(HeaderMenuItem)>
+                        </ul>
+                      </nav>
+                    </HeaderNavigation>
+                  </div>
+                </MastheadL1>
+              </div>
+            </div>
+          </render>
+        </HeaderContainer>
+      </Masthead>
+    </Default>
   </div>
   <input
     aria-label="input-text-offleft"
@@ -49801,6 +61739,524 @@ exports[`Storyshots Components|Quote Default 1`] = `
 </Container>
 `;
 
+exports[`Storyshots Components|Simple Benefits Default 1`] = `
+<Container
+  story={[Function]}
+>
+  <div
+    data-floating-menu-container=""
+    role="main"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  >
+    <SimpleBenefits
+      content={
+        Array [
+          Object {
+            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+            "title": "Aliquam condimentum interdum",
+          },
+          Object {
+            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+            "link": Object {
+              "href": "https://www.example.com",
+              "target": "_self",
+              "text": "Learn more",
+            },
+            "title": "Aliquam",
+          },
+          Object {
+            "copy": "Lorem ipsum dolor sit amet. Consectetur adipiscing elit. Aenean et ultricies est. Aenean et ultricies est.",
+            "link": Object {
+              "href": "https://www.example.com",
+              "target": "_self",
+              "text": "Learn more",
+            },
+            "title": "Aliquam condimentum interdum",
+          },
+          Object {
+            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.",
+            "link": Object {
+              "href": "https://www.example.com",
+              "target": "_self",
+              "text": "Learn more",
+            },
+            "title": "Aliquam condimentum interdum ultricies est",
+          },
+          Object {
+            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+            "title": "Aliquam condimentum interdum",
+          },
+          Object {
+            "copy": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.",
+            "link": Object {
+              "href": "https://www.example.com",
+              "target": "_self",
+              "text": "Learn more",
+            },
+            "title": "Aliquam condimentum interdum",
+          },
+        ]
+      }
+      theme=""
+      title="Lorem ipsum dolor sit amet consectetur adipiscing elit"
+    >
+      <section
+        className="bx--simplebenefits bx--simplebenefits--multirow "
+        data-autoid="dds--simplebenefits"
+      >
+        <div
+          className="bx--simplebenefits__container"
+        >
+          <div
+            className="bx--simplebenefits__row"
+          >
+            <h2
+              className="bx--simplebenefits__title"
+            >
+              <div
+                className="bx--simplebenefits__title-container"
+              >
+                Lorem ipsum dolor sit amet consectetur adipiscing elit
+              </div>
+            </h2>
+            <div
+              className="bx--simplebenefits__content"
+              data-autoid="dds--simplebenefits__content"
+            >
+              <SimpleBenefitsItem
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                key="0"
+                title="Aliquam condimentum interdum"
+              >
+                <div
+                  className="bx--simplebenefits__content-item"
+                  data-autoid="dds--simplebenefits__content-item"
+                >
+                  <div
+                    className="bx--simplebenefits__content-item-container"
+                  >
+                    <h3
+                      className="bx--simplebenefits__content-item__title"
+                    >
+                      Aliquam condimentum interdum
+                    </h3>
+                    <div
+                      className="bx--simplebenefits__content-item__divider"
+                    />
+                    <div
+                      className="bx--simplebenefits__content-item__content"
+                    >
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+                    </div>
+                  </div>
+                </div>
+              </SimpleBenefitsItem>
+              <SimpleBenefitsItem
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                key="1"
+                link={
+                  Object {
+                    "href": "https://www.example.com",
+                    "target": "_self",
+                    "text": "Learn more",
+                  }
+                }
+                title="Aliquam"
+              >
+                <div
+                  className="bx--simplebenefits__content-item"
+                  data-autoid="dds--simplebenefits__content-item"
+                >
+                  <div
+                    className="bx--simplebenefits__content-item-container"
+                  >
+                    <h3
+                      className="bx--simplebenefits__content-item__title"
+                    >
+                      Aliquam
+                    </h3>
+                    <div
+                      className="bx--simplebenefits__content-item__divider"
+                    />
+                    <div
+                      className="bx--simplebenefits__content-item__content"
+                    >
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+                    </div>
+                    <div
+                      className="bx--simplebenefits__content-item__link"
+                    >
+                      <LinkWithIcon
+                        href="https://www.example.com"
+                        iconPlacement="right"
+                        target="_self"
+                      >
+                        <div
+                          className="bx--link-with-icon__container"
+                          data-autoid="dds--link-with-icon"
+                        >
+                          <Link
+                            className="bx--link-with-icon"
+                            href="https://www.example.com"
+                            target="_self"
+                          >
+                            <a
+                              className="bx--link bx--link-with-icon"
+                              href="https://www.example.com"
+                              target="_self"
+                            >
+                              <span>
+                                Learn more
+                              </span>
+                              <ForwardRef(ArrowRight20)>
+                                <Icon
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 20 20"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 20 20"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowRight20)>
+                            </a>
+                          </Link>
+                        </div>
+                      </LinkWithIcon>
+                    </div>
+                  </div>
+                </div>
+              </SimpleBenefitsItem>
+              <SimpleBenefitsItem
+                copy="Lorem ipsum dolor sit amet. Consectetur adipiscing elit. Aenean et ultricies est. Aenean et ultricies est."
+                key="2"
+                link={
+                  Object {
+                    "href": "https://www.example.com",
+                    "target": "_self",
+                    "text": "Learn more",
+                  }
+                }
+                title="Aliquam condimentum interdum"
+              >
+                <div
+                  className="bx--simplebenefits__content-item"
+                  data-autoid="dds--simplebenefits__content-item"
+                >
+                  <div
+                    className="bx--simplebenefits__content-item-container"
+                  >
+                    <h3
+                      className="bx--simplebenefits__content-item__title"
+                    >
+                      Aliquam condimentum interdum
+                    </h3>
+                    <div
+                      className="bx--simplebenefits__content-item__divider"
+                    />
+                    <div
+                      className="bx--simplebenefits__content-item__content"
+                    >
+                      Lorem ipsum dolor sit amet. Consectetur adipiscing elit. Aenean et ultricies est. Aenean et ultricies est.
+                    </div>
+                    <div
+                      className="bx--simplebenefits__content-item__link"
+                    >
+                      <LinkWithIcon
+                        href="https://www.example.com"
+                        iconPlacement="right"
+                        target="_self"
+                      >
+                        <div
+                          className="bx--link-with-icon__container"
+                          data-autoid="dds--link-with-icon"
+                        >
+                          <Link
+                            className="bx--link-with-icon"
+                            href="https://www.example.com"
+                            target="_self"
+                          >
+                            <a
+                              className="bx--link bx--link-with-icon"
+                              href="https://www.example.com"
+                              target="_self"
+                            >
+                              <span>
+                                Learn more
+                              </span>
+                              <ForwardRef(ArrowRight20)>
+                                <Icon
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 20 20"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 20 20"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowRight20)>
+                            </a>
+                          </Link>
+                        </div>
+                      </LinkWithIcon>
+                    </div>
+                  </div>
+                </div>
+              </SimpleBenefitsItem>
+              <SimpleBenefitsItem
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est."
+                key="3"
+                link={
+                  Object {
+                    "href": "https://www.example.com",
+                    "target": "_self",
+                    "text": "Learn more",
+                  }
+                }
+                title="Aliquam condimentum interdum ultricies est"
+              >
+                <div
+                  className="bx--simplebenefits__content-item"
+                  data-autoid="dds--simplebenefits__content-item"
+                >
+                  <div
+                    className="bx--simplebenefits__content-item-container"
+                  >
+                    <h3
+                      className="bx--simplebenefits__content-item__title"
+                    >
+                      Aliquam condimentum interdum ultricies est
+                    </h3>
+                    <div
+                      className="bx--simplebenefits__content-item__divider"
+                    />
+                    <div
+                      className="bx--simplebenefits__content-item__content"
+                    >
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est.
+                    </div>
+                    <div
+                      className="bx--simplebenefits__content-item__link"
+                    >
+                      <LinkWithIcon
+                        href="https://www.example.com"
+                        iconPlacement="right"
+                        target="_self"
+                      >
+                        <div
+                          className="bx--link-with-icon__container"
+                          data-autoid="dds--link-with-icon"
+                        >
+                          <Link
+                            className="bx--link-with-icon"
+                            href="https://www.example.com"
+                            target="_self"
+                          >
+                            <a
+                              className="bx--link bx--link-with-icon"
+                              href="https://www.example.com"
+                              target="_self"
+                            >
+                              <span>
+                                Learn more
+                              </span>
+                              <ForwardRef(ArrowRight20)>
+                                <Icon
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 20 20"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 20 20"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowRight20)>
+                            </a>
+                          </Link>
+                        </div>
+                      </LinkWithIcon>
+                    </div>
+                  </div>
+                </div>
+              </SimpleBenefitsItem>
+              <SimpleBenefitsItem
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                key="4"
+                title="Aliquam condimentum interdum"
+              >
+                <div
+                  className="bx--simplebenefits__content-item"
+                  data-autoid="dds--simplebenefits__content-item"
+                >
+                  <div
+                    className="bx--simplebenefits__content-item-container"
+                  >
+                    <h3
+                      className="bx--simplebenefits__content-item__title"
+                    >
+                      Aliquam condimentum interdum
+                    </h3>
+                    <div
+                      className="bx--simplebenefits__content-item__divider"
+                    />
+                    <div
+                      className="bx--simplebenefits__content-item__content"
+                    >
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+                    </div>
+                  </div>
+                </div>
+              </SimpleBenefitsItem>
+              <SimpleBenefitsItem
+                copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+                key="5"
+                link={
+                  Object {
+                    "href": "https://www.example.com",
+                    "target": "_self",
+                    "text": "Learn more",
+                  }
+                }
+                title="Aliquam condimentum interdum"
+              >
+                <div
+                  className="bx--simplebenefits__content-item"
+                  data-autoid="dds--simplebenefits__content-item"
+                >
+                  <div
+                    className="bx--simplebenefits__content-item-container"
+                  >
+                    <h3
+                      className="bx--simplebenefits__content-item__title"
+                    >
+                      Aliquam condimentum interdum
+                    </h3>
+                    <div
+                      className="bx--simplebenefits__content-item__divider"
+                    />
+                    <div
+                      className="bx--simplebenefits__content-item__content"
+                    >
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
+                    </div>
+                    <div
+                      className="bx--simplebenefits__content-item__link"
+                    >
+                      <LinkWithIcon
+                        href="https://www.example.com"
+                        iconPlacement="right"
+                        target="_self"
+                      >
+                        <div
+                          className="bx--link-with-icon__container"
+                          data-autoid="dds--link-with-icon"
+                        >
+                          <Link
+                            className="bx--link-with-icon"
+                            href="https://www.example.com"
+                            target="_self"
+                          >
+                            <a
+                              className="bx--link bx--link-with-icon"
+                              href="https://www.example.com"
+                              target="_self"
+                            >
+                              <span>
+                                Learn more
+                              </span>
+                              <ForwardRef(ArrowRight20)>
+                                <Icon
+                                  fill="currentColor"
+                                  height={20}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 20 20"
+                                  width={20}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height={20}
+                                    preserveAspectRatio="xMidYMid meet"
+                                    viewBox="0 0 20 20"
+                                    width={20}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"
+                                    />
+                                  </svg>
+                                </Icon>
+                              </ForwardRef(ArrowRight20)>
+                            </a>
+                          </Link>
+                        </div>
+                      </LinkWithIcon>
+                    </div>
+                  </div>
+                </div>
+              </SimpleBenefitsItem>
+            </div>
+          </div>
+        </div>
+      </section>
+    </SimpleBenefits>
+  </div>
+  <input
+    aria-label="input-text-offleft"
+    className="bx--visually-hidden"
+    type="text"
+  />
+</Container>
+`;
+
 exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
 <Container
   story={[Function]}
@@ -50662,14 +63118,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                           />
                           <img
                             alt="Lorem Ipsum"
-                            aria-describedby="bx--image-83"
+                            aria-describedby="bx--image-99"
                             className="bx--image__img"
                             src="https://dummyimage.com/672x672"
                           />
                         </picture>
                         <div
                           className="bx--image__longdescription"
-                          id="bx--image-83"
+                          id="bx--image-99"
                         >
                           Lorem Ipsum Dolor
                         </div>
@@ -50880,14 +63336,14 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                             />
                             <img
                               alt="Lorem Ipsum"
-                              aria-describedby="bx--image-84"
+                              aria-describedby="bx--image-100"
                               className="bx--image__img"
                               src="https://dummyimage.com/672x672"
                             />
                           </picture>
                           <div
                             className="bx--image__longdescription"
-                            id="bx--image-84"
+                            id="bx--image-100"
                           >
                             Lorem Ipsum Dolor
                           </div>
@@ -51099,7 +63555,7 @@ exports[`Storyshots Components|VideoPlayer Default 1`] = `
               >
                 <div
                   className="bx--video-player__video"
-                  id="bx--video-player__video-0_uka1msg4-86"
+                  id="bx--video-player__video-0_uka1msg4-102"
                 >
                   <VideoImageOverlay
                     embedVideo={[Function]}

--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -41729,7 +41729,7 @@ exports[`Storyshots Components|Dotcom Shell With L 1 1`] = `
                                 style={
                                   Object {
                                     "position": "sticky",
-                                    "top": "0",
+                                    "top": 0,
                                   }
                                 }
                               >

--- a/packages/react/src/__tests__/storyshots.test.js
+++ b/packages/react/src/__tests__/storyshots.test.js
@@ -9,6 +9,8 @@ import initStoryshots from '@storybook/addon-storyshots';
 import { mount } from 'enzyme';
 import path from 'path';
 
+process.env = Object.assign(process.env, { DDS_FLAGS_ALL: true });
+
 /**
  * This will initialize storyshots for snapshot testing.
  * NOTE: If a molecule/organism requires deeper testing, a __tests__ folder must be created in the corresponding folder

--- a/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
+++ b/packages/react/src/components/DotcomShell/__stories__/DotcomShell.stories.js
@@ -5,10 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {
+  Default as mastheadStory,
+  WithL1 as withL1Story,
+} from '../../Masthead/__stories__/Masthead.stories.js';
 import Content from './data/content';
+import { DDS_MASTHEAD_L1 } from '../../../internal/FeatureFlags';
 import DotcomShell from '../DotcomShell';
 import { Default as footerStory } from '../../Footer/__stories__/Footer.stories.js';
-import { Default as mastheadStory } from '../../Masthead/__stories__/Masthead.stories.js';
+
 import React from 'react';
 import readme from '../README.stories.mdx';
 import { select } from '@storybook/addon-knobs';
@@ -60,3 +65,34 @@ export const Default = ({ parameters }) => {
     </DotcomShell>
   );
 };
+
+export const WithL1 = !DDS_MASTHEAD_L1
+  ? undefined
+  : ({ parameters }) => <Default parameters={parameters} />;
+
+if (WithL1) {
+  WithL1.story = {
+    parameters: {
+      knobs: {
+        DotcomShell: () => {
+          const {
+            Masthead: mastheadKnobs,
+          } = withL1Story.story.parameters.knobs;
+          const { Footer: footerKnobs } = footerStory.story.parameters.knobs;
+          return {
+            mastheadProps: mastheadKnobs({ groupId: 'Masthead' }),
+            footerProps: {
+              ...footerKnobs({ groupId: 'Footer' }),
+              type: select(
+                'Footer (footerProps): sets the type of footer (type)',
+                footerTypeOptions,
+                footerTypeOptions.tall,
+                'Footer'
+              ),
+            },
+          };
+        },
+      },
+    },
+  };
+}

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -42,9 +42,7 @@ const { prefix } = settings;
  * @param {boolean} props.searchOpenOnload Determines if the search field is open on page load
  * @param {string} props.placeHolderText Placeholder value for search input
  * @param {object} props.platform Platform name that appears on L0.
- * @param {string} props.title Title for the masthead L1
- * @param {string} props.eyebrowText Text for the eyebrow link in masthead L1
- * @param {string} props.eyebrowLink URL for the eyebrow link in masthead L1
+ * @param {object} props.mastheadL1Data L1 data
  * @returns {*} Masthead component
  */
 const Masthead = ({

--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -147,6 +147,7 @@ MastheadL1.propTypes = {
 };
 
 MastheadL1.defaultProps = {
+  isShort: false,
   navigationL1: [],
   titleLink: null,
 };

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -2,6 +2,7 @@ import { Props, Description } from '@storybook/addon-docs/blocks';
 import contributing from '../../../../../docs/contributing-license.md';
 import corsproxy from '../../../../../docs/cors-proxy.md';
 import Masthead from './Masthead';
+import MastheadL1 from './MastheadL1';
 
 # Masthead
 
@@ -73,6 +74,10 @@ DDS_MASTHEAD_L1=true
 ## Props
 
 <Props of={Masthead} />
+
+### L1 Props
+
+<Props of={MastheadL1} />
 
 ## platform
 

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -30,20 +30,6 @@ Default.story = {
   parameters: {
     knobs: {
       Masthead: ({ groupId }) => {
-        const mastheadL1Data = DDS_MASTHEAD_L1 && {
-          title: text(
-            'L1 title (title) (experimental)',
-            'Stock Charts',
-            groupId
-          ),
-          titleLink: text(
-            'L1 title link (titleLink) (experimental)',
-            'https://example.com/',
-            groupId
-          ),
-          navigationL1: mastheadKnobs.navigation.custom,
-        };
-
         const standardProps = {
           navigation: select(
             'navigation data (navigation)',
@@ -74,7 +60,6 @@ Default.story = {
             'Search all of IBM',
             groupId
           ),
-          mastheadL1Data,
         };
         return {
           ...standardProps,
@@ -129,28 +114,71 @@ WithPlatform.story = {
             groupId
           ),
         };
-        const mastheadL1Props = DDS_MASTHEAD_L1 && {
-          title: text(
-            'L1 title (title) (experimental)',
-            'Stock Charts',
-            groupId
-          ),
-          eyebrowText: text(
-            'L1 eyebrow text (eyebrowText) (experimental)',
-            'Eyebrow',
-            groupId
-          ),
-          eyebrowLink: text(
-            'L1 eyebrow link (eyebrowLink) (experimental)',
-            '#',
-            groupId
-          ),
-        };
         return {
           ...standardProps,
-          ...mastheadL1Props,
         };
       },
     },
   },
 };
+
+export const WithL1 = !DDS_MASTHEAD_L1
+  ? undefined
+  : ({ parameters }) => <Default parameters={parameters} />;
+
+if (WithL1) {
+  WithL1.story = {
+    parameters: {
+      knobs: {
+        Masthead: ({ groupId }) => {
+          const standardProps = {
+            hasProfile: boolean(
+              'show the profile functionality (hasProfile)',
+              true,
+              groupId
+            ),
+            hasSearch: boolean(
+              'show the search functionality (hasSearch)',
+              true,
+              groupId
+            ),
+            placeHolderText: text(
+              'search placeholder (placeHolderText)',
+              'Search all of IBM',
+              groupId
+            ),
+          };
+          const mastheadL1Props = {
+            mastheadL1Data: {
+              title: text(
+                'L1 title (mastheadL1Data.title) (experimental)',
+                'Stock Charts',
+                groupId
+              ),
+              titleLink: text(
+                'L1 title link(mastheadL1Data.titleLink) (experimental)',
+                'https://www.example.com',
+                groupId
+              ),
+              eyebrowText: text(
+                'L1 eyebrow text (mastheadL1Data.eyebrowText) (experimental)',
+                'Eyebrow',
+                groupId
+              ),
+              eyebrowLink: text(
+                'L1 eyebrow link (mastheadL1Data.eyebrowLink) (experimental)',
+                '#',
+                groupId
+              ),
+              navigationL1: mastheadKnobs.navigation.custom,
+            },
+          };
+          return {
+            ...standardProps,
+            ...mastheadL1Props,
+          };
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

For experimental, the stories for L1 was directly integrated.
This separates out into their own stories.

One other change that had to be made, storyshots gets confused when it runs
snapshots over sub stories that are behind a feature flag. The only way I could find
to fix this issue is to enable feature flags for snapshot test. This seems to address the 
issue.

### Changelog

**New**

- Separated Masthead L1 stories in `Masthead` and `DotcomShell`

**Changed**

- Enabled feature flags for Jest snapshot testing