### PR TITLE
chore(lint): update .lintstagedrc

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,17 +2,14 @@
   "**/*.{js,ts,tsx}": [
     "prettier --write",
     "yarn lint:license:staged",
-    "yarn lint:scripts:staged",
-    "git add"
+    "yarn lint:scripts:staged"
   ],
   "**/*.scss": [
     "prettier --write",
     "yarn lint:license:staged",
-    "stylelint '**/*.scss' --config ./packages/stylelint-config-ibmdotcom",
-    "git add"
+    "stylelint '**/*.scss' --config ./packages/stylelint-config-ibmdotcom"
   ],
   "*.md": [
-    "prettier --write",
-    "git add"
+    "prettier --write"
   ]
 }


### PR DESCRIPTION
### Description

Newer version of `lint-staged` doesn't require `git add` in `.lintstagedrc`, and thus they are removed.

### Changelog

**Removed**

- `git add` in `.lintstagedrc`