### PR TITLE
fix(CTASection): add sameHeight to content items

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1574,7 +1574,7 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                   "heading": "Get connected",
                 },
                 Object {
-                  "copy": "IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.",
+                  "copy": "IBM DevOps partners have a wide range of expertise",
                   "cta": Object {
                     "copy": "Browse tutorials",
                     "href": "https://example.com/",
@@ -1911,7 +1911,7 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                     </div>
                   </ContentItem>
                   <ContentItem
-                    copy="IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you."
+                    copy="IBM DevOps partners have a wide range of expertise"
                     cta={
                       Object {
                         "copy": "Browse tutorials",
@@ -1936,7 +1936,7 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                         className="bx--content-item__copy"
                         dangerouslySetInnerHTML={
                           Object {
-                            "__html": "<p>IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.</p> ",
+                            "__html": "<p>IBM DevOps partners have a wide range of expertise</p> ",
                           }
                         }
                         data-autoid="dds--content-item__copy"

--- a/packages/react/src/components/CTASection/CTASection.js
+++ b/packages/react/src/components/CTASection/CTASection.js
@@ -5,13 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React, { useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import ContentBlock from '../../internal/components/ContentBlock/ContentBlock';
 import ContentItem from '../../internal/components/ContentItem/ContentItem';
 import { CTA } from '../CTA';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import PropTypes from 'prop-types';
-import React from 'react';
+import root from 'window-or-global';
+import sameHeight from '@carbon/ibmdotcom-utilities/es/utilities/sameHeight/sameHeight';
 import settings from 'carbon-components/es/globals/js/settings';
 
 const { stablePrefix } = ddsSettings;
@@ -21,13 +23,38 @@ const { prefix } = settings;
  * CTASection pattern.
  */
 const CTASection = ({ heading, copy, cta, items, theme }) => {
+  const containerRef = useRef();
+
+  useEffect(() => {
+    setSameHeight();
+    root.addEventListener('resize', setSameHeight);
+
+    return () => root.removeEventListener('resize', setSameHeight);
+  }, []);
+
+  /**
+   * Function that activates the sameHeight utility
+   */
+  const setSameHeight = () => {
+    root.requestAnimationFrame(() => {
+      const { current: containerNode } = containerRef;
+      if (containerNode) {
+        sameHeight(
+          containerNode.getElementsByClassName(`${prefix}--content-item__copy`),
+          'md'
+        );
+      }
+    });
+  };
+
   return (
     <section
       data-autoid={`${stablePrefix}--cta-section`}
       className={classNames(`${prefix}--cta-section`, {
         [`${prefix}--cta-section__has-items`]: items,
         [`${prefix}--cta-section--${theme}`]: theme,
-      })}>
+      })}
+      ref={containerRef}>
       <ContentBlock heading={heading} copy={copy} />
       <CTA customClassName={`${prefix}--cta-section__cta`} {...cta} />
       {items && (

--- a/packages/react/src/components/CTASection/__stories__/CTASection.stories.js
+++ b/packages/react/src/components/CTASection/__stories__/CTASection.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { select, text, object } from '@storybook/addon-knobs';
+import { select, text } from '@storybook/addon-knobs';
 import CTASection from '../CTASection';
 import React from 'react';
 import readme from '../README.stories.mdx';
@@ -25,8 +25,7 @@ const contentItemsProps = [
   },
   {
     heading: 'Learn how',
-    copy:
-      'IBM DevOps partners have a wide range of expertise. Find one to build the right solution for you.',
+    copy: 'IBM DevOps partners have a wide range of expertise',
     cta: {
       copy: 'Browse tutorials',
       type: types[0],
@@ -127,9 +126,9 @@ WithContentItems.story = {
   parameters: {
     knobs: {
       CTASection: ({ groupId }) => ({
-        heading: text('ContentBlock | heading:', 'Take the next step', groupId),
+        heading: text('Heading (heading):', 'Take the next step', groupId),
         copy: text(
-          'ContentBlock | copy:',
+          'Copy (copy):',
           `Want to discuss your options with a DevOps expert? Contact our sales team to evaluate your needs.`,
           groupId
         ),
@@ -138,18 +137,18 @@ WithContentItems.story = {
           type: types[0],
           buttons: [
             {
-              type: select('ContentBlock | CTA type', types, types[2], groupId),
+              type: select('CTA (type):', types, types[2], groupId),
               copy: 'Secondary button',
               href: 'https://example.com/',
             },
             {
-              type: select('ContentBlock | CTA type', types, types[2], groupId),
+              type: select('CTA (type):', types, types[2], groupId),
               copy: 'Primary button',
               href: 'https://example.com/',
             },
           ],
         },
-        items: object('ContentItems | Data', contentItemsProps, groupId),
+        items: contentItemsProps,
       }),
     },
   },

--- a/packages/react/src/components/ContentBlockHeadlines/ContentBlockHeadlines.js
+++ b/packages/react/src/components/ContentBlockHeadlines/ContentBlockHeadlines.js
@@ -11,6 +11,7 @@ import { DDS_CONTENTBLOCK_HEADLINES } from '../../internal/FeatureFlags';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import featureFlag from '@carbon/ibmdotcom-utilities/es/utilities/featureflag/featureflag';
 import PropTypes from 'prop-types';
+import root from 'window-or-global';
 import sameHeight from '@carbon/ibmdotcom-utilities/es/utilities/sameHeight/sameHeight';
 import settings from 'carbon-components/es/globals/js/settings';
 
@@ -26,16 +27,16 @@ const ContentBlockHeadlines = ({ heading, copy, items }) => {
 
   useEffect(() => {
     setSameHeight();
-    window.addEventListener('resize', setSameHeight);
+    root.addEventListener('resize', setSameHeight);
 
-    return () => window.removeEventListener('resize', setSameHeight);
+    return () => root.removeEventListener('resize', setSameHeight);
   }, []);
 
   /**
    * Function that activates the sameHeight utility
    */
   const setSameHeight = () => {
-    window.requestAnimationFrame(() => {
+    root.requestAnimationFrame(() => {
       const { current: containerNode } = containerRef;
       if (containerNode) {
         sameHeight(


### PR DESCRIPTION
### Description

`CTASection` content items should be set to the same height.

![image](https://user-images.githubusercontent.com/909118/88778870-0be2e300-d157-11ea-999f-65de23425fc8.png)


### Changelog

**Changed**

- set `sameHeight` for content items


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
