### PR TITLE
fix(cta): prevent lightbox from opening for non-video

### DIFF
--- a/packages/web-components/src/components/cta/__tests__/cta-container.test.ts
+++ b/packages/web-components/src/components/cta/__tests__/cta-container.test.ts
@@ -199,7 +199,7 @@ describe('dds-cta-container', function() {
       );
       await Promise.resolve();
       const ctaContainer = document.querySelector('dds-cta-container');
-      ctaContainer!.dispatchEvent(new CustomEvent('dds-cta-run-action', { detail: { href: '0_uka1msg4' } }));
+      ctaContainer!.dispatchEvent(new CustomEvent('dds-cta-run-action', { detail: { href: '0_uka1msg4', type: 'video' } }));
       await Promise.resolve();
       const { modalRenderRoot } = document.querySelector('dds-cta-container') as any;
       expect((modalRenderRoot!.querySelector('dds-modal') as DDSModal).open).toBe(true);

--- a/packages/web-components/src/components/cta/cta-container.ts
+++ b/packages/web-components/src/components/cta/cta-container.ts
@@ -96,8 +96,11 @@ class DDSCTAContainer extends ModalRenderMixin(HybridRenderMixin(LitElement)) {
    * @param event The event.
    */
   private _handleRunAction(event: CustomEvent) {
-    this._currentVideoId = event.detail.href;
-    this.requestUpdate();
+    const { href, type } = event.detail;
+    if (type === CTA_TYPE.VIDEO) {
+      this._currentVideoId = href;
+      this.requestUpdate();
+    }
   }
 
   /**

--- a/packages/web-components/src/globals/internal/link.ts
+++ b/packages/web-components/src/globals/internal/link.ts
@@ -23,6 +23,11 @@ class DDSLink extends BXLink {
   protected _linkNode?: HTMLAnchorElement | HTMLParagraphElement;
 
   /**
+   * Handles `click` event on the `<a>`.
+   */
+  protected _handleClickLink() {} // eslint-disable-line class-methods-use-this
+
+  /**
    * @returns The inner content.
    */
   // eslint-disable-next-line class-methods-use-this
@@ -33,7 +38,7 @@ class DDSLink extends BXLink {
   }
 
   render() {
-    const { disabled, download, href, hreflang, ping, rel, target, type } = this;
+    const { disabled, download, href, hreflang, ping, rel, target, type, _handleClickLink: handleClickLink } = this;
     const classes = classMap({
       [`${prefix}--link`]: true,
       [`${prefix}--link--disabled`]: disabled,
@@ -50,6 +55,7 @@ class DDSLink extends BXLink {
         rel="${ifNonNull(rel)}"
         target="${ifNonNull(target)}"
         type="${ifNonNull(type)}"
+        @click="${handleClickLink}"
       >
         ${this._renderInner()}
       </a>


### PR DESCRIPTION
### Related Ticket(s)

Refs #3440.

### Description

This change

### Changelog

**Changed**

- A fix to ensure lightbox won't open upon clicking link unless the CTA type is video.