### PR TITLE
docs(readme): update for WC

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -37,30 +37,85 @@ yarn add @carbon/ibmdotcom-web-components lit-html lit-element
 
 ### Basic usage
 
-The first thing you need is **setting up a module bundler** to resolve ECMAScript `import`s. Once you set up a module bundler, you can start importing our component modules, like:
-
-```javascript
-import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon';
-```
-
-Once you do that, you can use our components in the same manner as native HTML tags, like:
+For quick start, you can use CDNs that support module mapping (e.g. [JSPM](https://jspm.org)). With it, you can use our components as easy as using HTML tags, just by importing our modules in `<script type="module">` like:
 
 ```html
-<dds-link-with-icon href="http://ibmdotcom-web-components-canary.mybluemix.net/">
-  Link text
-  <svg
-    slot="icon"
-    focusable="false"
-    preserveAspectRatio="xMidYMid meet"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-    width="20"
-    height="20"
-    viewBox="0 0 20 20"
-  >
-    <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
-  </svg>
-</dds-link-with-icon>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module">
+      import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/button/button.js';
+      import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal.js';
+      import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal-header.js';
+      import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal-heading.js';
+      import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal-close-button.js';
+      import 'https://jspm.dev/@carbon/ibmdotcom-web-components@canary/es/components/modal/modal-body.js';
+    </script>
+    <style type="text/css">
+      body {
+        font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+        margin: 0;
+      }
+
+      dds-btn:not(:defined),
+      dds-modal:not(:defined) {
+        visibility: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <dds-btn id="launch-modal" kind="primary">Open modal</dds-btn>
+    <dds-modal>
+      <dds-modal-header>
+        <dds-modal-close-button></dds-modal-close-button>
+        <dds-modal-heading>Modal Title</dds-modal-heading>
+      </dds-modal-header>
+      <dds-modal-body>
+        Modal content
+      </dds-modal-body>
+    </dds-modal>
+    <script type="text/javascript">
+      document.addEventListener('click', event => {
+        if (event.target.matches('dds-btn#launch-modal')) {
+          document.querySelector('dds-modal').open = true;
+        }
+      });
+    </script>
+  </body>
+</html>
+```
+
+For production usage, our recommendation is **setting up a module bundler** to resolve ECMAScript `import`s. Once you set up a module bundler, you can start importing our component modules, like:
+
+```javascript
+import '@carbon/ibmdotcom-web-components/es/components/button/button';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal-header';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal-heading';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal-close-button';
+import '@carbon/ibmdotcom-web-components/es/components/modal/modal-body';
+```
+
+Once you do that, you can use our components as easy as using HTML tags, like:
+
+```html
+<dds-btn id="launch-modal" kind="primary">Open modal</dds-btn>
+<dds-modal>
+  <dds-modal-header>
+    <dds-modal-close-button></dds-modal-close-button>
+    <dds-modal-heading>Modal Title</dds-modal-heading>
+  </dds-modal-header>
+  <dds-modal-body>
+    Modal content
+  </dds-modal-body>
+</dds-modal>
+<script type="text/javascript">
+  document.addEventListener('click', event => {
+    if (event.target.matches('dds-btn#launch-modal')) {
+      document.querySelector('dds-modal').open = true;
+    }
+  });
+</script>
 ```
 
 > 💡 Check our


### PR DESCRIPTION
### Description

This change updates basic usage section in Web Components variant's README, to add an example with no toolstack. Also updates existing example, replacing `<dds-link-with-icon>` with `<dds-modal>`.

### Changelog

**Changed**

- Updated basic usage section in Web Components variant's README, to add an example with no toolstack.
- Updated existing example, replacing `<dds-link-with-icon>` with `<dds-modal>`.