### PR TITLE
chore(services): introduce REST cache

### DIFF
--- a/packages/services/src/services/Locale/__tests__/Locale.test.js
+++ b/packages/services/src/services/Locale/__tests__/Locale.test.js
@@ -42,6 +42,8 @@ describe('LocaleAPI', () => {
     );
 
     root.digitalData = mockDigitalDataResponse;
+
+    LocaleAPI.clearCache();
   });
 
   afterEach(() => {
@@ -124,5 +126,13 @@ describe('LocaleAPI', () => {
         'Content-Type': 'application/json; charset=utf-8',
       },
     });
+  });
+
+  it('should use the cache for the country list, keyed by locale', async () => {
+    await LocaleAPI.getList({ cc: 'us', lc: 'en' });
+    await LocaleAPI.getList({ cc: 'us', lc: 'en' });
+    await LocaleAPI.getList({ cc: 'kr', lc: 'ko' });
+
+    expect(mockAxios.get).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
### Description

This change introduces an in-memory cache for in-flight requests of `LocaleAPI.getList()` and `TrasnlationAPI.getTranslation()` APIs.

It prevents multiple requests from getting in-flight, especially when multiple request of those happens in a short amount of time. In other words, without this change, the cache in `sessionStorage` from the 1st call of `LocaleAPI.getList()` hasn't been populated when 2nd call of `LocaleAPI.getList()` happens, given the response of the 1st call hasn't come.

### Changelog

**New**

- In-memory cache for in-flight requests of `LocaleAPI.getList()` and `TrasnlationAPI.getTranslation()` APIs.