### PR TITLE
fix(MastheadSearch): fix UC browser

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -117,10 +117,19 @@ const MastheadSearch = ({ placeHolderText, renderValue, searchOpenOnload }) => {
   const [state, dispatch] = useReducer(_reducer, _initialState);
 
   useEffect(() => {
-    const abortController = new AbortController();
+    const abortController =
+      typeof AbortController !== 'undefined'
+        ? new AbortController()
+        : {
+            signal: {},
+            abort() {
+              this.signal.aborted = true;
+            },
+          };
+    abortController.abort();
     (async () => {
       const response = await LocaleAPI.getLang();
-      if (!abortController.signal && response) {
+      if (!abortController.signal.aborted && response) {
         dispatch({ type: 'setLc', payload: { lc: response.lc } });
         dispatch({ type: 'setCc', payload: { cc: response.cc } });
       }


### PR DESCRIPTION
### Related Ticket(s)

Refs #2896.

### Description

This change implements a mini-polyfill of `AbortController` that's not implemented in UC browser, our tier-2 supported browser.

### Changelog

**Changed**

- `<MastheadSearch>` to mini-polyfill `AbortController` for UC browser.