### PR TITLE
fix(contentblockcards): fixes video modal background transparency

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -413,7 +413,6 @@ exports[`Storyshots Components|CTA Button 1`] = `
                               aria-hidden="true"
                               aria-label="right arrow icon"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -424,7 +423,6 @@ exports[`Storyshots Components|CTA Button 1`] = `
                                 aria-hidden="true"
                                 aria-label="right arrow icon"
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -494,7 +492,6 @@ exports[`Storyshots Components|CTA Button 1`] = `
                               aria-hidden="true"
                               aria-label="right arrow icon"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -505,7 +502,6 @@ exports[`Storyshots Components|CTA Button 1`] = `
                                 aria-hidden="true"
                                 aria-label="right arrow icon"
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -716,7 +712,6 @@ exports[`Storyshots Components|CTA Card 1`] = `
                             >
                               <Icon
                                 className="bx--card__cta"
-                                fill="currentColor"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
                                 src={
@@ -732,7 +727,6 @@ exports[`Storyshots Components|CTA Card 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   className="bx--card__cta"
-                                  fill="currentColor"
                                   focusable="false"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
@@ -1045,7 +1039,6 @@ exports[`Storyshots Components|CTA Feature Card 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -1061,7 +1054,6 @@ exports[`Storyshots Components|CTA Feature Card 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -1203,7 +1195,6 @@ exports[`Storyshots Components|CTA Text 1`] = `
                         </span>
                         <ForwardRef(ArrowRight20)>
                           <Icon
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 20 20"
@@ -1212,7 +1203,6 @@ exports[`Storyshots Components|CTA Text 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -1878,7 +1868,6 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                                     </span>
                                     <ForwardRef(ArrowRight20)>
                                       <Icon
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 20 20"
@@ -1887,7 +1876,6 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                                       >
                                         <svg
                                           aria-hidden={true}
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -1997,7 +1985,6 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                                     </span>
                                     <ForwardRef(ArrowRight20)>
                                       <Icon
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 20 20"
@@ -2006,7 +1993,6 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                                       >
                                         <svg
                                           aria-hidden={true}
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -2195,7 +2181,6 @@ exports[`Storyshots Components|CalloutQuote Default 1`] = `
                                     </span>
                                     <ForwardRef(ArrowRight20)>
                                       <Icon
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 20 20"
@@ -2204,7 +2189,6 @@ exports[`Storyshots Components|CalloutQuote Default 1`] = `
                                       >
                                         <svg
                                           aria-hidden={true}
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -2601,7 +2585,6 @@ exports[`Storyshots Components|Card Default 1`] = `
                       >
                         <Icon
                           className="bx--card__cta"
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           src={
@@ -2617,7 +2600,6 @@ exports[`Storyshots Components|Card Default 1`] = `
                           <svg
                             aria-hidden={true}
                             className="bx--card__cta"
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -2879,7 +2861,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -2895,7 +2876,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -3082,7 +3062,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -3098,7 +3077,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -3285,7 +3263,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -3301,7 +3278,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -3488,7 +3464,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -3504,7 +3479,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -3691,7 +3665,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -3707,7 +3680,6 @@ exports[`Storyshots Components|CardGroup Default 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -3983,7 +3955,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -3999,7 +3970,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -4186,7 +4156,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -4202,7 +4171,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -4389,7 +4357,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -4405,7 +4372,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -4592,7 +4558,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -4608,7 +4573,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -4795,7 +4759,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -4811,7 +4774,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -4900,7 +4862,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                           >
                             <Icon
                               className="bx--card__cta"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               src={
@@ -4916,7 +4877,6 @@ exports[`Storyshots Components|CardGroup With CTA 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--card__cta"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -5239,7 +5199,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -5255,7 +5214,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -5481,7 +5439,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -5497,7 +5454,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -5723,7 +5679,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -5739,7 +5694,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -5965,7 +5919,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -5981,7 +5934,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -6207,7 +6159,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -6223,7 +6174,6 @@ exports[`Storyshots Components|CardGroup With Images 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -6558,7 +6508,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -6574,7 +6523,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -6800,7 +6748,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -6816,7 +6763,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -7042,7 +6988,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -7058,7 +7003,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -7284,7 +7228,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -7300,7 +7243,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -7526,7 +7468,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                   >
                                     <Icon
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       src={
@@ -7542,7 +7483,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                                       <svg
                                         aria-hidden={true}
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -7631,7 +7571,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                           >
                             <Icon
                               className="bx--card__cta"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               src={
@@ -7647,7 +7586,6 @@ exports[`Storyshots Components|CardGroup With Images And CTA 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--card__cta"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -7789,7 +7727,6 @@ exports[`Storyshots Components|CardLink Default 1`] = `
                       >
                         <Icon
                           className="bx--card__cta"
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           src={
@@ -7805,7 +7742,6 @@ exports[`Storyshots Components|CardLink Default 1`] = `
                           <svg
                             aria-hidden={true}
                             className="bx--card__cta"
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -8207,7 +8143,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -8223,7 +8158,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -8449,7 +8383,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -8465,7 +8398,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -8691,7 +8623,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -8707,7 +8638,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -8933,7 +8863,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -8949,7 +8878,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -9175,7 +9103,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -9191,7 +9118,6 @@ exports[`Storyshots Components|CardSectionImages Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -9535,7 +9461,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -9551,7 +9476,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -9740,7 +9664,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -9756,7 +9679,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -9945,7 +9867,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -9961,7 +9882,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -10150,7 +10070,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -10166,7 +10085,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -10355,7 +10273,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -10371,7 +10288,6 @@ exports[`Storyshots Components|CardSectionSimple Default 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -10731,7 +10647,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -10747,7 +10662,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -10936,7 +10850,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -10952,7 +10865,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -11141,7 +11053,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -11157,7 +11068,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -11346,7 +11256,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -11362,7 +11271,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -11551,7 +11459,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                         >
                                           <Icon
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             src={
@@ -11567,7 +11474,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                             <svg
                                               aria-hidden={true}
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -11656,7 +11562,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                 >
                                   <Icon
                                     className="bx--card__cta"
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     src={
@@ -11672,7 +11577,6 @@ exports[`Storyshots Components|CardSectionSimple With CTA 1`] = `
                                     <svg
                                       aria-hidden={true}
                                       className="bx--card__cta"
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -12040,7 +11944,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -12056,7 +11959,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -12245,7 +12147,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -12261,7 +12162,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -12450,7 +12350,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -12466,7 +12365,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -12655,7 +12553,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -12671,7 +12568,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -12860,7 +12756,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -12876,7 +12771,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -13041,7 +12935,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -13057,7 +12950,6 @@ exports[`Storyshots Components|ContentBlockCards Default 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -13495,7 +13387,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -13511,7 +13402,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -13737,7 +13627,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -13753,7 +13642,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -13979,7 +13867,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -13995,7 +13882,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -14221,7 +14107,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -14237,7 +14122,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -14463,7 +14347,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -14479,7 +14362,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -14644,7 +14526,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -14660,7 +14541,6 @@ exports[`Storyshots Components|ContentBlockCards With Images 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -15071,7 +14951,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -15087,7 +14966,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -15309,7 +15187,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -15325,7 +15202,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -15547,7 +15423,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -15563,7 +15438,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -15785,7 +15659,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -15801,7 +15674,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -16023,7 +15895,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -16039,7 +15910,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -16207,7 +16077,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -16223,7 +16092,6 @@ exports[`Storyshots Components|ContentBlockCards With Videos 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -16912,7 +16780,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                 >
                                                   <Icon
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     src={
@@ -16928,7 +16795,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     <svg
                                                       aria-hidden={true}
                                                       className="bx--card__cta"
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -17372,7 +17238,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                 >
                                                   <Icon
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     src={
@@ -17388,7 +17253,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     <svg
                                                       aria-hidden={true}
                                                       className="bx--card__cta"
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -17632,7 +17496,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           >
                                             <Icon
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               src={
@@ -17648,7 +17511,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               <svg
                                                 aria-hidden={true}
                                                 className="bx--card__cta"
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -18437,7 +18299,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         >
                                                           <Icon
                                                             className="bx--card__cta"
-                                                            fill="currentColor"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
                                                             src={
@@ -18453,7 +18314,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                             <svg
                                                               aria-hidden={true}
                                                               className="bx--card__cta"
-                                                              fill="currentColor"
                                                               focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
@@ -18897,7 +18757,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         >
                                                           <Icon
                                                             className="bx--card__cta"
-                                                            fill="currentColor"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
                                                             src={
@@ -18913,7 +18772,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                             <svg
                                                               aria-hidden={true}
                                                               className="bx--card__cta"
-                                                              fill="currentColor"
                                                               focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
@@ -19157,7 +19015,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   >
                                                     <Icon
                                                       className="bx--card__cta"
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       src={
@@ -19173,7 +19030,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       <svg
                                                         aria-hidden={true}
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -19374,7 +19230,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -19390,7 +19245,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -19550,7 +19404,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -19566,7 +19419,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -19989,7 +19841,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -20005,7 +19856,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -20105,7 +19955,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -20121,7 +19970,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -20221,7 +20069,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -20237,7 +20084,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -20337,7 +20183,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -20353,7 +20198,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -20507,7 +20351,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           data-autoid="dds--pictogram-item__pictogram"
                                           height={48}
                                           preserveAspectRatio="xMidYMid meet"
-                                          stroke="currentColor"
                                           viewBox="0 0 48 48"
                                           width={48}
                                           xmlns="http://www.w3.org/2000/svg"
@@ -20520,7 +20363,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             height={48}
                                             preserveAspectRatio="xMidYMid meet"
                                             role="img"
-                                            stroke="currentColor"
                                             viewBox="0 0 48 48"
                                             width={48}
                                             xmlns="http://www.w3.org/2000/svg"
@@ -20528,6 +20370,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             <path
                                               d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
                                               fill="none"
+                                              stroke="#000"
                                               strokeLinejoin="round"
                                               strokeMiterlimit="10"
                                               strokeWidth=".72"
@@ -20627,7 +20470,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         </span>
                                                         <ForwardRef(ArrowRight20)>
                                                           <Icon
-                                                            fill="currentColor"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
                                                             viewBox="0 0 20 20"
@@ -20636,7 +20478,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           >
                                                             <svg
                                                               aria-hidden={true}
-                                                              fill="currentColor"
                                                               focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
@@ -20706,7 +20547,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           data-autoid="dds--pictogram-item__pictogram"
                                           height={48}
                                           preserveAspectRatio="xMidYMid meet"
-                                          stroke="currentColor"
                                           viewBox="0 0 48 48"
                                           width={48}
                                           xmlns="http://www.w3.org/2000/svg"
@@ -20719,7 +20559,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             height={48}
                                             preserveAspectRatio="xMidYMid meet"
                                             role="img"
-                                            stroke="currentColor"
                                             viewBox="0 0 48 48"
                                             width={48}
                                             xmlns="http://www.w3.org/2000/svg"
@@ -20727,6 +20566,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             <path
                                               d="M27,29H11c-1.1,0-2-0.9-2-2V11c0-1.1,0.9-2,2-2h16c1.1,0,2,0.9,2,2v16C29,28.1,28.1,29,27,29z M19,29v8c0,1.1,0.9,2,2,2h16 c1.1,0,2-0.9,2-2V21c0-1.1-0.9-2-2-2h-8 M23,11l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C22.552,12,23,11.552,23,11z M18,17l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C17.552,18,18,17.552,18,17z M29,17l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C28.552,18,29,17.552,29,17z M12,22v-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C11.552,23,12,22.552,12,22z M23,22l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C22.552,23,23,22.552,23,22z M18,28l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C17.552,29,18,28.552,18,28z M29,27L29,27c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h0 C28.105,29,29,28.105,29,27z M9,11L9,11c0,0.552,0.448,1,1,1h1c0.552,0,1-0.448,1-1v-1c0-0.552-0.448-1-1-1h0"
                                               fill="none"
+                                              stroke="#000"
                                               strokeLinecap="round"
                                               strokeLinejoin="round"
                                               strokeMiterlimit="10"
@@ -20827,7 +20667,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         </span>
                                                         <ForwardRef(ArrowRight20)>
                                                           <Icon
-                                                            fill="currentColor"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
                                                             viewBox="0 0 20 20"
@@ -20836,7 +20675,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           >
                                                             <svg
                                                               aria-hidden={true}
-                                                              fill="currentColor"
                                                               focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
@@ -20906,7 +20744,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           data-autoid="dds--pictogram-item__pictogram"
                                           height={48}
                                           preserveAspectRatio="xMidYMid meet"
-                                          stroke="currentColor"
                                           viewBox="0 0 48 48"
                                           width={48}
                                           xmlns="http://www.w3.org/2000/svg"
@@ -20919,7 +20756,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             height={48}
                                             preserveAspectRatio="xMidYMid meet"
                                             role="img"
-                                            stroke="currentColor"
                                             viewBox="0 0 48 48"
                                             width={48}
                                             xmlns="http://www.w3.org/2000/svg"
@@ -20927,6 +20763,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                             <path
                                               d="M21,15 c0-1.186,0.821-2,2-2h-0.003C24.176,13,25,13.814,25,15v8c0,0,4.663,0,6.913,0C34.162,23,36,24.541,36,26.776c0,0,0,2.758,0,4.01 C36,35.478,34.706,39,27.769,39c-4.829,0-7.104-2.056-10.134-5.48c-0.845-0.955-3.439-3.765-3.439-3.765 C13.365,28.819,12,27.415,12,26.985c0-1.299,3.219-2.011,4.792-0.803C18.008,27.116,21,30.5,21,30.5V15z M26.994,19.46 c1.23-1.09,2-2.69,2-4.46c0-3.31-2.69-6-6-6s-6,2.69-6,6c0,1.77,0.77,3.37,2,4.46"
                                               fill="none"
+                                              stroke="#000"
                                               strokeLinejoin="round"
                                               strokeMiterlimit="10"
                                               strokeWidth=".72"
@@ -21026,7 +20863,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         </span>
                                                         <ForwardRef(ArrowRight20)>
                                                           <Icon
-                                                            fill="currentColor"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
                                                             viewBox="0 0 20 20"
@@ -21035,7 +20871,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           >
                                                             <svg
                                                               aria-hidden={true}
-                                                              fill="currentColor"
                                                               focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
@@ -21463,7 +21298,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -21479,7 +21313,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -21990,7 +21823,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       >
                                                         <Icon
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
                                                           src={
@@ -22006,7 +21838,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           <svg
                                                             aria-hidden={true}
                                                             className="bx--card__cta"
-                                                            fill="currentColor"
                                                             focusable="false"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
@@ -22106,7 +21937,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       >
                                                         <Icon
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
                                                           src={
@@ -22122,7 +21952,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           <svg
                                                             aria-hidden={true}
                                                             className="bx--card__cta"
-                                                            fill="currentColor"
                                                             focusable="false"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
@@ -22222,7 +22051,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       >
                                                         <Icon
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
                                                           src={
@@ -22238,7 +22066,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           <svg
                                                             aria-hidden={true}
                                                             className="bx--card__cta"
-                                                            fill="currentColor"
                                                             focusable="false"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
@@ -22338,7 +22165,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       >
                                                         <Icon
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
                                                           src={
@@ -22354,7 +22180,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                           <svg
                                                             aria-hidden={true}
                                                             className="bx--card__cta"
-                                                            fill="currentColor"
                                                             focusable="false"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
@@ -22508,7 +22333,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   data-autoid="dds--pictogram-item__pictogram"
                                                   height={48}
                                                   preserveAspectRatio="xMidYMid meet"
-                                                  stroke="currentColor"
                                                   viewBox="0 0 48 48"
                                                   width={48}
                                                   xmlns="http://www.w3.org/2000/svg"
@@ -22521,7 +22345,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     height={48}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     role="img"
-                                                    stroke="currentColor"
                                                     viewBox="0 0 48 48"
                                                     width={48}
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -22529,6 +22352,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     <path
                                                       d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
                                                       fill="none"
+                                                      stroke="#000"
                                                       strokeLinejoin="round"
                                                       strokeMiterlimit="10"
                                                       strokeWidth=".72"
@@ -22628,7 +22452,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                                 </span>
                                                                 <ForwardRef(ArrowRight20)>
                                                                   <Icon
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     viewBox="0 0 20 20"
@@ -22637,7 +22460,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                                   >
                                                                     <svg
                                                                       aria-hidden={true}
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -22707,7 +22529,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   data-autoid="dds--pictogram-item__pictogram"
                                                   height={48}
                                                   preserveAspectRatio="xMidYMid meet"
-                                                  stroke="currentColor"
                                                   viewBox="0 0 48 48"
                                                   width={48}
                                                   xmlns="http://www.w3.org/2000/svg"
@@ -22720,7 +22541,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     height={48}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     role="img"
-                                                    stroke="currentColor"
                                                     viewBox="0 0 48 48"
                                                     width={48}
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -22728,6 +22548,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     <path
                                                       d="M27,29H11c-1.1,0-2-0.9-2-2V11c0-1.1,0.9-2,2-2h16c1.1,0,2,0.9,2,2v16C29,28.1,28.1,29,27,29z M19,29v8c0,1.1,0.9,2,2,2h16 c1.1,0,2-0.9,2-2V21c0-1.1-0.9-2-2-2h-8 M23,11l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C22.552,12,23,11.552,23,11z M18,17l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C17.552,18,18,17.552,18,17z M29,17l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C28.552,18,29,17.552,29,17z M12,22v-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C11.552,23,12,22.552,12,22z M23,22l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1l0,1c0,0.552,0.448,1,1,1h1 C22.552,23,23,22.552,23,22z M18,28l0-1c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h1 C17.552,29,18,28.552,18,28z M29,27L29,27c0-0.552-0.448-1-1-1h-1c-0.552,0-1,0.448-1,1v1c0,0.552,0.448,1,1,1h0 C28.105,29,29,28.105,29,27z M9,11L9,11c0,0.552,0.448,1,1,1h1c0.552,0,1-0.448,1-1v-1c0-0.552-0.448-1-1-1h0"
                                                       fill="none"
+                                                      stroke="#000"
                                                       strokeLinecap="round"
                                                       strokeLinejoin="round"
                                                       strokeMiterlimit="10"
@@ -22828,7 +22649,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                                 </span>
                                                                 <ForwardRef(ArrowRight20)>
                                                                   <Icon
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     viewBox="0 0 20 20"
@@ -22837,7 +22657,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                                   >
                                                                     <svg
                                                                       aria-hidden={true}
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -22907,7 +22726,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   data-autoid="dds--pictogram-item__pictogram"
                                                   height={48}
                                                   preserveAspectRatio="xMidYMid meet"
-                                                  stroke="currentColor"
                                                   viewBox="0 0 48 48"
                                                   width={48}
                                                   xmlns="http://www.w3.org/2000/svg"
@@ -22920,7 +22738,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     height={48}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     role="img"
-                                                    stroke="currentColor"
                                                     viewBox="0 0 48 48"
                                                     width={48}
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -22928,6 +22745,7 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     <path
                                                       d="M21,15 c0-1.186,0.821-2,2-2h-0.003C24.176,13,25,13.814,25,15v8c0,0,4.663,0,6.913,0C34.162,23,36,24.541,36,26.776c0,0,0,2.758,0,4.01 C36,35.478,34.706,39,27.769,39c-4.829,0-7.104-2.056-10.134-5.48c-0.845-0.955-3.439-3.765-3.439-3.765 C13.365,28.819,12,27.415,12,26.985c0-1.299,3.219-2.011,4.792-0.803C18.008,27.116,21,30.5,21,30.5V15z M26.994,19.46 c1.23-1.09,2-2.69,2-4.46c0-3.31-2.69-6-6-6s-6,2.69-6,6c0,1.77,0.77,3.37,2,4.46"
                                                       fill="none"
+                                                      stroke="#000"
                                                       strokeLinejoin="round"
                                                       strokeMiterlimit="10"
                                                       strokeWidth=".72"
@@ -23027,7 +22845,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                                 </span>
                                                                 <ForwardRef(ArrowRight20)>
                                                                   <Icon
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     viewBox="0 0 20 20"
@@ -23036,7 +22853,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                                   >
                                                                     <svg
                                                                       aria-hidden={true}
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -23464,7 +23280,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -23480,7 +23295,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -23679,7 +23493,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -23695,7 +23508,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -23855,7 +23667,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -23871,7 +23682,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -24272,7 +24082,6 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                         </span>
                                         <ForwardRef(ArrowRight20)>
                                           <Icon
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             viewBox="0 0 20 20"
@@ -24281,7 +24090,6 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -24504,7 +24312,6 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                         </span>
                                         <ForwardRef(ArrowRight20)>
                                           <Icon
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             viewBox="0 0 20 20"
@@ -24513,7 +24320,6 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -24669,7 +24475,6 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -24685,7 +24490,6 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -25023,7 +24827,6 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                         </span>
                                         <ForwardRef(ArrowRight20)>
                                           <Icon
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             viewBox="0 0 20 20"
@@ -25032,7 +24835,6 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -25255,7 +25057,6 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                         </span>
                                         <ForwardRef(ArrowRight20)>
                                           <Icon
-                                            fill="currentColor"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
                                             viewBox="0 0 20 20"
@@ -25264,7 +25065,6 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              fill="currentColor"
                                               focusable="false"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
@@ -25420,7 +25220,6 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -25436,7 +25235,6 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -26127,7 +25925,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -26143,7 +25940,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -26342,7 +26138,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -26358,7 +26153,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -26518,7 +26312,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -26534,7 +26327,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -26840,7 +26632,6 @@ exports[`Storyshots Components|ContentBlockSimple Default 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -26856,7 +26647,6 @@ exports[`Storyshots Components|ContentBlockSimple Default 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -27266,7 +27056,6 @@ exports[`Storyshots Components|ContentBlockSimple With Image 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -27282,7 +27071,6 @@ exports[`Storyshots Components|ContentBlockSimple With Image 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -27639,7 +27427,6 @@ exports[`Storyshots Components|ContentBlockSimple With Video 1`] = `
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -27655,7 +27442,6 @@ exports[`Storyshots Components|ContentBlockSimple With Video 1`] = `
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -28163,7 +27949,6 @@ exports[`Storyshots Components|ContentBlockSimple With aside elements 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -28179,7 +27964,6 @@ exports[`Storyshots Components|ContentBlockSimple With aside elements 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -28378,7 +28162,6 @@ exports[`Storyshots Components|ContentBlockSimple With aside elements 1`] = `
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -28394,7 +28177,6 @@ exports[`Storyshots Components|ContentBlockSimple With aside elements 1`] = `
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -28554,7 +28336,6 @@ exports[`Storyshots Components|ContentBlockSimple With aside elements 1`] = `
                                                     >
                                                       <Icon
                                                         className="bx--card__cta"
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         src={
@@ -28570,7 +28351,6 @@ exports[`Storyshots Components|ContentBlockSimple With aside elements 1`] = `
                                                         <svg
                                                           aria-hidden={true}
                                                           className="bx--card__cta"
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -28795,7 +28575,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -28811,7 +28590,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -28911,7 +28689,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -28927,7 +28704,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -29027,7 +28803,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -29043,7 +28818,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -29143,7 +28917,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -29159,7 +28932,6 @@ exports[`Storyshots Components|ContentGroupCards Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -29484,7 +29256,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                     </span>
                                                     <ForwardRef(ArrowRight20)>
                                                       <Icon
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         viewBox="0 0 20 20"
@@ -29493,7 +29264,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                       >
                                                         <svg
                                                           aria-hidden={true}
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -29584,7 +29354,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                     </span>
                                                     <ForwardRef(Launch20)>
                                                       <Icon
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         viewBox="0 0 32 32"
@@ -29593,7 +29362,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                       >
                                                         <svg
                                                           aria-hidden={true}
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -29791,7 +29559,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                     </span>
                                                     <ForwardRef(ArrowRight20)>
                                                       <Icon
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         viewBox="0 0 20 20"
@@ -29800,7 +29567,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                       >
                                                         <svg
                                                           aria-hidden={true}
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -29891,7 +29657,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                     </span>
                                                     <ForwardRef(Launch20)>
                                                       <Icon
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         viewBox="0 0 32 32"
@@ -29900,7 +29665,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                       >
                                                         <svg
                                                           aria-hidden={true}
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -30084,7 +29848,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                     </span>
                                                     <ForwardRef(ArrowRight20)>
                                                       <Icon
-                                                        fill="currentColor"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
                                                         viewBox="0 0 20 20"
@@ -30093,7 +29856,6 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                       >
                                                         <svg
                                                           aria-hidden={true}
-                                                          fill="currentColor"
                                                           focusable="false"
                                                           height={20}
                                                           preserveAspectRatio="xMidYMid meet"
@@ -30277,7 +30039,6 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                               data-autoid="dds--pictogram-item__pictogram"
                               height={48}
                               preserveAspectRatio="xMidYMid meet"
-                              stroke="currentColor"
                               viewBox="0 0 48 48"
                               width={48}
                               xmlns="http://www.w3.org/2000/svg"
@@ -30290,7 +30051,6 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                                 height={48}
                                 preserveAspectRatio="xMidYMid meet"
                                 role="img"
-                                stroke="currentColor"
                                 viewBox="0 0 48 48"
                                 width={48}
                                 xmlns="http://www.w3.org/2000/svg"
@@ -30298,6 +30058,7 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                                 <path
                                   d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
                                   fill="none"
+                                  stroke="#000"
                                   strokeLinejoin="round"
                                   strokeMiterlimit="10"
                                   strokeWidth=".72"
@@ -30377,7 +30138,6 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                               data-autoid="dds--pictogram-item__pictogram"
                               height={48}
                               preserveAspectRatio="xMidYMid meet"
-                              stroke="currentColor"
                               viewBox="0 0 48 48"
                               width={48}
                               xmlns="http://www.w3.org/2000/svg"
@@ -30390,7 +30150,6 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                                 height={48}
                                 preserveAspectRatio="xMidYMid meet"
                                 role="img"
-                                stroke="currentColor"
                                 viewBox="0 0 48 48"
                                 width={48}
                                 xmlns="http://www.w3.org/2000/svg"
@@ -30398,6 +30157,7 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                                 <path
                                   d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
                                   fill="none"
+                                  stroke="#000"
                                   strokeLinejoin="round"
                                   strokeMiterlimit="10"
                                   strokeWidth=".72"
@@ -30477,7 +30237,6 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                               data-autoid="dds--pictogram-item__pictogram"
                               height={48}
                               preserveAspectRatio="xMidYMid meet"
-                              stroke="currentColor"
                               viewBox="0 0 48 48"
                               width={48}
                               xmlns="http://www.w3.org/2000/svg"
@@ -30490,7 +30249,6 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                                 height={48}
                                 preserveAspectRatio="xMidYMid meet"
                                 role="img"
-                                stroke="currentColor"
                                 viewBox="0 0 48 48"
                                 width={48}
                                 xmlns="http://www.w3.org/2000/svg"
@@ -30498,6 +30256,7 @@ exports[`Storyshots Components|ContentGroupPictograms Default 1`] = `
                                 <path
                                   d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
                                   fill="none"
+                                  stroke="#000"
                                   strokeLinejoin="round"
                                   strokeMiterlimit="10"
                                   strokeWidth=".72"
@@ -30884,7 +30643,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -30900,7 +30658,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -31387,7 +31144,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -31403,7 +31159,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -31837,7 +31592,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                       >
                                         <Icon
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           src={
@@ -31853,7 +31607,6 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                           <svg
                                             aria-hidden={true}
                                             className="bx--card__cta"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -32085,7 +31838,6 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                           </span>
                                           <ForwardRef(ArrowRight20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 20 20"
@@ -32094,7 +31846,6 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -32185,7 +31936,6 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                           </span>
                                           <ForwardRef(Launch20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 32 32"
@@ -32194,7 +31944,6 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -32339,7 +32088,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                       >
                         <ForwardRef(Menu20)>
                           <Icon
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 20 20"
@@ -32348,7 +32096,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -32453,7 +32200,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                               >
                                 <ForwardRef(Search20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -32462,7 +32208,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -32493,7 +32238,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                               >
                                 <ForwardRef(Close20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -32502,7 +32246,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -32576,7 +32319,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                               onOpen={[Function]}
                               open={false}
                               renderIcon={[Function]}
-                              selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                               style={
                                 Object {
                                   "width": "3rem",
@@ -32613,7 +32355,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                   >
                                     <ForwardRef(User20)>
                                       <Icon
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 32 32"
@@ -32622,7 +32363,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                       >
                                         <svg
                                           aria-hidden={true}
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -32823,7 +32563,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                       <Icon
                                         aria-label="menu icon"
                                         className="bx--tableofcontents__mobile__select__icon"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 32 32"
@@ -32833,7 +32572,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                         <svg
                                           aria-label="menu icon"
                                           className="bx--tableofcontents__mobile__select__icon"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -33145,7 +32883,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       </span>
                                                                       <ForwardRef(ArrowRight20)>
                                                                         <Icon
-                                                                          fill="currentColor"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
                                                                           viewBox="0 0 20 20"
@@ -33154,7 +32891,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         >
                                                                           <svg
                                                                             aria-hidden={true}
-                                                                            fill="currentColor"
                                                                             focusable="false"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
@@ -33245,7 +32981,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       </span>
                                                                       <ForwardRef(ArrowRight20)>
                                                                         <Icon
-                                                                          fill="currentColor"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
                                                                           viewBox="0 0 20 20"
@@ -33254,7 +32989,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         >
                                                                           <svg
                                                                             aria-hidden={true}
-                                                                            fill="currentColor"
                                                                             focusable="false"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
@@ -33345,7 +33079,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       </span>
                                                                       <ForwardRef(ArrowRight20)>
                                                                         <Icon
-                                                                          fill="currentColor"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
                                                                           viewBox="0 0 20 20"
@@ -33354,7 +33087,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         >
                                                                           <svg
                                                                             aria-hidden={true}
-                                                                            fill="currentColor"
                                                                             focusable="false"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
@@ -33502,7 +33234,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                     aria-hidden="true"
                                                                     aria-label="right arrow icon"
                                                                     className="bx--btn__icon"
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     viewBox="0 0 20 20"
@@ -33513,7 +33244,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       aria-hidden="true"
                                                                       aria-label="right arrow icon"
                                                                       className="bx--btn__icon"
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -33722,7 +33452,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             </span>
                                                             <ForwardRef(ArrowRight20)>
                                                               <Icon
-                                                                fill="currentColor"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 viewBox="0 0 20 20"
@@ -33731,7 +33460,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               >
                                                                 <svg
                                                                   aria-hidden={true}
-                                                                  fill="currentColor"
                                                                   focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
@@ -33909,7 +33637,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             </span>
                                                             <ForwardRef(ArrowRight20)>
                                                               <Icon
-                                                                fill="currentColor"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 viewBox="0 0 20 20"
@@ -33918,7 +33645,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               >
                                                                 <svg
                                                                   aria-hidden={true}
-                                                                  fill="currentColor"
                                                                   focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
@@ -34116,7 +33842,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               >
                                                 <Icon
                                                   className="bx--card__cta"
-                                                  fill="currentColor"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
                                                   src={
@@ -34132,7 +33857,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   <svg
                                                     aria-hidden={true}
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     focusable="false"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
@@ -34472,7 +34196,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                             </span>
                                                             <ForwardRef(ArrowRight20)>
                                                               <Icon
-                                                                fill="currentColor"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 viewBox="0 0 20 20"
@@ -34481,7 +34204,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               >
                                                                 <svg
                                                                   aria-hidden={true}
-                                                                  fill="currentColor"
                                                                   focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
@@ -34787,7 +34509,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           >
                                                             <Icon
                                                               className="bx--card__cta"
-                                                              fill="currentColor"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
                                                               src={
@@ -34803,7 +34524,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               <svg
                                                                 aria-hidden={true}
                                                                 className="bx--card__cta"
-                                                                fill="currentColor"
                                                                 focusable="false"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
@@ -35207,7 +34927,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -35216,7 +34935,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -35297,7 +35015,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         </span>
                                                                         <ForwardRef(Launch20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 32 32"
@@ -35306,7 +35023,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -35490,7 +35206,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -35499,7 +35214,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -35580,7 +35294,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                         </span>
                                                                         <ForwardRef(Launch20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 32 32"
@@ -35589,7 +35302,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -36050,7 +35762,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                               >
                                                                 <Icon
                                                                   className="bx--card__cta"
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   src={
@@ -36066,7 +35777,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                   <svg
                                                                     aria-hidden={true}
                                                                     className="bx--card__cta"
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -36412,7 +36122,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                   >
                                                                     <Icon
                                                                       className="bx--card__cta"
-                                                                      fill="currentColor"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
                                                                       src={
@@ -36428,7 +36137,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       <svg
                                                                         aria-hidden={true}
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         focusable="false"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
@@ -36654,7 +36362,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                   >
                                                                     <Icon
                                                                       className="bx--card__cta"
-                                                                      fill="currentColor"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
                                                                       src={
@@ -36670,7 +36377,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       <svg
                                                                         aria-hidden={true}
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         focusable="false"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
@@ -36896,7 +36602,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                   >
                                                                     <Icon
                                                                       className="bx--card__cta"
-                                                                      fill="currentColor"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
                                                                       src={
@@ -36912,7 +36617,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       <svg
                                                                         aria-hidden={true}
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         focusable="false"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
@@ -37073,7 +36777,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                         </span>
                                                         <ForwardRef(ArrowRight20)>
                                                           <Icon
-                                                            fill="currentColor"
                                                             height={20}
                                                             preserveAspectRatio="xMidYMid meet"
                                                             viewBox="0 0 20 20"
@@ -37082,7 +36785,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           >
                                                             <svg
                                                               aria-hidden={true}
-                                                              fill="currentColor"
                                                               focusable="false"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
@@ -37335,7 +37037,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               aria-hidden="true"
                                               aria-label="right arrow icon"
                                               className="bx--btn__icon"
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 20 20"
@@ -37346,7 +37047,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                 aria-hidden="true"
                                                 aria-label="right arrow icon"
                                                 className="bx--btn__icon"
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -37462,7 +37162,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                 </span>
                                                 <ForwardRef(ArrowRight20)>
                                                   <Icon
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     viewBox="0 0 20 20"
@@ -37471,7 +37170,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   >
                                                     <svg
                                                       aria-hidden={true}
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -37581,7 +37279,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                 </span>
                                                 <ForwardRef(ArrowRight20)>
                                                   <Icon
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     viewBox="0 0 20 20"
@@ -37590,7 +37287,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                   >
                                                     <svg
                                                       aria-hidden={true}
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -37724,7 +37420,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                           aria-hidden="true"
                           aria-label="Earth Filled Icon"
                           className="bx--btn__icon"
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           viewBox="0 0 32 32"
@@ -37735,7 +37430,6 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                             aria-hidden="true"
                             aria-label="Earth Filled Icon"
                             className="bx--btn__icon"
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -37919,7 +37613,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                         >
                           <ForwardRef(Menu20)>
                             <Icon
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -37928,7 +37621,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -38203,7 +37895,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                 >
                                   <ForwardRef(Search20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -38212,7 +37903,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -38243,7 +37933,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                 >
                                   <ForwardRef(Close20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -38252,7 +37941,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -38326,7 +38014,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                 onOpen={[Function]}
                                 open={false}
                                 renderIcon={[Function]}
-                                selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                                 style={
                                   Object {
                                     "width": "3rem",
@@ -38363,7 +38050,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                     >
                                       <ForwardRef(User20)>
                                         <Icon
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           viewBox="0 0 32 32"
@@ -38372,7 +38058,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                         >
                                           <svg
                                             aria-hidden={true}
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -38573,7 +38258,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                         <Icon
                                           aria-label="menu icon"
                                           className="bx--tableofcontents__mobile__select__icon"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           viewBox="0 0 32 32"
@@ -38583,7 +38267,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                           <svg
                                             aria-label="menu icon"
                                             className="bx--tableofcontents__mobile__select__icon"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -38895,7 +38578,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -38904,7 +38586,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -38995,7 +38676,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -39004,7 +38684,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -39095,7 +38774,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -39104,7 +38782,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -39252,7 +38929,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                       aria-hidden="true"
                                                                       aria-label="right arrow icon"
                                                                       className="bx--btn__icon"
-                                                                      fill="currentColor"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
                                                                       viewBox="0 0 20 20"
@@ -39263,7 +38939,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         aria-hidden="true"
                                                                         aria-label="right arrow icon"
                                                                         className="bx--btn__icon"
-                                                                        fill="currentColor"
                                                                         focusable="false"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
@@ -39472,7 +39147,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -39481,7 +39155,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -39659,7 +39332,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -39668,7 +39340,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -39866,7 +39537,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                 >
                                                   <Icon
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     src={
@@ -39882,7 +39552,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                     <svg
                                                       aria-hidden={true}
                                                       className="bx--card__cta"
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -40222,7 +39891,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -40231,7 +39899,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -40537,7 +40204,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                             >
                                                               <Icon
                                                                 className="bx--card__cta"
-                                                                fill="currentColor"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 src={
@@ -40553,7 +40219,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                 <svg
                                                                   aria-hidden={true}
                                                                   className="bx--card__cta"
-                                                                  fill="currentColor"
                                                                   focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
@@ -40957,7 +40622,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 20 20"
@@ -40966,7 +40630,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -41047,7 +40710,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           </span>
                                                                           <ForwardRef(Launch20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 32 32"
@@ -41056,7 +40718,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -41240,7 +40901,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 20 20"
@@ -41249,7 +40909,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -41330,7 +40989,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                           </span>
                                                                           <ForwardRef(Launch20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 32 32"
@@ -41339,7 +40997,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -41800,7 +41457,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                 >
                                                                   <Icon
                                                                     className="bx--card__cta"
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     src={
@@ -41816,7 +41472,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                     <svg
                                                                       aria-hidden={true}
                                                                       className="bx--card__cta"
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -42162,7 +41817,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -42178,7 +41832,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -42404,7 +42057,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -42420,7 +42072,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -42646,7 +42297,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -42662,7 +42312,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -42823,7 +42472,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                           </span>
                                                           <ForwardRef(ArrowRight20)>
                                                             <Icon
-                                                              fill="currentColor"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
                                                               viewBox="0 0 20 20"
@@ -42832,7 +42480,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                             >
                                                               <svg
                                                                 aria-hidden={true}
-                                                                fill="currentColor"
                                                                 focusable="false"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
@@ -43085,7 +42732,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                 aria-hidden="true"
                                                 aria-label="right arrow icon"
                                                 className="bx--btn__icon"
-                                                fill="currentColor"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
                                                 viewBox="0 0 20 20"
@@ -43096,7 +42742,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                   aria-hidden="true"
                                                   aria-label="right arrow icon"
                                                   className="bx--btn__icon"
-                                                  fill="currentColor"
                                                   focusable="false"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
@@ -43212,7 +42857,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                   </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       viewBox="0 0 20 20"
@@ -43221,7 +42865,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                     >
                                                       <svg
                                                         aria-hidden={true}
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -43331,7 +42974,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                   </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       viewBox="0 0 20 20"
@@ -43340,7 +42982,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                     >
                                                       <svg
                                                         aria-hidden={true}
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -43474,7 +43115,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                             aria-hidden="true"
                             aria-label="Earth Filled Icon"
                             className="bx--btn__icon"
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 32 32"
@@ -43485,7 +43125,6 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                               aria-hidden="true"
                               aria-label="Earth Filled Icon"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -43679,7 +43318,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                         >
                           <ForwardRef(Menu20)>
                             <Icon
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -43688,7 +43326,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -43818,7 +43455,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                 >
                                   <ForwardRef(Search20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -43827,7 +43463,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -43858,7 +43493,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                 >
                                   <ForwardRef(Close20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -43867,7 +43501,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -43941,7 +43574,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                 onOpen={[Function]}
                                 open={false}
                                 renderIcon={[Function]}
-                                selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                                 style={
                                   Object {
                                     "width": "3rem",
@@ -43978,7 +43610,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                     >
                                       <ForwardRef(User20)>
                                         <Icon
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           viewBox="0 0 32 32"
@@ -43987,7 +43618,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                         >
                                           <svg
                                             aria-hidden={true}
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -44201,7 +43831,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                         <Icon
                                           aria-label="menu icon"
                                           className="bx--tableofcontents__mobile__select__icon"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           viewBox="0 0 32 32"
@@ -44211,7 +43840,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                           <svg
                                             aria-label="menu icon"
                                             className="bx--tableofcontents__mobile__select__icon"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -44523,7 +44151,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -44532,7 +44159,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -44623,7 +44249,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -44632,7 +44257,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -44723,7 +44347,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -44732,7 +44355,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -44880,7 +44502,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                       aria-hidden="true"
                                                                       aria-label="right arrow icon"
                                                                       className="bx--btn__icon"
-                                                                      fill="currentColor"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
                                                                       viewBox="0 0 20 20"
@@ -44891,7 +44512,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         aria-hidden="true"
                                                                         aria-label="right arrow icon"
                                                                         className="bx--btn__icon"
-                                                                        fill="currentColor"
                                                                         focusable="false"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
@@ -45100,7 +44720,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -45109,7 +44728,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -45287,7 +44905,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -45296,7 +44913,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -45494,7 +45110,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                 >
                                                   <Icon
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     src={
@@ -45510,7 +45125,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                     <svg
                                                       aria-hidden={true}
                                                       className="bx--card__cta"
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -45850,7 +45464,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -45859,7 +45472,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -46165,7 +45777,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                             >
                                                               <Icon
                                                                 className="bx--card__cta"
-                                                                fill="currentColor"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 src={
@@ -46181,7 +45792,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                 <svg
                                                                   aria-hidden={true}
                                                                   className="bx--card__cta"
-                                                                  fill="currentColor"
                                                                   focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
@@ -46585,7 +46195,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 20 20"
@@ -46594,7 +46203,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -46675,7 +46283,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           </span>
                                                                           <ForwardRef(Launch20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 32 32"
@@ -46684,7 +46291,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -46868,7 +46474,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 20 20"
@@ -46877,7 +46482,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -46958,7 +46562,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                           </span>
                                                                           <ForwardRef(Launch20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 32 32"
@@ -46967,7 +46570,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -47428,7 +47030,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                 >
                                                                   <Icon
                                                                     className="bx--card__cta"
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     src={
@@ -47444,7 +47045,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                     <svg
                                                                       aria-hidden={true}
                                                                       className="bx--card__cta"
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -47790,7 +47390,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -47806,7 +47405,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -48032,7 +47630,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -48048,7 +47645,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -48274,7 +47870,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -48290,7 +47885,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -48451,7 +48045,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                           </span>
                                                           <ForwardRef(ArrowRight20)>
                                                             <Icon
-                                                              fill="currentColor"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
                                                               viewBox="0 0 20 20"
@@ -48460,7 +48053,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                             >
                                                               <svg
                                                                 aria-hidden={true}
-                                                                fill="currentColor"
                                                                 focusable="false"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
@@ -48713,7 +48305,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                 aria-hidden="true"
                                                 aria-label="right arrow icon"
                                                 className="bx--btn__icon"
-                                                fill="currentColor"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
                                                 viewBox="0 0 20 20"
@@ -48724,7 +48315,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                   aria-hidden="true"
                                                   aria-label="right arrow icon"
                                                   className="bx--btn__icon"
-                                                  fill="currentColor"
                                                   focusable="false"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
@@ -48840,7 +48430,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                   </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       viewBox="0 0 20 20"
@@ -48849,7 +48438,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                     >
                                                       <svg
                                                         aria-hidden={true}
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -48959,7 +48547,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                   </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       viewBox="0 0 20 20"
@@ -48968,7 +48555,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                     >
                                                       <svg
                                                         aria-hidden={true}
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -49102,7 +48688,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                             aria-hidden="true"
                             aria-label="Earth Filled Icon"
                             className="bx--btn__icon"
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 32 32"
@@ -49113,7 +48698,6 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                               aria-hidden="true"
                               aria-label="Earth Filled Icon"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -49298,7 +48882,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                         >
                           <ForwardRef(Menu20)>
                             <Icon
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -49307,7 +48890,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -49412,7 +48994,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                 >
                                   <ForwardRef(Search20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -49421,7 +49002,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -49452,7 +49032,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                 >
                                   <ForwardRef(Close20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -49461,7 +49040,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -49535,7 +49113,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                 onOpen={[Function]}
                                 open={false}
                                 renderIcon={[Function]}
-                                selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                                 style={
                                   Object {
                                     "width": "3rem",
@@ -49572,7 +49149,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                     >
                                       <ForwardRef(User20)>
                                         <Icon
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           viewBox="0 0 32 32"
@@ -49581,7 +49157,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                         >
                                           <svg
                                             aria-hidden={true}
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -49782,7 +49357,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                         <Icon
                                           aria-label="menu icon"
                                           className="bx--tableofcontents__mobile__select__icon"
-                                          fill="currentColor"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
                                           viewBox="0 0 32 32"
@@ -49792,7 +49366,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                           <svg
                                             aria-label="menu icon"
                                             className="bx--tableofcontents__mobile__select__icon"
-                                            fill="currentColor"
                                             focusable="false"
                                             height={20}
                                             preserveAspectRatio="xMidYMid meet"
@@ -50104,7 +49677,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -50113,7 +49685,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -50204,7 +49775,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -50213,7 +49783,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -50304,7 +49873,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         </span>
                                                                         <ForwardRef(ArrowRight20)>
                                                                           <Icon
-                                                                            fill="currentColor"
                                                                             height={20}
                                                                             preserveAspectRatio="xMidYMid meet"
                                                                             viewBox="0 0 20 20"
@@ -50313,7 +49881,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           >
                                                                             <svg
                                                                               aria-hidden={true}
-                                                                              fill="currentColor"
                                                                               focusable="false"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
@@ -50461,7 +50028,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                       aria-hidden="true"
                                                                       aria-label="right arrow icon"
                                                                       className="bx--btn__icon"
-                                                                      fill="currentColor"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
                                                                       viewBox="0 0 20 20"
@@ -50472,7 +50038,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         aria-hidden="true"
                                                                         aria-label="right arrow icon"
                                                                         className="bx--btn__icon"
-                                                                        fill="currentColor"
                                                                         focusable="false"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
@@ -50681,7 +50246,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -50690,7 +50254,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -50868,7 +50431,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -50877,7 +50439,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -51075,7 +50636,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                 >
                                                   <Icon
                                                     className="bx--card__cta"
-                                                    fill="currentColor"
                                                     height={20}
                                                     preserveAspectRatio="xMidYMid meet"
                                                     src={
@@ -51091,7 +50651,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                     <svg
                                                       aria-hidden={true}
                                                       className="bx--card__cta"
-                                                      fill="currentColor"
                                                       focusable="false"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
@@ -51431,7 +50990,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                               </span>
                                                               <ForwardRef(ArrowRight20)>
                                                                 <Icon
-                                                                  fill="currentColor"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
                                                                   viewBox="0 0 20 20"
@@ -51440,7 +50998,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                 >
                                                                   <svg
                                                                     aria-hidden={true}
-                                                                    fill="currentColor"
                                                                     focusable="false"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
@@ -51746,7 +51303,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                             >
                                                               <Icon
                                                                 className="bx--card__cta"
-                                                                fill="currentColor"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
                                                                 src={
@@ -51762,7 +51318,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                 <svg
                                                                   aria-hidden={true}
                                                                   className="bx--card__cta"
-                                                                  fill="currentColor"
                                                                   focusable="false"
                                                                   height={20}
                                                                   preserveAspectRatio="xMidYMid meet"
@@ -52166,7 +51721,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 20 20"
@@ -52175,7 +51729,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -52256,7 +51809,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           </span>
                                                                           <ForwardRef(Launch20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 32 32"
@@ -52265,7 +51817,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -52449,7 +52000,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           </span>
                                                                           <ForwardRef(ArrowRight20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 20 20"
@@ -52458,7 +52008,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -52539,7 +52088,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                           </span>
                                                                           <ForwardRef(Launch20)>
                                                                             <Icon
-                                                                              fill="currentColor"
                                                                               height={20}
                                                                               preserveAspectRatio="xMidYMid meet"
                                                                               viewBox="0 0 32 32"
@@ -52548,7 +52096,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                             >
                                                                               <svg
                                                                                 aria-hidden={true}
-                                                                                fill="currentColor"
                                                                                 focusable="false"
                                                                                 height={20}
                                                                                 preserveAspectRatio="xMidYMid meet"
@@ -53009,7 +52556,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                 >
                                                                   <Icon
                                                                     className="bx--card__cta"
-                                                                    fill="currentColor"
                                                                     height={20}
                                                                     preserveAspectRatio="xMidYMid meet"
                                                                     src={
@@ -53025,7 +52571,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                     <svg
                                                                       aria-hidden={true}
                                                                       className="bx--card__cta"
-                                                                      fill="currentColor"
                                                                       focusable="false"
                                                                       height={20}
                                                                       preserveAspectRatio="xMidYMid meet"
@@ -53371,7 +52916,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -53387,7 +52931,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -53613,7 +53156,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -53629,7 +53171,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -53855,7 +53396,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                     >
                                                                       <Icon
                                                                         className="bx--card__cta"
-                                                                        fill="currentColor"
                                                                         height={20}
                                                                         preserveAspectRatio="xMidYMid meet"
                                                                         src={
@@ -53871,7 +53411,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         <svg
                                                                           aria-hidden={true}
                                                                           className="bx--card__cta"
-                                                                          fill="currentColor"
                                                                           focusable="false"
                                                                           height={20}
                                                                           preserveAspectRatio="xMidYMid meet"
@@ -54032,7 +53571,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                           </span>
                                                           <ForwardRef(ArrowRight20)>
                                                             <Icon
-                                                              fill="currentColor"
                                                               height={20}
                                                               preserveAspectRatio="xMidYMid meet"
                                                               viewBox="0 0 20 20"
@@ -54041,7 +53579,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                             >
                                                               <svg
                                                                 aria-hidden={true}
-                                                                fill="currentColor"
                                                                 focusable="false"
                                                                 height={20}
                                                                 preserveAspectRatio="xMidYMid meet"
@@ -54294,7 +53831,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                 aria-hidden="true"
                                                 aria-label="right arrow icon"
                                                 className="bx--btn__icon"
-                                                fill="currentColor"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
                                                 viewBox="0 0 20 20"
@@ -54305,7 +53841,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                   aria-hidden="true"
                                                   aria-label="right arrow icon"
                                                   className="bx--btn__icon"
-                                                  fill="currentColor"
                                                   focusable="false"
                                                   height={20}
                                                   preserveAspectRatio="xMidYMid meet"
@@ -54421,7 +53956,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                   </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       viewBox="0 0 20 20"
@@ -54430,7 +53964,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                     >
                                                       <svg
                                                         aria-hidden={true}
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -54540,7 +54073,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                   </span>
                                                   <ForwardRef(ArrowRight20)>
                                                     <Icon
-                                                      fill="currentColor"
                                                       height={20}
                                                       preserveAspectRatio="xMidYMid meet"
                                                       viewBox="0 0 20 20"
@@ -54549,7 +54081,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                     >
                                                       <svg
                                                         aria-hidden={true}
-                                                        fill="currentColor"
                                                         focusable="false"
                                                         height={20}
                                                         preserveAspectRatio="xMidYMid meet"
@@ -54681,7 +54212,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                             aria-hidden="true"
                             aria-label="Earth Filled Icon"
                             className="bx--btn__icon"
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 32 32"
@@ -54692,7 +54222,6 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                               aria-hidden="true"
                               aria-label="Earth Filled Icon"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -54772,7 +54301,7 @@ exports[`Storyshots Components|Expressive Modal Default 1`] = `
           </span>
           <div
             className="bx--modal-container"
-            role="dialog"
+            tabIndex={-1}
           >
             <ExpressiveModalCloseBtn
               iconDescription="Close"
@@ -54793,7 +54322,6 @@ exports[`Storyshots Components|Expressive Modal Default 1`] = `
                   <Icon
                     aria-label="Close"
                     className="bx--modal-close__icon"
-                    fill="currentColor"
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 32 32"
@@ -54803,7 +54331,6 @@ exports[`Storyshots Components|Expressive Modal Default 1`] = `
                     <svg
                       aria-label="Close"
                       className="bx--modal-close__icon"
-                      fill="currentColor"
                       focusable="false"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
@@ -54903,7 +54430,6 @@ exports[`Storyshots Components|Expressive Modal Default 1`] = `
                                 <Icon
                                   aria-hidden="true"
                                   className="bx--btn__icon"
-                                  fill="currentColor"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 20 20"
@@ -54913,7 +54439,6 @@ exports[`Storyshots Components|Expressive Modal Default 1`] = `
                                   <svg
                                     aria-hidden={true}
                                     className="bx--btn__icon"
-                                    fill="currentColor"
                                     focusable="false"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
@@ -55000,7 +54525,7 @@ exports[`Storyshots Components|Expressive Modal Expanded 1`] = `
           </span>
           <div
             className="bx--modal-container"
-            role="dialog"
+            tabIndex={-1}
           >
             <ExpressiveModalCloseBtn
               iconDescription="Close"
@@ -55021,7 +54546,6 @@ exports[`Storyshots Components|Expressive Modal Expanded 1`] = `
                   <Icon
                     aria-label="Close"
                     className="bx--modal-close__icon"
-                    fill="currentColor"
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 32 32"
@@ -55031,7 +54555,6 @@ exports[`Storyshots Components|Expressive Modal Expanded 1`] = `
                     <svg
                       aria-label="Close"
                       className="bx--modal-close__icon"
-                      fill="currentColor"
                       focusable="false"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
@@ -55131,7 +54654,6 @@ exports[`Storyshots Components|Expressive Modal Expanded 1`] = `
                                 <Icon
                                   aria-hidden="true"
                                   className="bx--btn__icon"
-                                  fill="currentColor"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 20 20"
@@ -55141,7 +54663,6 @@ exports[`Storyshots Components|Expressive Modal Expanded 1`] = `
                                   <svg
                                     aria-hidden={true}
                                     className="bx--btn__icon"
-                                    fill="currentColor"
                                     focusable="false"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
@@ -55316,7 +54837,6 @@ exports[`Storyshots Components|FeatureCard Default 1`] = `
                         >
                           <Icon
                             className="bx--card__cta"
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             src={
@@ -55332,7 +54852,6 @@ exports[`Storyshots Components|FeatureCard Default 1`] = `
                             <svg
                               aria-hidden={true}
                               className="bx--card__cta"
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -55611,7 +55130,6 @@ exports[`Storyshots Components|FeatureCardBlockLarge Default 1`] = `
                           >
                             <Icon
                               className="bx--card__cta"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               src={
@@ -55627,7 +55145,6 @@ exports[`Storyshots Components|FeatureCardBlockLarge Default 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--card__cta"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -55824,7 +55341,6 @@ exports[`Storyshots Components|FeatureCardBlockMedium Default 1`] = `
                             >
                               <Icon
                                 className="bx--card__cta"
-                                fill="currentColor"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
                                 src={
@@ -55840,7 +55356,6 @@ exports[`Storyshots Components|FeatureCardBlockMedium Default 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   className="bx--card__cta"
-                                  fill="currentColor"
                                   focusable="false"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
@@ -55994,7 +55509,6 @@ exports[`Storyshots Components|Footer Default 1`] = `
                         aria-hidden="true"
                         aria-label="Earth Filled Icon"
                         className="bx--btn__icon"
-                        fill="currentColor"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
                         viewBox="0 0 32 32"
@@ -56005,7 +55519,6 @@ exports[`Storyshots Components|Footer Default 1`] = `
                           aria-hidden="true"
                           aria-label="Earth Filled Icon"
                           className="bx--btn__icon"
-                          fill="currentColor"
                           focusable="false"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
@@ -56174,7 +55687,6 @@ exports[`Storyshots Components|Footer Short 1`] = `
                           aria-hidden="true"
                           aria-label="Earth Filled Icon"
                           className="bx--btn__icon"
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           viewBox="0 0 32 32"
@@ -56185,7 +55697,6 @@ exports[`Storyshots Components|Footer Short 1`] = `
                             aria-hidden="true"
                             aria-label="Earth Filled Icon"
                             className="bx--btn__icon"
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -56496,7 +56007,6 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
                   >
                     <Icon
                       aria-label="Zoom In Icon"
-                      fill="currentColor"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
                       viewBox="0 0 32 32"
@@ -56505,7 +56015,6 @@ exports[`Storyshots Components|ImageWithCaption Default 1`] = `
                     >
                       <svg
                         aria-label="Zoom In Icon"
-                        fill="currentColor"
                         focusable="false"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
@@ -56973,7 +56482,6 @@ exports[`Storyshots Components|LeadSpace Centered 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -56983,7 +56491,6 @@ exports[`Storyshots Components|LeadSpace Centered 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -57033,7 +56540,6 @@ exports[`Storyshots Components|LeadSpace Centered 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -57043,7 +56549,6 @@ exports[`Storyshots Components|LeadSpace Centered 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -57233,7 +56738,6 @@ exports[`Storyshots Components|LeadSpace Centered with image 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -57243,7 +56747,6 @@ exports[`Storyshots Components|LeadSpace Centered with image 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -57293,7 +56796,6 @@ exports[`Storyshots Components|LeadSpace Centered with image 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -57303,7 +56805,6 @@ exports[`Storyshots Components|LeadSpace Centered with image 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -57501,7 +57002,6 @@ exports[`Storyshots Components|LeadSpace Default with image 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -57511,7 +57011,6 @@ exports[`Storyshots Components|LeadSpace Default with image 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -57561,7 +57060,6 @@ exports[`Storyshots Components|LeadSpace Default with image 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -57571,7 +57069,6 @@ exports[`Storyshots Components|LeadSpace Default with image 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -57821,7 +57318,6 @@ exports[`Storyshots Components|LeadSpace Default with no image 1`] = `
                               <Icon
                                 aria-hidden="true"
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
                                 viewBox="0 0 20 20"
@@ -57831,7 +57327,6 @@ exports[`Storyshots Components|LeadSpace Default with no image 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   className="bx--btn__icon"
-                                  fill="currentColor"
                                   focusable="false"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
@@ -57881,7 +57376,6 @@ exports[`Storyshots Components|LeadSpace Default with no image 1`] = `
                               <Icon
                                 aria-hidden="true"
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
                                 viewBox="0 0 20 20"
@@ -57891,7 +57385,6 @@ exports[`Storyshots Components|LeadSpace Default with no image 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   className="bx--btn__icon"
-                                  fill="currentColor"
                                   focusable="false"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
@@ -58060,7 +57553,6 @@ exports[`Storyshots Components|LeadSpace Small 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -58070,7 +57562,6 @@ exports[`Storyshots Components|LeadSpace Small 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -58120,7 +57611,6 @@ exports[`Storyshots Components|LeadSpace Small 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -58130,7 +57620,6 @@ exports[`Storyshots Components|LeadSpace Small 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -58320,7 +57809,6 @@ exports[`Storyshots Components|LeadSpace Small with image 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -58330,7 +57818,6 @@ exports[`Storyshots Components|LeadSpace Small with image 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -58380,7 +57867,6 @@ exports[`Storyshots Components|LeadSpace Small with image 1`] = `
                             <Icon
                               aria-hidden="true"
                               className="bx--btn__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 20 20"
@@ -58390,7 +57876,6 @@ exports[`Storyshots Components|LeadSpace Small with image 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--btn__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -58807,7 +58292,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                           </span>
                                           <ForwardRef(ArrowRight20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 20 20"
@@ -58816,7 +58300,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -58907,7 +58390,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                           </span>
                                           <ForwardRef(ArrowRight20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 20 20"
@@ -58916,7 +58398,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -59007,7 +58488,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                           </span>
                                           <ForwardRef(Download20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 32 32"
@@ -59016,7 +58496,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -59167,7 +58646,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                         aria-hidden="true"
                                         aria-label="right arrow icon"
                                         className="bx--btn__icon"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 20 20"
@@ -59178,7 +58656,6 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                           aria-hidden="true"
                                           aria-label="right arrow icon"
                                           className="bx--btn__icon"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -59515,7 +58992,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                           </span>
                                           <ForwardRef(ArrowRight20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 20 20"
@@ -59524,7 +59000,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -59615,7 +59090,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                           </span>
                                           <ForwardRef(ArrowRight20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 20 20"
@@ -59624,7 +59098,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -59715,7 +59188,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                           </span>
                                           <ForwardRef(Download20)>
                                             <Icon
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               viewBox="0 0 32 32"
@@ -59724,7 +59196,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -59875,7 +59346,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                         aria-hidden="true"
                                         aria-label="right arrow icon"
                                         className="bx--btn__icon"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 20 20"
@@ -59886,7 +59356,6 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                           aria-hidden="true"
                                           aria-label="right arrow icon"
                                           className="bx--btn__icon"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -59991,7 +59460,7 @@ exports[`Storyshots Components|LightboxMediaViewer Default 1`] = `
               </span>
               <div
                 className="bx--modal-container"
-                role="dialog"
+                tabIndex={-1}
               >
                 <ExpressiveModalCloseBtn
                   iconDescription="Close"
@@ -60012,7 +59481,6 @@ exports[`Storyshots Components|LightboxMediaViewer Default 1`] = `
                       <Icon
                         aria-label="Close"
                         className="bx--modal-close__icon"
-                        fill="currentColor"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
                         viewBox="0 0 32 32"
@@ -60022,7 +59490,6 @@ exports[`Storyshots Components|LightboxMediaViewer Default 1`] = `
                         <svg
                           aria-label="Close"
                           className="bx--modal-close__icon"
-                          fill="currentColor"
                           focusable="false"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
@@ -60218,7 +59685,7 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                 </span>
                 <div
                   className="bx--modal-container"
-                  role="dialog"
+                  tabIndex={-1}
                 >
                   <ExpressiveModalCloseBtn
                     iconDescription="Close"
@@ -60239,7 +59706,6 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                         <Icon
                           aria-label="Close"
                           className="bx--modal-close__icon"
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           viewBox="0 0 32 32"
@@ -60249,7 +59715,6 @@ exports[`Storyshots Components|LightboxMediaViewer Embedded Video Player 1`] = `
                           <svg
                             aria-label="Close"
                             className="bx--modal-close__icon"
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -60535,7 +60000,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -60551,7 +60015,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -60711,7 +60174,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -60727,7 +60189,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -60890,7 +60351,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -60906,7 +60366,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -61085,7 +60544,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -61101,7 +60559,6 @@ exports[`Storyshots Components|LinkList Default 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -61288,7 +60745,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                 </span>
                                 <ForwardRef(ArrowRight20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 20 20"
@@ -61297,7 +60753,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -61388,7 +60843,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                 </span>
                                 <ForwardRef(Download20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -61397,7 +60851,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -61491,7 +60944,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                 </span>
                                 <ForwardRef(Launch20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -61500,7 +60952,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -61594,7 +61045,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                   </span>
                                   <ForwardRef(PlayOutline20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -61603,7 +61053,6 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -61771,7 +61220,6 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                                 </span>
                                 <ForwardRef(ArrowRight20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 20 20"
@@ -61780,7 +61228,6 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -61872,7 +61319,6 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                                 </span>
                                 <ForwardRef(Download20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -61881,7 +61327,6 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62062,7 +61507,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                 </span>
                                 <ForwardRef(ArrowLeft20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -62071,7 +61515,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62163,7 +61606,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                 </span>
                                 <ForwardRef(Download20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -62172,7 +61614,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62267,7 +61708,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                 </span>
                                 <ForwardRef(Launch20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -62276,7 +61716,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62371,7 +61810,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                   </span>
                                   <ForwardRef(PlayOutline20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -62380,7 +61818,6 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -62562,7 +61999,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 </span>
                                 <ForwardRef(ArrowLeft20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -62571,7 +62007,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62663,7 +62098,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 </span>
                                 <ForwardRef(Download20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -62672,7 +62106,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62767,7 +62200,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 </span>
                                 <ForwardRef(Launch20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -62776,7 +62208,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -62871,7 +62302,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                   </span>
                                   <ForwardRef(PlayOutline20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -62880,7 +62310,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -63087,7 +62516,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -63103,7 +62531,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -63263,7 +62690,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -63279,7 +62705,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -63442,7 +62867,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -63458,7 +62882,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -63637,7 +63060,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                     >
                                       <Icon
                                         className="bx--card__cta"
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         src={
@@ -63653,7 +63075,6 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                         <svg
                                           aria-hidden={true}
                                           className="bx--card__cta"
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -63746,7 +63167,6 @@ exports[`Storyshots Components|LinkwithIcon Default 1`] = `
               </span>
               <ForwardRef(ArrowRight20)>
                 <Icon
-                  fill="currentColor"
                   height={20}
                   preserveAspectRatio="xMidYMid meet"
                   viewBox="0 0 20 20"
@@ -63755,7 +63175,6 @@ exports[`Storyshots Components|LinkwithIcon Default 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    fill="currentColor"
                     focusable="false"
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
@@ -63830,7 +63249,7 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
           </span>
           <div
             className="bx--modal-container"
-            role="dialog"
+            tabIndex={-1}
           >
             <ModalHeader
               buttonOnClick={[Function]}
@@ -63858,7 +63277,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                   >
                     <Icon
                       className="bx--locale-modal__label-globe"
-                      fill="currentColor"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
                       viewBox="0 0 32 32"
@@ -63868,7 +63286,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                       <svg
                         aria-hidden={true}
                         className="bx--locale-modal__label-globe"
-                        fill="currentColor"
                         focusable="false"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
@@ -63895,7 +63312,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                   >
                     <Icon
                       className="bx--modal-close__icon"
-                      fill="currentColor"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
                       viewBox="0 0 32 32"
@@ -63905,7 +63321,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                       <svg
                         aria-hidden={true}
                         className="bx--modal-close__icon"
-                        fill="currentColor"
                         focusable="false"
                         height={20}
                         preserveAspectRatio="xMidYMid meet"
@@ -63974,7 +63389,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                           >
                             <Icon
                               className="bx--search-magnifier"
-                              fill="currentColor"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 16 16"
@@ -63984,7 +63398,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                               <svg
                                 aria-hidden={true}
                                 className="bx--search-magnifier"
-                                fill="currentColor"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -64024,7 +63437,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                           >
                             <ForwardRef(Close20)>
                               <Icon
-                                fill="currentColor"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
                                 viewBox="0 0 32 32"
@@ -64033,7 +63445,6 @@ exports[`Storyshots Components|Locale Modal Default 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  fill="currentColor"
                                   focusable="false"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
@@ -64715,7 +64126,6 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                           >
                                             <Icon
                                               className="bx--card__cta"
-                                              fill="currentColor"
                                               height={20}
                                               preserveAspectRatio="xMidYMid meet"
                                               src={
@@ -64731,7 +64141,6 @@ exports[`Storyshots Components|LogoGrid Default 1`] = `
                                               <svg
                                                 aria-hidden={true}
                                                 className="bx--card__cta"
-                                                fill="currentColor"
                                                 focusable="false"
                                                 height={20}
                                                 preserveAspectRatio="xMidYMid meet"
@@ -64852,7 +64261,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                     >
                       <ForwardRef(Menu20)>
                         <Icon
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           viewBox="0 0 20 20"
@@ -64861,7 +64269,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                         >
                           <svg
                             aria-hidden={true}
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -64966,7 +64373,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                             >
                               <ForwardRef(Search20)>
                                 <Icon
-                                  fill="currentColor"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 32 32"
@@ -64975,7 +64381,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                                 >
                                   <svg
                                     aria-hidden={true}
-                                    fill="currentColor"
                                     focusable="false"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
@@ -65006,7 +64411,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                             >
                               <ForwardRef(Close20)>
                                 <Icon
-                                  fill="currentColor"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 32 32"
@@ -65015,7 +64419,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                                 >
                                   <svg
                                     aria-hidden={true}
-                                    fill="currentColor"
                                     focusable="false"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
@@ -65089,7 +64492,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                             onOpen={[Function]}
                             open={false}
                             renderIcon={[Function]}
-                            selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                             style={
                               Object {
                                 "width": "3rem",
@@ -65126,7 +64528,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                                 >
                                   <ForwardRef(User20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -65135,7 +64536,6 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -65292,7 +64692,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                     >
                       <ForwardRef(Menu20)>
                         <Icon
-                          fill="currentColor"
                           height={20}
                           preserveAspectRatio="xMidYMid meet"
                           viewBox="0 0 20 20"
@@ -65301,7 +64700,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                         >
                           <svg
                             aria-hidden={true}
-                            fill="currentColor"
                             focusable="false"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
@@ -65576,7 +64974,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                             >
                               <ForwardRef(Search20)>
                                 <Icon
-                                  fill="currentColor"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 32 32"
@@ -65585,7 +64982,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                 >
                                   <svg
                                     aria-hidden={true}
-                                    fill="currentColor"
                                     focusable="false"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
@@ -65616,7 +65012,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                             >
                               <ForwardRef(Close20)>
                                 <Icon
-                                  fill="currentColor"
                                   height={20}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 32 32"
@@ -65625,7 +65020,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                 >
                                   <svg
                                     aria-hidden={true}
-                                    fill="currentColor"
                                     focusable="false"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
@@ -65699,7 +65093,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                             onOpen={[Function]}
                             open={false}
                             renderIcon={[Function]}
-                            selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                             style={
                               Object {
                                 "width": "3rem",
@@ -65736,7 +65129,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                 >
                                   <ForwardRef(User20)>
                                     <Icon
-                                      fill="currentColor"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
                                       viewBox="0 0 32 32"
@@ -65745,7 +65137,6 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        fill="currentColor"
                                         focusable="false"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
@@ -65942,7 +65333,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                       >
                         <ForwardRef(Menu20)>
                           <Icon
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 20 20"
@@ -65951,7 +65341,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -66081,7 +65470,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                               >
                                 <ForwardRef(Search20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -66090,7 +65478,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -66121,7 +65508,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                               >
                                 <ForwardRef(Close20)>
                                   <Icon
-                                    fill="currentColor"
                                     height={20}
                                     preserveAspectRatio="xMidYMid meet"
                                     viewBox="0 0 32 32"
@@ -66130,7 +65516,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                                   >
                                     <svg
                                       aria-hidden={true}
-                                      fill="currentColor"
                                       focusable="false"
                                       height={20}
                                       preserveAspectRatio="xMidYMid meet"
@@ -66204,7 +65589,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                               onOpen={[Function]}
                               open={false}
                               renderIcon={[Function]}
-                              selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                               style={
                                 Object {
                                   "width": "3rem",
@@ -66241,7 +65625,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                                   >
                                     <ForwardRef(User20)>
                                       <Icon
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 32 32"
@@ -66250,7 +65633,6 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                                       >
                                         <svg
                                           aria-hidden={true}
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -66410,7 +65792,6 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                       data-autoid="dds--pictogram-item__pictogram"
                       height={48}
                       preserveAspectRatio="xMidYMid meet"
-                      stroke="currentColor"
                       viewBox="0 0 48 48"
                       width={48}
                       xmlns="http://www.w3.org/2000/svg"
@@ -66423,7 +65804,6 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                         height={48}
                         preserveAspectRatio="xMidYMid meet"
                         role="img"
-                        stroke="currentColor"
                         viewBox="0 0 48 48"
                         width={48}
                         xmlns="http://www.w3.org/2000/svg"
@@ -66431,6 +65811,7 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                         <path
                           d="M37,32 H11c-1.1,0-2-0.9-2-2V13c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2v17C39,31.1,38.1,32,37,32z M17,37h14 M24,32v5 M9,27h30"
                           fill="none"
+                          stroke="#000"
                           strokeLinejoin="round"
                           strokeMiterlimit="10"
                           strokeWidth=".72"
@@ -66530,7 +65911,6 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                                     </span>
                                     <ForwardRef(ArrowRight20)>
                                       <Icon
-                                        fill="currentColor"
                                         height={20}
                                         preserveAspectRatio="xMidYMid meet"
                                         viewBox="0 0 20 20"
@@ -66539,7 +65919,6 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                                       >
                                         <svg
                                           aria-hidden={true}
-                                          fill="currentColor"
                                           focusable="false"
                                           height={20}
                                           preserveAspectRatio="xMidYMid meet"
@@ -66693,7 +66072,6 @@ exports[`Storyshots Components|Quote Default 1`] = `
                         </span>
                         <ForwardRef(ArrowRight20)>
                           <Icon
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 20 20"
@@ -66702,7 +66080,6 @@ exports[`Storyshots Components|Quote Default 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -66880,7 +66257,6 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
                             <Icon
                               aria-label="menu icon"
                               className="bx--tableofcontents__mobile__select__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 32 32"
@@ -66890,7 +66266,6 @@ exports[`Storyshots Components|Table of Contents Dynamic Items 1`] = `
                               <svg
                                 aria-label="menu icon"
                                 className="bx--tableofcontents__mobile__select__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"
@@ -67208,7 +66583,6 @@ exports[`Storyshots Components|Table of Contents Manually define Menu Items 1`] 
                           <Icon
                             aria-label="menu icon"
                             className="bx--tableofcontents__mobile__select__icon"
-                            fill="currentColor"
                             height={20}
                             preserveAspectRatio="xMidYMid meet"
                             viewBox="0 0 32 32"
@@ -67218,7 +66592,6 @@ exports[`Storyshots Components|Table of Contents Manually define Menu Items 1`] 
                             <svg
                               aria-label="menu icon"
                               className="bx--tableofcontents__mobile__select__icon"
-                              fill="currentColor"
                               focusable="false"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
@@ -67720,7 +67093,6 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                             <Icon
                               aria-label="menu icon"
                               className="bx--tableofcontents__mobile__select__icon"
-                              fill="currentColor"
                               height={20}
                               preserveAspectRatio="xMidYMid meet"
                               viewBox="0 0 32 32"
@@ -67730,7 +67102,6 @@ exports[`Storyshots Components|Table of Contents With Heading Content 1`] = `
                               <svg
                                 aria-label="menu icon"
                                 className="bx--tableofcontents__mobile__select__icon"
-                                fill="currentColor"
                                 focusable="false"
                                 height={20}
                                 preserveAspectRatio="xMidYMid meet"

--- a/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
+++ b/packages/styles/scss/components/content-block-cards/_content-block-cards.scss
@@ -10,6 +10,9 @@
 @import '../card-group/card-group';
 
 @mixin content-block-cards {
+  .#{$prefix}--modal.is-visible {
+    background-color: rgba(140, 140, 140, 1);
+  }
   .#{$prefix}--content-block-cards {
     &__content {
       .#{$prefix}--card__CTA {


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/issues/3260

### Description

When opening the video player modal on content block cards, you were able to see the parent page behind it. This fix gets rid of the transparency 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
