### PR TITLE
fix(docs): fixed codesandbox links pointing to old folders

### DIFF
--- a/packages/react/src/components/CTASection/README.stories.mdx
+++ b/packages/react/src/components/CTASection/README.stories.mdx
@@ -8,10 +8,10 @@ import CTASection from './CTASection';
 > section or page with specific calls to action.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/CTASection)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CTASection)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/CTASection)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CTASection)
 
 ## Getting started
 

--- a/packages/react/src/components/CalloutWithMedia/README.stories.mdx
+++ b/packages/react/src/components/CalloutWithMedia/README.stories.mdx
@@ -8,10 +8,10 @@ import CalloutWithMedia from '../CalloutWithMedia/CalloutWithMedia';
 > `Content Block Simple`.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/CalloutWithMedia)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CalloutWithMedia)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/CalloutWithMedia)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CalloutWithMedia)
 
 ## Getting started
 

--- a/packages/react/src/components/CardSectionImages/README.stories.mdx
+++ b/packages/react/src/components/CardSectionImages/README.stories.mdx
@@ -8,10 +8,10 @@ import CardSectionImages from './CardSectionImages';
 > presented in a section with a left-column header.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/CardSectionImages)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardSectionImages)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/CardSectionImages)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardSectionImages)
 
 ## Getting started
 

--- a/packages/react/src/components/CardSectionSimple/README.stories.mdx
+++ b/packages/react/src/components/CardSectionSimple/README.stories.mdx
@@ -8,10 +8,10 @@ import CardSectionSimple from './CardSectionSimple';
 > a section with a left-column header.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/CardSectionSimple)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardSectionSimple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/CardSectionSimple)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/CardSectionSimple)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentBlockCards/README.stories.mdx
+++ b/packages/react/src/components/ContentBlockCards/README.stories.mdx
@@ -8,10 +8,10 @@ import ContentBlockCards from './ContentBlockCards';
 > includes a single `CardGroup`.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockCards)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockCards)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockCards)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockCards)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentBlockMedia/README.stories.mdx
+++ b/packages/react/src/components/ContentBlockMedia/README.stories.mdx
@@ -8,10 +8,10 @@ import ContentBlockMedia from './ContentBlockMedia';
 > includes a number of `Content Group - Simple`, and ends with a `Feature Card`.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockMedia)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockMedia)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockMedia)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockMedia)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentBlockMixed/README.stories.mdx
+++ b/packages/react/src/components/ContentBlockMixed/README.stories.mdx
@@ -9,10 +9,10 @@ import ContentBlockMixed from './ContentBlockMixed';
 > patterns to be included.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockMixed)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockMixed)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockMixed)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockMixed)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentBlockSegmented/README.stories.mdx
+++ b/packages/react/src/components/ContentBlockSegmented/README.stories.mdx
@@ -8,10 +8,10 @@ import ContentBlockSegmented from './ContentBlockSegmented';
 > be presented at once.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockSegmented)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockSegmented)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockSegmented)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockSegmented)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentBlockSimple/README.stories.mdx
+++ b/packages/react/src/components/ContentBlockSimple/README.stories.mdx
@@ -8,10 +8,10 @@ import ContentBlockSimple from './ContentBlockSimple';
 > includes a single `ContentItem`, optional media (image), and ends with a CTA.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockSimple)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockSimple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentBlockSimple)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentBlockSimple)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentGroupCards/README.stories.mdx
+++ b/packages/react/src/components/ContentGroupCards/README.stories.mdx
@@ -7,10 +7,10 @@ import ContentGroupCards from './ContentGroupCards';
 > The Content Group Cards pattern is to be utilized within IBM.com.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentGroupCards)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentGroupCards)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentGroupCards)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentGroupCards)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentGroupHorizontal/README.stories.mdx
+++ b/packages/react/src/components/ContentGroupHorizontal/README.stories.mdx
@@ -9,10 +9,10 @@ import ContentGroupHorizontal from './ContentGroupHorizontal';
 > content items.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentItemHorizontal)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentItemHorizontal)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentItemHorizontal)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentItemHorizontal)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentGroupPictograms/README.stories.mdx
+++ b/packages/react/src/components/ContentGroupPictograms/README.stories.mdx
@@ -7,10 +7,10 @@ import ContentGroupPictograms from './ContentGroupPictograms';
 > The Content Group — with Pictograms pattern is to be utilized within IBM.com.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentGroupPictograms)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentGroupPictograms)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentGroupPictograms)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentGroupPictograms)
 
 ## Getting started
 

--- a/packages/react/src/components/ContentGroupSimple/README.stories.mdx
+++ b/packages/react/src/components/ContentGroupSimple/README.stories.mdx
@@ -8,10 +8,10 @@ import ContentGroupSimple from './ContentGroupSimple';
 > optional CTA Component, and an optional media (image or video).
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentGroupSimple)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentGroupSimple)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/ContentGroupSimple)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/ContentGroupSimple)
 
 ## Getting started
 

--- a/packages/react/src/components/FeatureCardBlockLarge/README.stories.mdx
+++ b/packages/react/src/components/FeatureCardBlockLarge/README.stories.mdx
@@ -7,10 +7,10 @@ import FeatureCardBlockLarge from './FeatureCardBlockLarge';
 > The Feature Card Block Large pattern is to be utilized within IBM.com.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/FeatureCardBlockLarge)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/FeatureCardBlockLarge)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/FeatureCardBlockLarge)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/FeatureCardBlockLarge)
 
 ## Getting started
 

--- a/packages/react/src/components/FeatureCardBlockMedium/README.stories.mdx
+++ b/packages/react/src/components/FeatureCardBlockMedium/README.stories.mdx
@@ -7,10 +7,10 @@ import FeatureCardBlockMedium from './FeatureCardBlockMedium';
 > The Feature Card Block Medium pattern is to be utilized within IBM.com.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/FeatureCardBlockMedium)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/FeatureCardBlockMedium)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/FeatureCardBlockMedium)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/FeatureCardBlockMedium)
 
 ## Getting started
 

--- a/packages/react/src/components/LeadSpace/README.stories.mdx
+++ b/packages/react/src/components/LeadSpace/README.stories.mdx
@@ -7,10 +7,10 @@ import LeadSpace from './LeadSpace';
 > The Lead Space pattern is to be utilized within IBM.com.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/Leadspace)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Leadspace)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/sections/Leadspace)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/Leadspace)
 
 ## Getting started
 

--- a/packages/react/src/components/LeadSpaceBlock/README.stories.mdx
+++ b/packages/react/src/components/LeadSpaceBlock/README.stories.mdx
@@ -8,10 +8,10 @@ import LeadSpaceBlock from './LeadSpaceBlock';
 > this pattern, and allows to select media with link lists followed by a button.
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/LeadSpaceBlock)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LeadSpaceBlock)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/LeadSpaceBlock)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LeadSpaceBlock)
 
 ## Getting started
 

--- a/packages/react/src/components/LogoGrid/README.stories.mdx
+++ b/packages/react/src/components/LogoGrid/README.stories.mdx
@@ -9,10 +9,10 @@ import LogoGrid from './LogoGrid';
 > [Carbon white theme](https://www.carbondesignsystem.com/guidelines/themes/overview#default-theme).
 
 > 💡 Check our
-> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/LogoGrid)
+> [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LogoGrid)
 > example implementation.
 
-[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/patterns/blocks/LogoGrid)
+[![Edit @carbon/ibmdotcom-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react/examples/codesandbox/components/LogoGrid)
 
 ## Getting started
 


### PR DESCRIPTION
### Related Ticket(s)

#3541 

### Description

Fixed codesandbox links on docs that were pointing to the patterns folder.