### PR TITLE
fix(Masthead): hide left nav from screen readers when not displayed

### DIFF
--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -145,23 +145,25 @@
 :host(#{$dds-prefix}-left-nav) {
   @extend :host(#{$prefix}-side-nav);
 
-  display: block;
   overflow: auto;
   margin-top: calc(#{mini-units(6)} + 1px);
   height: calc(100% - #{mini-units(6)} - 1px);
 
   &[usage-mode='header-nav'],
   &[collapse-mode][usage-mode='header-nav'] {
+    display: none;
     width: 0;
   }
 
   &[expanded][usage-mode='header-nav'],
   &[collapse-mode][expanded][usage-mode='header-nav'] {
     @include carbon--breakpoint-down('lg') {
+      display: block;
       width: mini-units(32);
     }
 
     @include carbon--breakpoint-down('md') {
+      display: block;
       max-width: 100vw;
       width: 100vw;
     }


### PR DESCRIPTION
### Related Ticket(s)

#3159

### Description

Screen readers were picking up collapsed left nav menu items even when collapsed or responsively hidden. Setting the display to `block` when the left nav is shown; otherwise `none`.

### Changelog

**Changed**

- Fixed web-component masthead styles
