### PR TITLE
docs(locale-modal): add CodeSandbox example

### DIFF
--- a/packages/web-components/examples/codesandbox/components/locale-modal/.babelrc
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": false,
+        "targets": [
+          "last 1 version",
+          "Firefox ESR",
+          "not opera > 0",
+          "not op_mini > 0",
+          "not op_mob > 0",
+          "not android > 0",
+          "not edge > 0",
+          "not ie > 0",
+          "not ie_mob > 0"
+        ]
+      }
+    ]
+  ],
+  "plugins": [["@babel/plugin-transform-runtime", { "version": "7.3.0" }]]
+}

--- a/packages/web-components/examples/codesandbox/components/locale-modal/.gitignore
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/web-components/examples/codesandbox/components/locale-modal/index.html
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/index.html
@@ -1,0 +1,175 @@
+<!--
+@license
+
+Copyright IBM Corp. 2020
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html>
+  <head>
+    <title>@carbon/ibmdotcom-web-components example</title>
+    <meta charset="UTF-8" />
+    <link rel="alternate" hreflang="en-us" href="https://www.ibm.com/us-en/">
+    <link rel="alternate" hreflang="x-default" href="https://www.ibm.com">
+    <link rel="alternate" hreflang="en-af" href="https://www.ibm.com/af-en">
+    <link rel="alternate" hreflang="fr-dz" href="https://www.ibm.com/dz-fr">
+    <link rel="alternate" hreflang="pt-ao" href="https://www.ibm.com/ao-pt">
+    <link rel="alternate" hreflang="en-ai" href="https://www.ibm.com/ai-en">
+    <link rel="alternate" hreflang="en-ag" href="https://www.ibm.com/ag-en">
+    <link rel="alternate" hreflang="es-ar" href="https://www.ibm.com/ar-es">
+    <link rel="alternate" hreflang="en-aw" href="https://www.ibm.com/aw-en">
+    <link rel="alternate" hreflang="en-au" href="https://www.ibm.com/au-en">
+    <link rel="alternate" hreflang="de-at" href="https://www.ibm.com/at-de">
+    <link rel="alternate" hreflang="en-bs" href="https://www.ibm.com/bs-en">
+    <link rel="alternate" hreflang="en-bh" href="https://www.ibm.com/bh-en">
+    <link rel="alternate" hreflang="en-bd" href="https://www.ibm.com/bd-en">
+    <link rel="alternate" hreflang="en-bb" href="https://www.ibm.com/bb-en">
+    <link rel="alternate" hreflang="en-be" href="https://www.ibm.com/be-en">
+    <link rel="alternate" hreflang="en-bm" href="https://www.ibm.com/bm-en">
+    <link rel="alternate" hreflang="es-bo" href="https://www.ibm.com/bo-es">
+    <link rel="alternate" hreflang="en-bw" href="https://www.ibm.com/bw-en">
+    <link rel="alternate" hreflang="pt-br" href="https://www.ibm.com/br-pt">
+    <link rel="alternate" hreflang="en-vg" href="https://www.ibm.com/vg-en">
+    <link rel="alternate" hreflang="en-bn" href="https://www.ibm.com/bn-en">
+    <link rel="alternate" hreflang="en-bg" href="https://www.ibm.com/bg-en">
+    <link rel="alternate" hreflang="fr-bf" href="https://www.ibm.com/bf-fr">
+    <link rel="alternate" hreflang="en-kh" href="https://www.ibm.com/kh-en">
+    <link rel="alternate" hreflang="fr-cm" href="https://www.ibm.com/cm-fr">
+    <link rel="alternate" hreflang="en-ca" href="https://www.ibm.com/ca-en">
+    <link rel="alternate" hreflang="fr-ca" href="https://www.ibm.com/ca-fr">
+    <link rel="alternate" hreflang="en-ky" href="https://www.ibm.com/ky-en">
+    <link rel="alternate" hreflang="fr-td" href="https://www.ibm.com/td-fr">
+    <link rel="alternate" hreflang="es-cl" href="https://www.ibm.com/cl-es">
+    <link rel="alternate" hreflang="zh-cn" href="https://www.ibm.com/cn-zh">
+    <link rel="alternate" hreflang="es-co" href="https://www.ibm.com/co-es">
+    <link rel="alternate" hreflang="fr-cd" href="https://www.ibm.com/cd-fr">
+    <link rel="alternate" hreflang="fr-cg" href="https://www.ibm.com/cg-fr">
+    <link rel="alternate" hreflang="es-cr" href="https://www.ibm.com/cr-es">
+    <link rel="alternate" hreflang="en-hr" href="https://www.ibm.com/hr-en">
+    <link rel="alternate" hreflang="en-cw" href="https://www.ibm.com/cw-en">
+    <link rel="alternate" hreflang="en-cy" href="https://www.ibm.com/cy-en">
+    <link rel="alternate" hreflang="en-cz" href="https://www.ibm.com/cz-en">
+    <link rel="alternate" hreflang="en-dm" href="https://www.ibm.com/dm-en">
+    <link rel="alternate" hreflang="en-dk" href="https://www.ibm.com/dk-en">
+    <link rel="alternate" hreflang="es-ec" href="https://www.ibm.com/ec-es">
+    <link rel="alternate" hreflang="en-eg" href="https://www.ibm.com/eg-en">
+    <link rel="alternate" hreflang="en-ee" href="https://www.ibm.com/ee-en">
+    <link rel="alternate" hreflang="en-et" href="https://www.ibm.com/et-en">
+    <link rel="alternate" hreflang="en-fi" href="https://www.ibm.com/fi-en">
+    <link rel="alternate" hreflang="fr-fr" href="https://www.ibm.com/fr-fr">
+    <link rel="alternate" hreflang="fr-ga" href="https://www.ibm.com/ga-fr">
+    <link rel="alternate" hreflang="de-de" href="https://www.ibm.com/de-de">
+    <link rel="alternate" hreflang="en-gh" href="https://www.ibm.com/gh-en">
+    <link rel="alternate" hreflang="en-gr" href="https://www.ibm.com/gr-en">
+    <link rel="alternate" hreflang="en-gd" href="https://www.ibm.com/gd-en">
+    <link rel="alternate" hreflang="en-gy" href="https://www.ibm.com/gy-en">
+    <link rel="alternate" hreflang="en-hk" href="https://www.ibm.com/hk-en">
+    <link rel="alternate" hreflang="en-hu" href="https://www.ibm.com/hu-en">
+    <link rel="alternate" hreflang="en-in" href="https://www.ibm.com/in-en">
+    <link rel="alternate" hreflang="en-id" href="https://www.ibm.com/id-en">
+    <link rel="alternate" hreflang="en-iq" href="https://www.ibm.com/iq-en">
+    <link rel="alternate" hreflang="en-ie" href="https://www.ibm.com/ie-en">
+    <link rel="alternate" hreflang="en-il" href="https://www.ibm.com/il-en">
+    <link rel="alternate" hreflang="it-it" href="https://www.ibm.com/it-it">
+    <link rel="alternate" hreflang="fr-ci" href="https://www.ibm.com/ci-fr">
+    <link rel="alternate" hreflang="en-jm" href="https://www.ibm.com/jm-en">
+    <link rel="alternate" hreflang="ja-jp" href="https://www.ibm.com/jp-ja">
+    <link rel="alternate" hreflang="en-jo" href="https://www.ibm.com/jo-en">
+    <link rel="alternate" hreflang="en-kz" href="https://www.ibm.com/kz-en">
+    <link rel="alternate" hreflang="en-ke" href="https://www.ibm.com/ke-en">
+    <link rel="alternate" hreflang="ko-kr" href="https://www.ibm.com/kr-ko">
+    <link rel="alternate" hreflang="en-kw" href="https://www.ibm.com/kw-en">
+    <link rel="alternate" hreflang="en-lv" href="https://www.ibm.com/lv-en">
+    <link rel="alternate" hreflang="en-lb" href="https://www.ibm.com/lb-en">
+    <link rel="alternate" hreflang="en-ly" href="https://www.ibm.com/ly-en">
+    <link rel="alternate" hreflang="en-lt" href="https://www.ibm.com/lt-en">
+    <link rel="alternate" hreflang="en-mw" href="https://www.ibm.com/mw-en">
+    <link rel="alternate" hreflang="en-my" href="https://www.ibm.com/my-en">
+    <link rel="alternate" hreflang="fr-mu" href="https://www.ibm.com/mu-fr">
+    <link rel="alternate" hreflang="es-mx" href="https://www.ibm.com/mx-es">
+    <link rel="alternate" hreflang="en-ms" href="https://www.ibm.com/ms-en">
+    <link rel="alternate" hreflang="fr-ma" href="https://www.ibm.com/ma-fr">
+    <link rel="alternate" hreflang="pt-mz" href="https://www.ibm.com/mz-pt">
+    <link rel="alternate" hreflang="en-na" href="https://www.ibm.com/na-en">
+    <link rel="alternate" hreflang="en-np" href="https://www.ibm.com/np-en">
+    <link rel="alternate" hreflang="en-nl" href="https://www.ibm.com/nl-en">
+    <link rel="alternate" hreflang="en-nz" href="https://www.ibm.com/nz-en">
+    <link rel="alternate" hreflang="fr-ne" href="https://www.ibm.com/ne-fr">
+    <link rel="alternate" hreflang="en-ng" href="https://www.ibm.com/ng-en">
+    <link rel="alternate" hreflang="en-no" href="https://www.ibm.com/no-en">
+    <link rel="alternate" hreflang="en-om" href="https://www.ibm.com/om-en">
+    <link rel="alternate" hreflang="en-pk" href="https://www.ibm.com/pk-en">
+    <link rel="alternate" hreflang="es-py" href="https://www.ibm.com/py-es">
+    <link rel="alternate" hreflang="es-pe" href="https://www.ibm.com/pe-es">
+    <link rel="alternate" hreflang="en-ph" href="https://www.ibm.com/ph-en">
+    <link rel="alternate" hreflang="pl-pl" href="https://www.ibm.com/pl-pl">
+    <link rel="alternate" hreflang="en-pt" href="https://www.ibm.com/pt-en">
+    <link rel="alternate" hreflang="en-qa" href="https://www.ibm.com/qa-en">
+    <link rel="alternate" hreflang="en-ro" href="https://www.ibm.com/ro-en">
+    <link rel="alternate" hreflang="ru-ru" href="https://www.ibm.com/ru-ru">
+    <link rel="alternate" hreflang="en-kn" href="https://www.ibm.com/kn-en">
+    <link rel="alternate" hreflang="en-lc" href="https://www.ibm.com/lc-en">
+    <link rel="alternate" hreflang="en-vc" href="https://www.ibm.com/vc-en">
+    <link rel="alternate" hreflang="en-sa" href="https://www.ibm.com/sa-en">
+    <link rel="alternate" hreflang="fr-sn" href="https://www.ibm.com/sn-fr">
+    <link rel="alternate" hreflang="en-rs" href="https://www.ibm.com/rs-en">
+    <link rel="alternate" hreflang="fr-sc" href="https://www.ibm.com/sc-fr">
+    <link rel="alternate" hreflang="en-sl" href="https://www.ibm.com/sl-en">
+    <link rel="alternate" hreflang="en-sg" href="https://www.ibm.com/sg-en">
+    <link rel="alternate" hreflang="en-sk" href="https://www.ibm.com/sk-en">
+    <link rel="alternate" hreflang="en-si" href="https://www.ibm.com/si-en">
+    <link rel="alternate" hreflang="en-za" href="https://www.ibm.com/za-en">
+    <link rel="alternate" hreflang="es-es" href="https://www.ibm.com/es-es">
+    <link rel="alternate" hreflang="en-lk" href="https://www.ibm.com/lk-en">
+    <link rel="alternate" hreflang="en-sr" href="https://www.ibm.com/sr-en">
+    <link rel="alternate" hreflang="en-se" href="https://www.ibm.com/se-en">
+    <link rel="alternate" hreflang="fr-ch" href="https://www.ibm.com/ch-fr">
+    <link rel="alternate" hreflang="de-ch" href="https://www.ibm.com/ch-de">
+    <link rel="alternate" hreflang="zh-tw" href="https://www.ibm.com/tw-zh">
+    <link rel="alternate" hreflang="en-tz" href="https://www.ibm.com/tz-en">
+    <link rel="alternate" hreflang="en-th" href="https://www.ibm.com/th-en">
+    <link rel="alternate" hreflang="en-tt" href="https://www.ibm.com/tt-en">
+    <link rel="alternate" hreflang="fr-tn" href="https://www.ibm.com/tn-fr">
+    <link rel="alternate" hreflang="tr-tr" href="https://www.ibm.com/tr-tr">
+    <link rel="alternate" hreflang="en-ye" href="https://www.ibm.com/ye-en">
+    <link rel="alternate" hreflang="en-tc" href="https://www.ibm.com/tc-en">
+    <link rel="alternate" hreflang="en-ua" href="https://www.ibm.com/ua-en">
+    <link rel="alternate" hreflang="en-ug" href="https://www.ibm.com/ug-en">
+    <link rel="alternate" hreflang="en-ae" href="https://www.ibm.com/ae-en">
+    <link rel="alternate" hreflang="en-gb" href="https://www.ibm.com/uk-en">
+    <link rel="alternate" hreflang="es-uy" href="https://www.ibm.com/uy-es">
+    <link rel="alternate" hreflang="en-uz" href="https://www.ibm.com/uz-en">
+    <link rel="alternate" hreflang="es-ve" href="https://www.ibm.com/ve-es">
+    <link rel="alternate" hreflang="en-vn" href="https://www.ibm.com/vn-en">
+    <link rel="alternate" hreflang="en-zm" href="https://www.ibm.com/zm-en">
+    <link rel="alternate" hreflang="en-zw" href="https://www.ibm.com/zw-en">
+    <style type="text/css">
+      body {
+        font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+      }
+
+      app-locale-modal-container {
+        display: contents;
+      }
+
+      #app {
+        width: 300px;
+      }
+    </style>
+    <script src="src/index.js"></script>
+  </head>
+  <body>
+    <h1>Hello World! 👋</h1>
+    <div id="app">
+      <dds-btn id="open-modal-btn">Open modal</dds-btn>
+    </div>
+    <app-locale-modal-container id="modal"></app-locale-modal-container>
+  </body>
+  <script type="text/javascript">
+    document.getElementById('open-modal-btn').addEventListener('click', () => {
+      document.getElementById('modal').open = true;
+    });
+  </script>
+</html>

--- a/packages/web-components/examples/codesandbox/components/locale-modal/package.json
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ibmdotcom-web-components-link-with-icon-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for getting started with the Web Components from the IBM.com library.",
+  "license": "Apache-2",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel index.html --port=9000 --no-hmr",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {
+    "@carbon/ibmdotcom-web-components": "canary",
+    "lit-element": "^2.2.0",
+    "lit-html": "^1.1.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.8.0",
+    "parcel-bundler": "^1.10.0"
+  }
+}

--- a/packages/web-components/examples/codesandbox/components/locale-modal/sandbox.config.json
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/packages/web-components/examples/codesandbox/components/locale-modal/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/locale-modal/src/index.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ConnectMixin from '@carbon/ibmdotcom-web-components/es/globals/mixins/connect';
+import '@carbon/ibmdotcom-web-components/es/components/button/button';
+import DDSLocaleModalComposite from '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-composite';
+import {
+  reducers,
+  store,
+  mapStateToProps,
+  mapDispatchToProps,
+} from '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container';
+
+store.replaceReducer(reducers);
+
+// Wires `<dds-locale-modal-composite>` to `@carbon/ibmdotcom-servies` and creates `<app-locale-modal-container>`
+customElements.define(
+  'app-locale-modal-container',
+  class extends ConnectMixin(store, mapStateToProps, mapDispatchToProps)(DDSLocaleModalComposite) {}
+);

--- a/packages/web-components/src/components/locale-modal/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/locale-modal/__stories__/README.stories.mdx
@@ -22,10 +22,20 @@ import corsproxy from '../../../../../../docs/cors-proxy.md';
 ```javascript
 import ConnectMixin from '@carbon/ibmdotcom-web-components/es/globals/mixins/connect';
 import DDSLocaleModalComposite from '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-composite';
-import { store, mapStateToProps, mapDispatchToProps } from '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container';
+import {
+  reducers,
+  store,
+  mapStateToProps,
+  mapDispatchToProps,
+} from '@carbon/ibmdotcom-web-components/es/components/locale-modal/locale-modal-container';
+
+store.replaceReducer(reducers);
 
 // Wires `<dds-locale-modal-composite>` to `@carbon/ibmdotcom-servies` and creates `<app-locale-modal-container>`
-customElements.define('app-locale-modal-container', class extends ConnectMixin(store, mapStateToProps, mapDispatchToProps)(DDSLocaleModalComposite) {})
+customElements.define(
+  'app-locale-modal-container',
+  class extends ConnectMixin(store, mapStateToProps, mapDispatchToProps)(DDSLocaleModalComposite) {}
+);
 ```
 
 ##### HTML

--- a/packages/web-components/src/components/locale-modal/__stories__/locale-modal.stories.ts
+++ b/packages/web-components/src/components/locale-modal/__stories__/locale-modal.stories.ts
@@ -33,7 +33,11 @@ export default {
     ...readme.parameters,
     knobs: {
       'dds-locale-modal-container': ({ groupId }) => ({
-        langDisplay: textNullable('Display language (lang-display)', 'United States — English', groupId),
+        langDisplay: textNullable(
+          'Display language (lang-display)',
+          process.env.CORS_PROXY && !inPercy() ? '' : 'United States — English',
+          groupId
+        ),
       }),
     },
     props: {

--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
@@ -100,17 +100,22 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
   /**
    * The placeholder for `setLanguage()` Redux action that may be mixed in.
    */
-  private _setLanguage!: (string) => void;
+  private _setLanguage?: (string) => void;
 
   /**
    * The placeholder for `setLangDisplay()` Redux action that may be mixed in.
    */
-  private _setLangDisplay!: (string) => void;
+  private _setLangDisplay?: (string) => void;
+
+  /**
+   * The placeholder for `loadLangDisplay()` Redux action that may be mixed in.
+   */
+  private _loadLangDisplay?: () => Promise<string>;
 
   /**
    * The placeholder for `loadLocaleList()` Redux action that may be mixed in.
    */
-  private _loadLocaleList!: () => Promise<LocaleList>;
+  private _loadLocaleList?: () => Promise<LocaleList>;
 
   /**
    * @param countries A country list.
@@ -159,6 +164,7 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
     if (langDisplay) {
       this._setLangDisplay?.(langDisplay);
     }
+    this._loadLangDisplay?.();
     this._loadLocaleList?.();
   }
 

--- a/packages/web-components/src/components/locale-modal/locale-modal-container.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-container.ts
@@ -49,6 +49,11 @@ export interface LocaleModalContainerState {
  */
 interface LocaleModalContainerStateProps {
   /**
+   * The display language.
+   */
+  langDisplay?: string;
+
+  /**
    * The locale list.
    */
   localeList?: LocaleList;
@@ -60,8 +65,9 @@ interface LocaleModalContainerStateProps {
  */
 export function mapStateToProps(state: LocaleModalContainerState): LocaleModalContainerStateProps {
   const { localeAPI } = state;
-  const { language, localeLists } = localeAPI ?? {};
+  const { langDisplay, language, localeLists } = localeAPI ?? {};
   return {
+    langDisplay,
     localeList: !language ? undefined : localeLists?.[language],
   };
 }


### PR DESCRIPTION
### Related Ticket(s)

Refs #2883.

### Changelog

**New**

- CodeSandbox example for locale modal.

**Changed**

- Fix in `<dds-locale-modal-composite>`, to add missing capability to load `langDisplay` from `@carbon/ibmdotcom-services`.