### PR TITLE
fix(footer): fixed spacing of the legal nav list

### DIFF
--- a/packages/styles/scss/components/footer/_legal-nav.scss
+++ b/packages/styles/scss/components/footer/_legal-nav.scss
@@ -82,7 +82,7 @@
       &__list-item {
         display: inline-block;
         margin-right: carbon--mini-units(4);
-        padding: $spacing-03 0 0 0;
+        padding: $spacing-05 0 0 0;
 
         &:last-child {
           margin-right: 0;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/2771

### Description

Fixes the padding between the legal nav list on mobile

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
