### PR TITLE
fix(MegaMenu): change overflow scroll style from x to y

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -38,7 +38,7 @@
   }
 
   .#{$prefix}--masthead__megamenu {
-    overflow-x: scroll;
+    overflow-y: scroll;
     background-color: $ui-background;
 
     @include box-shadow;


### PR DESCRIPTION
### Related Ticket(s)

Component: Mega Menu - greyed out Horizontal scroll bar is visible on all 5 menu drop down list. #3543

### Description

`overflow-y` should be set to scroll instead of `overflow-x` which was causing uneccessary horizontal scroll for megamenu to appear.

Occurs in windows chrome

BEFORE:
<img width="1462" alt="Screen Shot 2020-08-12 at 10 59 11 PM" src="https://user-images.githubusercontent.com/54281166/90093621-03afa980-dcfa-11ea-8021-abe82ed9345a.png">

AFTER:
<img width="1676" alt="Screen Shot 2020-08-12 at 3 39 28 PM" src="https://user-images.githubusercontent.com/54281166/90093627-07433080-dcfa-11ea-8b84-426cfecdb1c7.png">


### Changelog

**Changed**

- set `overflow-y` to scroll instead of `overflow-x`

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
