### PR TITLE
chore(services): better error handling

### DIFF
--- a/packages/react/src/components/Footer/Footer.js
+++ b/packages/react/src/components/Footer/Footer.js
@@ -49,10 +49,14 @@ const Footer = ({
     let stale = false;
     if (!navigation) {
       (async () => {
-        const response = await TranslationAPI.getTranslation();
-        if (!stale) {
-          setFooterMenuData(response.footerMenu);
-          setFooterLegalData(response.footerThin);
+        try {
+          const response = await TranslationAPI.getTranslation();
+          if (!stale) {
+            setFooterMenuData(response.footerMenu);
+            setFooterLegalData(response.footerThin);
+          }
+        } catch (error) {
+          console.error('Error populating footer data:', error);
         }
       })();
     }

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -92,10 +92,14 @@ const Masthead = ({
   useEffect(() => {
     let unmounted = false;
     (async () => {
-      const pageData = await TranslationAPI.getTranslation();
-      if (!unmounted) {
-        setMastheadData(pageData.mastheadNav.links);
-        setProfileData(pageData.profileMenu);
+      try {
+        const pageData = await TranslationAPI.getTranslation();
+        if (!unmounted) {
+          setMastheadData(pageData.mastheadNav.links);
+          setProfileData(pageData.profileMenu);
+        }
+      } catch (error) {
+        console.error('Error populating masthead data:', error);
       }
     })();
     return () => {

--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -161,9 +161,9 @@ class TranslationAPI {
           _translationFetch[`${country}-${lang}`] = false;
           resolve(data);
         })
-        .catch(() => {
+        .catch(error => {
           _translationFetch[`${country}-${lang}`] = false;
-          reject();
+          reject(error);
         });
     }
   }

--- a/packages/vanilla/babel.config.js
+++ b/packages/vanilla/babel.config.js
@@ -15,5 +15,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-export-namespace-from',
     '@babel/plugin-proposal-export-default-from',
+    '@babel/plugin-proposal-nullish-coalescing-operator',
+    '@babel/plugin-proposal-optional-chaining',
   ],
 };

--- a/packages/vanilla/src/components/footer/footer.js
+++ b/packages/vanilla/src/components/footer/footer.js
@@ -39,12 +39,17 @@ class Footer {
    */
   static async getFooterWithData(type) {
     const lang = await LocaleAPI.getLang();
-    const response = await TranslationAPI.getTranslation(lang);
+    let response;
+    try {
+      response = await TranslationAPI.getTranslation(lang);
+    } catch (error) {
+      console.error('Error populating footer data:', error);
+    }
 
     return footerTemplate({
       type,
-      footerMenu: response.footerMenu,
-      footerThin: response.footerThin,
+      footerMenu: response?.footerMenu,
+      footerThin: response?.footerThin,
     });
   }
 }

--- a/packages/vanilla/src/components/footer/footer.template.js
+++ b/packages/vanilla/src/components/footer/footer.template.js
@@ -80,6 +80,7 @@ function _renderLegalItems(footerThin) {
       )
       .join('');
   }
+  return '';
 }
 
 /**
@@ -91,7 +92,7 @@ function _renderLegalItems(footerThin) {
  * @private
  */
 function _optionalFooterNav(type, footerMenu) {
-  if (type !== 'short') {
+  if (footerMenu && type !== 'short') {
     return footerNav(footerMenu);
   }
   return '';

--- a/packages/vanilla/src/components/masthead/masthead.js
+++ b/packages/vanilla/src/components/masthead/masthead.js
@@ -260,7 +260,12 @@ class Masthead {
     }
 
     const lang = await LocaleAPI.getLang();
-    const response = await TranslationAPI.getTranslation(lang);
+    let response;
+    try {
+      response = await TranslationAPI.getTranslation(lang);
+    } catch (error) {
+      console.error('Error populating masthead data:', error);
+    }
 
     if (searchProps.hasSearch) {
       searchProps = Object.assign(searchProps, { locale: lang });
@@ -273,7 +278,7 @@ class Masthead {
         navigation:
           typeof navigation == 'object'
             ? navigation
-            : response.mastheadNav.links,
+            : response?.mastheadNav?.links,
       }),
       ...(platform && {
         platform: platform,
@@ -282,8 +287,8 @@ class Masthead {
         profileData: {
           isAuthenticated: isAuthenticated,
           menu: isAuthenticated
-            ? response.profileMenu.signedin
-            : response.profileMenu.signedout,
+            ? response?.profileMenu?.signedin
+            : response?.profileMenu?.signedout,
         },
       }),
       ...(searchProps.hasSearch && {

--- a/packages/web-components/src/components/masthead/masthead-container.ts
+++ b/packages/web-components/src/components/masthead/masthead-container.ts
@@ -288,7 +288,7 @@ _  */
     const { _searchQueryString: searchQueryString, _searchResults: searchResults } = this;
     const cachedSearchResults = searchResults.get(searchQueryString);
     if (!cachedSearchResults) {
-      this._fetchResults();
+      this._fetchResults().catch(() => {}); // The error is logged in the Redux store
     }
     // While we fetch the search results, we see if there is a cached search results for partial search query string.
     // If so, updates the UI with the cached search results.
@@ -480,7 +480,7 @@ _  */
       this._setLanguage(language);
     }
     if (!navLinks) {
-      this._loadTranslation();
+      this._loadTranslation().catch(() => {}); // The error is logged in the Redux store
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

Refs #3382.

### Description

This change ensures the following things when there is an error in services layer:

* The error is caught and logged in browser console
* Vanilla template is still (partially) rendered

### Changelog

**Changed**

- `TrasnlateAPI.getTranslation()` to avoid rejecting with `undefined`. Vanilla/React code use it for logging the error.
- Web Components' service interface code so uncaught exception won't be logged. (The error itself is logged in Redux layer)
- Vanilla template so missing data of masthead nav links, masthead profile links and footer nav links won't prevent entire footer from rendered.