### PR TITLE
chore(beta-release): fixing beta release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "jest-junit": "^6.4.0",
     "lerna": "^3.20.2",
     "lint-staged": "^8.1.5",
+    "node-fetch": "^2.6.0",
     "prettier": "^1.17.0",
     "react": "16.9.0",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The script was not generating the beta release notes
for some reason. Turns out it was a CI configuration, but
in the process ended up switching to `node-fetch` instead
and cleaning up the script a bit.

### Changelog

**Changed**

- `beta-release.js` switched to `node-fetch`