### PR TITLE
fix(MegaMenu): add padding to the view all cta focus state

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -172,10 +172,14 @@
       border-top: carbon--rem(1px) solid $ui-03;
       height: $spacing-09;
 
-      &:hover {
-        border-top: carbon--rem(1px) solid transparent;
+      &:hover,
+      &:focus {
         margin: 0;
         padding: 0 $spacing-05;
+      }
+
+      &:hover {
+        border-top: carbon--rem(1px) solid transparent;
         color: $hover-primary-text;
       }
     }


### PR DESCRIPTION
### Related Ticket(s)

Mega menu desktop – CTA focus state #3498

### Description

Make sure padding is applied on focus state of the view all ctas

<img width="1596" alt="Screen Shot 2020-08-11 at 3 19 29 PM" src="https://user-images.githubusercontent.com/54281166/89939852-9c550500-dbe6-11ea-85c3-6f369b90dcac.png">

### Changelog

**Changed**

- add padding to :focus pseudo class


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
