### PR TITLE
chore(styles): rename type token zone mixin names

### DIFF
--- a/packages/styles/scss/components/card/index.scss
+++ b/packages/styles/scss/components/card/index.scss
@@ -46,7 +46,7 @@
     }
 
     &__eyebrow {
-      @include carbon-productive-tokens-custom-properties();
+      @include use-carbon-productive-tokens();
       @include carbon--type-style('body-short-01');
 
       margin-bottom: $carbon--spacing-03;
@@ -136,7 +136,7 @@
     &__video {
       .#{$prefix}--card__footer span {
         color: $text-02;
-        @include carbon-productive-tokens-custom-properties();
+        @include use-carbon-productive-tokens();
         @include carbon--type-style('body-short-01');
       }
     }

--- a/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
+++ b/packages/styles/scss/components/content-item-horizontal/_content-item-horizontal.scss
@@ -26,7 +26,7 @@
       &--eyebrow {
         color: $text-05;
         padding-bottom: $spacing-03;
-        @include carbon-productive-tokens-custom-properties();
+        @include use-carbon-productive-tokens();
         @include carbon--type-style('body-long-01');
       }
 

--- a/packages/styles/scss/components/image-with-caption/image-with-caption.scss
+++ b/packages/styles/scss/components/image-with-caption/image-with-caption.scss
@@ -77,7 +77,7 @@
   }
 
   .#{$prefix}--image__caption {
-    @include carbon-productive-tokens-custom-properties();
+    @include use-carbon-productive-tokens();
     @include carbon--type-style('body-short-01', true);
 
     margin-top: $carbon--spacing-03;

--- a/packages/styles/scss/components/locale-modal/_locale-modal.scss
+++ b/packages/styles/scss/components/locale-modal/_locale-modal.scss
@@ -184,7 +184,7 @@
           padding: $carbon--spacing-05;
           min-height: $carbon--spacing-09;
 
-          @include carbon-productive-tokens-custom-properties();
+          @include use-carbon-productive-tokens();
           @include carbon--type-style(heading-01, true);
         }
       }
@@ -225,7 +225,7 @@
             margin-right: $carbon--spacing-03;
           }
 
-          @include carbon-productive-tokens-custom-properties();
+          @include use-carbon-productive-tokens();
           @include carbon--type-style(body-short-01, true);
         }
 

--- a/packages/styles/scss/components/logo-grid/_logo-grid.scss
+++ b/packages/styles/scss/components/logo-grid/_logo-grid.scss
@@ -56,7 +56,7 @@
       }
 
       .#{$prefix}--card__heading {
-        @include carbon-productive-tokens-custom-properties();
+        @include use-carbon-productive-tokens();
         @include carbon--type-style('productive-heading-01');
       }
     }

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -149,7 +149,7 @@
             cursor: pointer;
             border-bottom: none;
             > .#{$prefix}--side-nav__link-text {
-              @include carbon-productive-tokens-custom-properties();
+              @include use-carbon-productive-tokens();
               @include carbon--type-style(body-short-01, true);
 
               color: $icon-02;

--- a/packages/styles/scss/components/video-player/_video-player.scss
+++ b/packages/styles/scss/components/video-player/_video-player.scss
@@ -41,7 +41,7 @@ $aspect-ratios: ((16, 9), (9, 16), (2, 1), (1, 2), (4, 3), (3, 4), (1, 1));
     }
 
     &__video-caption {
-      @include carbon-productive-tokens-custom-properties();
+      @include use-carbon-productive-tokens();
       @include carbon--type-style(body-long-01, true);
 
       padding-top: $spacing-05;

--- a/packages/styles/scss/themes/expressive/_tokens.scss
+++ b/packages/styles/scss/themes/expressive/_tokens.scss
@@ -260,7 +260,7 @@ $carbon-expressive-component-tokens: (
 /// @param {Map} $type-tokens [$carbon-productive-type-tokens] - The type tokens.
 /// @param {Map} $component-tokens [$carbon-productive-component-tokens] - The component tokens.
 /// @group carbon-expressive
-@mixin carbon-productive-tokens-custom-properties(
+@mixin use-carbon-productive-tokens(
   $size-tokens: $carbon-productive-size-tokens,
   $type-tokens: $carbon-productive-type-tokens,
   $component-tokens: $carbon-productive-component-tokens
@@ -284,7 +284,7 @@ $carbon-expressive-component-tokens: (
 /// @param {Map} $type-tokens [$carbon-expressive-type-tokens] - The type tokens.
 /// @param {Map} $component-tokens [$carbon-expressive-component-tokens] - The component tokens.
 /// @group carbon-expressive
-@mixin carbon-expressive-tokens-custom-properties(
+@mixin use-carbon-expressive-tokens(
   $size-tokens: $carbon-expressive-size-tokens,
   $type-tokens: $carbon-expressive-type-tokens,
   $component-tokens: $carbon-expressive-component-tokens
@@ -479,7 +479,7 @@ $carbon-expressive-component-tokens: (
   );
 
   :root {
-    @include carbon-expressive-tokens-custom-properties($component-tokens: ());
+    @include use-carbon-expressive-tokens($component-tokens: ());
   }
 }
 
@@ -536,9 +536,6 @@ $carbon-expressive-component-tokens: (
   ) !global;
 
   :root {
-    @include carbon-expressive-tokens-custom-properties(
-      $size-tokens: (),
-      $type-tokens: ()
-    );
+    @include use-carbon-expressive-tokens($size-tokens: (), $type-tokens: ());
   }
 }

--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -13,7 +13,7 @@
 
 :host(#{$dds-prefix}-btn) {
   // Enables expressive version of type/size/component tokens in this component
-  @include carbon-expressive-tokens-custom-properties();
+  @include use-carbon-expressive-tokens();
 
   @extend :host(#{$prefix}-btn);
 

--- a/packages/web-components/src/components/link-with-icon/link-with-icon.scss
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.scss
@@ -12,7 +12,7 @@
 
 :host(#{$dds-prefix}-link-with-icon) {
   // Enables expressive version of type/size/component tokens in this component
-  @include carbon-expressive-tokens-custom-properties();
+  @include use-carbon-expressive-tokens();
 
   // Re-define the ruleset so this wins over `.bx--link:visited`, etc.
   .#{$prefix}--link--disabled {


### PR DESCRIPTION
### Changelog

**Changed**

- Rename `@include carbon-productive-tokens-custom-properties` to `@include use-carbon-productive-tokens`.
- Rename `@include carbon-expressive-tokens-custom-properties` to `@include use-carbon-expressive-tokens`.