### PR TITLE
chore(footer): add expressive theme

### DIFF
--- a/packages/styles/scss/components/footer/_components.scss
+++ b/packages/styles/scss/components/footer/_components.scss
@@ -1,0 +1,30 @@
+/**
+ * Copyright IBM Corp. 2016, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@import '../../globals/imports';
+@import '../locale-modal/locale-modal';
+
+// /// Include footer components with g90 theme
+// /// @access private
+// /// @group footer
+
+$TEMP--breakpoint-down--md: map-get(
+    map-get($carbon--grid-breakpoints, 'md'),
+    'width'
+  ) - carbon--rem(1px);
+$TEMP--breakpoint-down--lg: map-get(
+    map-get($carbon--grid-breakpoints, 'lg'),
+    'width'
+  ) - carbon--rem(1px);
+
+@import 'language-selector';
+@import 'locale-button';
+@import 'footer';
+@import 'footer-logo';
+@import 'footer-nav';
+@import 'footer-nav-group';
+@import 'legal-nav';

--- a/packages/styles/scss/components/footer/index.scss
+++ b/packages/styles/scss/components/footer/index.scss
@@ -1,30 +1,12 @@
 /**
- * Copyright IBM Corp. 2016, 2020
+ * Copyright IBM Corp. 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-@import '../../globals/imports';
-@import '../locale-modal/locale-modal';
-
-// /// Include footer components with g90 theme
-// /// @access private
-// /// @group footer
-
-$TEMP--breakpoint-down--md: map-get(
-    map-get($carbon--grid-breakpoints, 'md'),
-    'width'
-  ) - carbon--rem(1px);
-$TEMP--breakpoint-down--lg: map-get(
-    map-get($carbon--grid-breakpoints, 'lg'),
-    'width'
-  ) - carbon--rem(1px);
-
-@import 'language-selector';
-@import 'locale-button';
-@import 'footer';
-@import 'footer-logo';
-@import 'footer-nav';
-@import 'footer-nav-group';
-@import 'legal-nav';
+// Our users seems to be using our footer as an entry point, like
+// "If I import footer I'll get everything I need".
+// To support such use case, we import the entire expressive theme here
+@import '../../themes/expressive/index';
+@import './components';


### PR DESCRIPTION
### Related Ticket(s)

Refs #3126.

### Description

According to @jeffchew, our users are using our footer as an "entry point" where they tend to expect including footer will provide everything they need from our library.

To support such use case, this change adds the whole expressive theme to `packages/styles/scss/components/footer/index.scss`.

### Changelog

**Changed**

- `packages/styles/scss/components/footer/index.scss` to include the whole expressive theme code.
