### PR TITLE
fix(lightbox-media-viewer): fix the size

### DIFF
--- a/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
+++ b/packages/styles/scss/components/expressive-modal/_expressive-modal.scss
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@import '../../globals/vars';
 @import '../../globals/imports';
 
 @import 'carbon-components/scss/components/modal/modal';
@@ -15,25 +16,13 @@
 
 @mixin expressive-model {
   $modal: '.#{$prefix}--modal';
+  $button-size: carbon--rem(48px);
+  $icon-size: carbon--rem(20px);
+  $offset-close-icon: $carbon--spacing-07 - (($button-size - $icon-size) / 2);
 
+  :host(#{$dds-prefix}-modal),
   #{$modal}--expressive {
-    $button-size: carbon--rem(48px);
-    $icon-size: carbon--rem(20px);
-    $offset-close-icon: $carbon--spacing-07 - (($button-size - $icon-size) / 2);
-
     color: $text-01;
-
-    #{$modal}-content {
-      display: flex;
-      padding-left: 0;
-      padding-right: $button-size - $offset-close-icon;
-      margin-bottom: 0;
-      padding-top: 0;
-
-      h1 {
-        @include carbon--type-style('expressive-heading-04');
-      }
-    }
 
     #{$modal}-close {
       top: $offset-close-icon;
@@ -44,28 +33,48 @@
       padding: $carbon--spacing-08 $carbon--spacing-07 $carbon--spacing-07;
       min-height: $carbon--spacing-07 + $icon-size + $carbon--spacing-07;
     }
-    &--fullwidth {
+
+    #{$modal}-content {
+      display: flex;
+      padding-left: 0;
+      padding-right: $button-size - $offset-close-icon;
+      margin-bottom: 0;
+      padding-top: 0;
+    }
+  }
+
+  :host(#{$dds-prefix}-modal-heading),
+  #{$modal}--expressive #{$modal}-content h1 {
+    @include carbon--type-style('expressive-heading-04');
+  }
+
+  :host(#{$dds-prefix}-modal)[expressive-size='full-width'],
+  #{$modal}--expressive--fullwidth {
+    #{$modal}-container {
+      padding: $carbon--spacing-07;
+    }
+    #{$modal}-close {
+      top: 0;
+      right: 0;
+    }
+    @include carbon--breakpoint('md') {
       #{$modal}-container {
-        padding: $carbon--spacing-07;
-      }
-      #{$modal}-content {
-        padding-right: 0;
-        height: auto;
-        min-height: carbon--rem(500px);
-      }
-      #{$modal}-close {
-        top: 0;
-        right: 0;
-      }
-      @include carbon--breakpoint('md') {
-        #{$modal}-container {
-          width: calc(100% - #{$carbon--spacing-07});
-          max-width: calc(100% - #{$carbon--spacing-07});
-          height: calc(100% - #{$carbon--spacing-07});
-          max-height: none;
-        }
+        width: calc(100% - #{$carbon--spacing-07});
+        max-width: calc(100% - #{$carbon--spacing-07});
+        height: calc(100% - #{$carbon--spacing-07});
+        max-height: none;
       }
     }
+  }
+
+  :host(#{$dds-prefix}-modal[expressive-size='full-width'])
+    ::slotted(#{$dds-prefix}-modal-body),
+  :host(#{$dds-prefix}-modal[expressive-size='full-width'])
+    ::slotted(#{$dds-prefix}-lightbox-media-viewer-body),
+  #{$modal}--expressive--fullwidth #{$modal}-content {
+    padding-right: 0;
+    height: auto;
+    min-height: carbon--rem(500px);
   }
 }
 

--- a/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
+++ b/packages/styles/scss/components/lightbox-media-viewer/_lightbox-media-viewer.scss
@@ -34,17 +34,45 @@
       width: 100%;
     }
 
-    &__container {
-      display: flex;
-      width: 100%;
-      padding-bottom: 0;
-
-      @include carbon--breakpoint-down('lg') {
-        display: block;
+    @include carbon--breakpoint('md') {
+      .#{$prefix}--model-container {
+        padding-top: $carbon--layout-05;
+        padding-bottom: 0;
       }
     }
 
-    &__row {
+    @include carbon--breakpoint('lg') {
+      .#{$prefix}--model-container {
+        padding-top: $carbon--layout-04;
+        padding-bottom: $carbon--spacing-05;
+      }
+
+      .#{$prefix}--modal-close {
+        top: 0;
+        right: 0;
+      }
+    }
+  }
+
+  :host(#{$dds-prefix}-lightbox-media-viewer-body),
+  .#{$prefix}--lightbox-media-viewer__container {
+    display: flex;
+    width: 100%;
+    padding-bottom: 0;
+
+    @include carbon--breakpoint-down('lg') {
+      display: block;
+    }
+
+    @include carbon--breakpoint('lg') {
+      padding-top: 0;
+      padding-bottom: $carbon--spacing-05;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .#{$prefix}--lightbox-media-viewer__row {
       @include carbon--make-row(0);
 
       flex-flow: column nowrap;
@@ -54,7 +82,8 @@
         flex-direction: row;
       }
     }
-    &__media {
+
+    .#{$prefix}--lightbox-media-viewer__media {
       @include carbon--breakpoint-down('lg') {
         position: relative;
         height: 100%;
@@ -72,76 +101,52 @@
         flex: auto;
         align-items: center;
       }
-    }
 
-    &__media-description {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-    }
-
-    &__content {
-      max-width: 95%;
-      @include carbon--type-style('body-long-02');
       @include carbon--breakpoint('lg') {
-        overflow: auto;
-      }
-
-      &__title {
-        padding-top: $carbon--spacing-05;
-        padding-bottom: $carbon--spacing-07;
-
-        @include carbon--type-style('expressive-heading-03');
-      }
-
-      &__desc {
-        color: $text-02;
-
-        @include carbon--type-style('body-long-02');
-      }
-
-      @include carbon--breakpoint-up('lg') {
-        padding-right: 0;
-        padding-left: $carbon--spacing-07;
-      }
-    }
-
-    @include carbon--breakpoint('md') {
-      .#{$prefix}--model-container {
-        padding-top: $carbon--layout-05;
-        padding-bottom: 0;
-      }
-    }
-    @include carbon--breakpoint('lg') {
-      .#{$prefix}--model-container {
-        padding-top: $carbon--layout-04;
-        padding-bottom: $carbon--spacing-05;
-      }
-
-      &__media {
         @include carbon--make-col-ready;
         @include carbon--make-col(12, 16);
       }
+    }
 
-      &__media-description {
+    .#{$prefix}--lightbox-media-viewer__media-description {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+
+      @include carbon--breakpoint('lg') {
         @include carbon--make-col-ready;
         @include carbon--make-col(4, 16);
 
         display: flex;
       }
-      .#{$prefix}--modal-close {
-        top: 0;
-        right: 0;
+    }
+
+    .#{$prefix}--lightbox-media-viewer__content {
+      max-width: 95%;
+      @include carbon--type-style('body-long-02');
+      @include carbon--breakpoint('lg') {
+        overflow: auto;
+        padding-right: 0;
+        padding-left: $carbon--spacing-07;
       }
-      &__container {
-        padding-top: 0;
-        padding-bottom: $carbon--spacing-05;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-      }
-      &__title,
-      &__desc {
+    }
+
+    .#{$prefix}--lightbox-media-viewer__content__title {
+      padding-top: $carbon--spacing-05;
+      padding-bottom: $carbon--spacing-07;
+
+      @include carbon--type-style('expressive-heading-03');
+    }
+
+    .#{$prefix}--lightbox-media-viewer__content__desc {
+      color: $text-02;
+
+      @include carbon--type-style('body-long-02');
+    }
+
+    .#{$prefix}--lightbox-media-viewer__title,
+    .#{$prefix}--lightbox-media-viewer__desc {
+      @include carbon--breakpoint('lg') {
         display: flex;
         max-width: 95%;
         height: 100%;

--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
@@ -32,7 +32,12 @@ export const EmbeddedVideoPlayer = ({ parameters }) => {
       ${styles}
     </style>
     <dds-lightbox-video-player-container ?hide-caption="${hideCaption}" video-id="${videoId}">
-      <dds-modal ?open="${open}" size="full-width" @dds-modal-beingclosed="${handleBeforeClose}" @dds-modal-closed="${onClose}">
+      <dds-modal
+        ?open="${open}"
+        expressive-size="full-width"
+        @dds-modal-beingclosed="${handleBeforeClose}"
+        @dds-modal-closed="${onClose}"
+      >
         <bx-modal-close-button></bx-modal-close-button>
         <dds-lightbox-media-viewer-body></dds-lightbox-media-viewer-body>
       </dds-modal>

--- a/packages/web-components/src/components/modal/modal.scss
+++ b/packages/web-components/src/components/modal/modal.scss
@@ -12,41 +12,28 @@
 
 :host(#{$dds-prefix}-modal) {
   @extend :host(#{$prefix}-modal);
-  @extend .#{$prefix}--modal--expressive;
 
   &[open] {
     @extend :host(#{$prefix}-modal[open]);
   }
 
   &[expressive-size='full-width'] {
-    ::slotted(#{$dds-prefix}-modal-body),
-    ::slotted(#{$dds-prefix}-lightbox-media-viewer-body) {
-      padding-right: 0;
-      height: auto;
-    }
-
     ::slotted(#{$dds-prefix}-lightbox-media-viewer-body) {
       height: 100%;
       overflow: auto;
     }
+  }
 
-    .#{$prefix}--modal-close {
-      top: 0;
-      right: 0;
-    }
-
-    @include carbon--breakpoint('md') {
-      .#{$prefix}--modal-container {
-        width: calc(100% - #{$carbon--spacing-07});
-        max-width: calc(100% - #{$carbon--spacing-07});
-        height: calc(100% - #{$carbon--spacing-07});
-        max-height: none;
-      }
-    }
+  .#{$prefix}--modal-content {
+    flex-direction: column;
   }
 
   .#{$dds-prefix}-ce--modal__hedaer--with-body {
     margin-bottom: $spacing-05;
+  }
+
+  .#{$dds-prefix}-ce--modal__body {
+    width: 100%;
   }
 
   .#{$dds-prefix}-ce--modal__body--with-footer {
@@ -54,8 +41,13 @@
   }
 }
 
-:host(#{$dds-prefix}-modal-header) {
+:host(#{$dds-prefix}-modal-header),
+:host(#{$dds-prefix}-modal-heading),
+:host(#{$dds-prefix}-modal-footer) {
   display: block;
+}
+
+:host(#{$dds-prefix}-modal-header) {
   padding: 0;
 }
 
@@ -69,27 +61,7 @@
 :host(#{$dds-prefix}-lightbox-media-viewer-body) {
   @include carbon--type-style('body-long-02');
 
-  $button-size: carbon--rem(48px);
-  $icon-size: carbon--rem(20px);
-  $offset-close-icon: $carbon--spacing-07 - (($button-size - $icon-size) / 2);
-
-  display: flex;
-  padding-left: 0;
-  padding-right: $button-size - $offset-close-icon;
-  margin-bottom: 0;
-  padding-top: 0;
-
   *:last-child {
     padding-bottom: 0;
   }
-}
-
-:host(#{$dds-prefix}-modal-footer) {
-  display: block;
-}
-
-:host(#{$dds-prefix}-modal-heading) {
-  @include carbon--type-style('expressive-heading-04');
-
-  display: block;
 }

--- a/packages/web-components/src/components/modal/modal.scss
+++ b/packages/web-components/src/components/modal/modal.scss
@@ -24,8 +24,13 @@
     }
   }
 
+  .#{$prefix}--modal-container {
+    grid-template-rows: 1fr;
+  }
+
   .#{$prefix}--modal-content {
-    flex-direction: column;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
   }
 
   .#{$dds-prefix}-ce--modal__hedaer--with-body {

--- a/packages/web-components/src/components/modal/modal.ts
+++ b/packages/web-components/src/components/modal/modal.ts
@@ -138,6 +138,7 @@ class DDSModal extends StableSelectorMixin(BXModal) {
   protected _renderBody(): TemplateResult | SVGTemplateResult | void {
     const { _hasBody: hasBody, _hasFooter: hasFooter } = this;
     const bodyClasses = classMap({
+      [`${ddsPrefix}-ce--modal__body`]: true,
       [`${ddsPrefix}-ce--modal__body--with-footer`]: hasBody && hasFooter,
     });
     return html`
@@ -185,7 +186,9 @@ class DDSModal extends StableSelectorMixin(BXModal) {
         @click="${handleClickContainerExpressive}"
         @slotchange="${handleSlotChange}"
       >
-        ${this._renderHeader()}${this._renderBody()}${this._renderFooter()}
+        <div class="bx--modal-content">
+          ${this._renderHeader()}${this._renderBody()}${this._renderFooter()}
+        </div>
       </div>
       <a id="end-sentinel" class="${prefix}--visually-hidden" href="javascript:void 0" role="navigation"></a>
     `;

--- a/packages/web-components/tests/snapshots/dds-lightbox-video-player-container.md
+++ b/packages/web-components/tests/snapshots/dds-lightbox-video-player-container.md
@@ -6,7 +6,8 @@
 <dds-lightbox-video-player-container video-id="video-id-foo">
   <dds-modal
     data-auto-id="dds--expressive-modal"
-    size="full-width"
+    expressive-size="full-width"
+    size=""
     tabindex="0"
   >
     <bx-modal-close-button

--- a/packages/web-components/tests/snapshots/dds-locale-modal.md
+++ b/packages/web-components/tests/snapshots/dds-locale-modal.md
@@ -17,22 +17,24 @@
   role="dialog"
   tabindex="-1"
 >
-  <dds-modal-header>
-    <dds-modal-close-button
-      role="button"
-      tabindex="0"
-    >
-    </dds-modal-close-button>
-    <dds-modal-heading>
-    </dds-modal-heading>
-  </dds-modal-header>
-  <div class="bx--locale-modal bx--modal-content">
-    <slot name="regions-selector">
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <dds-modal-header>
+      <dds-modal-close-button
+        role="button"
+        tabindex="0"
+      >
+      </dds-modal-close-button>
+      <dds-modal-heading>
+      </dds-modal-heading>
+    </dds-modal-header>
+    <div class="bx--locale-modal bx--modal-content">
+      <slot name="regions-selector">
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a
@@ -60,28 +62,30 @@
   role="dialog"
   tabindex="-1"
 >
-  <dds-modal-header>
-    <dds-modal-close-button
-      role="button"
-      tabindex="0"
-    >
-    </dds-modal-close-button>
-    <dds-modal-heading>
-      <p class="bx--modal-header__label bx--type-delta">
-        lang-display-foo
-      </p>
-      <p class="bx--modal-header__heading bx--type-beta">
-        header-title-foo
-      </p>
-    </dds-modal-heading>
-  </dds-modal-header>
-  <div class="bx--locale-modal bx--modal-content">
-    <slot name="regions-selector">
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <dds-modal-header>
+      <dds-modal-close-button
+        role="button"
+        tabindex="0"
+      >
+      </dds-modal-close-button>
+      <dds-modal-heading>
+        <p class="bx--modal-header__label bx--type-delta">
+          lang-display-foo
+        </p>
+        <p class="bx--modal-header__heading bx--type-beta">
+          header-title-foo
+        </p>
+      </dds-modal-heading>
+    </dds-modal-header>
+    <div class="bx--locale-modal bx--modal-content">
+      <slot name="regions-selector">
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a
@@ -109,33 +113,35 @@
   role="dialog"
   tabindex="-1"
 >
-  <dds-modal-header slot="header">
-    <dds-modal-close-button
-      role="button"
-      tabindex="0"
-    >
-    </dds-modal-close-button>
-    <dds-modal-heading>
-      <button
-        class="bx--modal-header__label bx--type-delta"
-        data-autoid="dds--locale-modal__region-back"
-        part="back-button"
-      >
-        header-title-foo
-      </button>
-      <p
-        class="bx--modal-header__heading bx--type-beta"
+  <div class="bx--modal-content">
+    <dds-modal-header slot="header">
+      <dds-modal-close-button
+        role="button"
         tabindex="0"
       >
-        region-foo
-      </p>
-    </dds-modal-heading>
-  </dds-modal-header>
-  <slot name="locales-selector">
-  </slot>
-  <div>
-    <slot name="footer">
+      </dds-modal-close-button>
+      <dds-modal-heading>
+        <button
+          class="bx--modal-header__label bx--type-delta"
+          data-autoid="dds--locale-modal__region-back"
+          part="back-button"
+        >
+          header-title-foo
+        </button>
+        <p
+          class="bx--modal-header__heading bx--type-beta"
+          tabindex="0"
+        >
+          region-foo
+        </p>
+      </dds-modal-heading>
+    </dds-modal-header>
+    <slot name="locales-selector">
     </slot>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a

--- a/packages/web-components/tests/snapshots/dds-modal.md
+++ b/packages/web-components/tests/snapshots/dds-modal.md
@@ -17,17 +17,19 @@
   role="dialog"
   tabindex="-1"
 >
-  <div class="dds-ce--modal__hedaer--with-body">
-    <slot name="header">
-    </slot>
-  </div>
-  <div class="dds-ce--modal__body--with-footer">
-    <slot>
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <div class="dds-ce--modal__hedaer--with-body">
+      <slot name="header">
+      </slot>
+    </div>
+    <div class="dds-ce--modal__body dds-ce--modal__body--with-footer">
+      <slot>
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a
@@ -55,17 +57,19 @@
   role="dialog"
   tabindex="-1"
 >
-  <div class="dds-ce--modal__hedaer--with-body">
-    <slot name="header">
-    </slot>
-  </div>
-  <div class="dds-ce--modal__body--with-footer">
-    <slot>
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <div class="dds-ce--modal__hedaer--with-body">
+      <slot name="header">
+      </slot>
+    </div>
+    <div class="dds-ce--modal__body dds-ce--modal__body--with-footer">
+      <slot>
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a
@@ -95,17 +99,19 @@
   role="dialog"
   tabindex="-1"
 >
-  <div>
-    <slot name="header">
-    </slot>
-  </div>
-  <div>
-    <slot>
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <div>
+      <slot name="header">
+      </slot>
+    </div>
+    <div class="dds-ce--modal__body">
+      <slot>
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a
@@ -133,17 +139,19 @@
   role="dialog"
   tabindex="-1"
 >
-  <div class="dds-ce--modal__hedaer--with-body">
-    <slot name="header">
-    </slot>
-  </div>
-  <div>
-    <slot>
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <div class="dds-ce--modal__hedaer--with-body">
+      <slot name="header">
+      </slot>
+    </div>
+    <div class="dds-ce--modal__body">
+      <slot>
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a
@@ -171,17 +179,19 @@
   role="dialog"
   tabindex="-1"
 >
-  <div class="dds-ce--modal__hedaer--with-body">
-    <slot name="header">
-    </slot>
-  </div>
-  <div>
-    <slot>
-    </slot>
-  </div>
-  <div>
-    <slot name="footer">
-    </slot>
+  <div class="bx--modal-content">
+    <div class="dds-ce--modal__hedaer--with-body">
+      <slot name="header">
+      </slot>
+    </div>
+    <div class="dds-ce--modal__body">
+      <slot>
+      </slot>
+    </div>
+    <div>
+      <slot name="footer">
+      </slot>
+    </div>
   </div>
 </div>
 <a


### PR DESCRIPTION
### Related Ticket(s)

Refs #3349.

### Description

This change fixes the size of lightbox media viewer by making sure the correct attribute of `<dds-modal>` is used.

This change also does:

* Making sure lightbox media viewer is vertically scrollable when screen real estate is big horizontally, but small vertically.
* Attempt to best reuse CSS between React and Web Components versions of modal and lightbox media viewer, by eliminating BEM concatenation.

### Changelog

**Changed**

- A fix to the size of lightbox media viewer.
- A change to make sure lightbox media viewer is vertically scrollable when screen real estate is big horizontally, but small vertically.
- Attempts to best reuse CSS between React and Web Components versions of modal and lightbox media viewer, by eliminating BEM concatenation.