### PR TITLE
fix(MegaMenu): tweak data-autoids for the mobile navigation

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -32490,7 +32490,7 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                           onFocus={[Function]}
                         >
                           <nav
-                            data-autoid="dds--masthead-default__l0-sidenav"
+                            data-autoid="dds--masthead-default-sidenav__l0"
                           >
                             <SideNavItems>
                               <ul
@@ -38248,7 +38248,7 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                             onFocus={[Function]}
                           >
                             <nav
-                              data-autoid="dds--masthead-default__l0-sidenav"
+                              data-autoid="dds--masthead-default-sidenav__l0"
                             >
                               <SideNavItems>
                                 <ul
@@ -43876,12 +43876,12 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                             onFocus={[Function]}
                           >
                             <nav
-                              data-autoid="dds--masthead-eco__l0-sidenav"
+                              data-autoid="dds--masthead-eco-sidenav__l0"
                             >
                               <a
                                 aria-haspopup="true"
                                 className="bx--side-nav__submenu bx--side-nav__submenu-platform"
-                                data-autoid="dds--masthead-eco__l0-side-nav__productname"
+                                data-autoid="dds--masthead-eco-sidenav__l0-productname"
                                 href="https://www.ibm.com/cloud"
                               >
                                 IBM Cloud
@@ -49473,7 +49473,7 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                             onFocus={[Function]}
                           >
                             <nav
-                              data-autoid="dds--masthead-default__l0-sidenav"
+                              data-autoid="dds--masthead-default-sidenav__l0"
                             >
                               <SideNavItems>
                                 <ul
@@ -64912,7 +64912,7 @@ exports[`Storyshots Components|Masthead Default 1`] = `
                         onFocus={[Function]}
                       >
                         <nav
-                          data-autoid="dds--masthead-default__l0-sidenav"
+                          data-autoid="dds--masthead-default-sidenav__l0"
                         >
                           <SideNavItems>
                             <ul
@@ -65527,7 +65527,7 @@ exports[`Storyshots Components|Masthead Search open by default 1`] = `
                         onFocus={[Function]}
                       >
                         <nav
-                          data-autoid="dds--masthead-default__l0-sidenav"
+                          data-autoid="dds--masthead-default-sidenav__l0"
                         >
                           <SideNavItems>
                             <ul
@@ -66042,12 +66042,12 @@ exports[`Storyshots Components|Masthead With Platform 1`] = `
                           onFocus={[Function]}
                         >
                           <nav
-                            data-autoid="dds--masthead-eco__l0-sidenav"
+                            data-autoid="dds--masthead-eco-sidenav__l0"
                           >
                             <a
                               aria-haspopup="true"
                               className="bx--side-nav__submenu bx--side-nav__submenu-platform"
-                              data-autoid="dds--masthead-eco__l0-side-nav__productname"
+                              data-autoid="dds--masthead-eco-sidenav__l0-productname"
                               href="https://www.ibm.com/cloud"
                             >
                               IBM Cloud

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -36,7 +36,7 @@ const MastheadLeftNav = ({
    */
   const sideNav = navigation.map((link, i) => {
     if (link.hasMenu) {
-      const autoid = `${stablePrefix}--masthead-${rest.navType}__l0-sidenav-nav${i}`;
+      const autoid = `${stablePrefix}--masthead-${rest.navType}-sidenav__l0-nav${i}`;
       return (
         <SideNavMenuWithBackFoward
           title={link.title}
@@ -44,14 +44,19 @@ const MastheadLeftNav = ({
           key={i}
           autoid={autoid}
           navType={rest.navType}>
-          {renderNavSections(link.menuSections, backButtonText, autoid)}
+          {renderNavSections(
+            link.menuSections,
+            backButtonText,
+            autoid,
+            rest.navType
+          )}
         </SideNavMenuWithBackFoward>
       );
     } else {
       return (
         <SideNavLink
           href={link.url}
-          data-autoid={`${stablePrefix}--masthead-${rest.navType}__l0-sidenav-nav${i}`}
+          data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0-nav${i}`}
           key={i}>
           {link.title}
         </SideNavLink>
@@ -65,10 +70,10 @@ const MastheadLeftNav = ({
       expanded={isSideNavExpanded}
       isPersistent={false}>
       <nav
-        data-autoid={`${stablePrefix}--masthead-${rest.navType}__l0-sidenav`}>
+        data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0`}>
         {platform && (
           <a // eslint-disable-line jsx-a11y/role-supports-aria-props
-            data-autoid={`${stablePrefix}--masthead-${rest.navType}__l0-side-nav__productname`}
+            data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0__productname`}
             href={platform.url}
             aria-haspopup="true"
             className={`${prefix}--side-nav__submenu ${prefix}--side-nav__submenu-platform`}>
@@ -89,9 +94,10 @@ const MastheadLeftNav = ({
  * @param {Array} sections A list of link sections to be rendered
  * @param {string} backButtonText back button text
  * @param {string} autoid autoid predecessor
+ * @param {string} navType navigation type
  * @returns {object} JSX object
  */
-function renderNavSections(sections, backButtonText, autoid) {
+function renderNavSections(sections, backButtonText, autoid, navType) {
   const sectionItems = [];
   sections.forEach(section => {
     section.menuItems.forEach((item, j) => {
@@ -103,6 +109,7 @@ function renderNavSections(sections, backButtonText, autoid) {
             titleUrl={item.url}
             backButtonText={backButtonText}
             autoid={dataAutoId}
+            navType={navType}
             key={j}>
             {renderNavItem(item.megapanelContent.quickLinks.links, dataAutoId)}
           </SideNavMenuWithBackFoward>
@@ -133,7 +140,7 @@ function renderNavSections(sections, backButtonText, autoid) {
 function renderNavItem(items, autoid) {
   const navItems = [];
   items.forEach((item, i) => {
-    const dataAutoId = `${autoid}-list${i}`;
+    const dataAutoId = `${autoid}-item${i}`;
     navItems.push(
       <SideNavMenuItem
         href={item.url}

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -73,7 +73,7 @@ const MastheadLeftNav = ({
         data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0`}>
         {platform && (
           <a // eslint-disable-line jsx-a11y/role-supports-aria-props
-            data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0__productname`}
+            data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0-productname`}
             href={platform.url}
             aria-haspopup="true"
             className={`${prefix}--side-nav__submenu ${prefix}--side-nav__submenu-platform`}>

--- a/packages/react/src/components/Masthead/__tests__/MastheadLeftNav.test.js
+++ b/packages/react/src/components/Masthead/__tests__/MastheadLeftNav.test.js
@@ -41,7 +41,7 @@ describe('MastheadLeftNav', () => {
     );
 
     const anchor = component.find(
-      `a[data-autoid="${stablePrefix}--masthead-${navType}__l0-side-nav__productname"]`
+      `a[data-autoid="${stablePrefix}--masthead-${navType}-sidenav__l0-productname"]`
     );
 
     expect(anchor.text()).toMatch('IBM Cloud');

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
@@ -36,7 +36,7 @@ const SideNavMenuWithBackForward = ({
       <SideNavMenuItem
         onClick={event => event.preventDefault()}
         className={`${prefix}--masthead__side-nav--submemu-back`}
-        data-autoid={`${stablePrefix}--masthead-${rest.navType}__l0-sidenav-back`}
+        data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0-back`}
         isbackbutton="true"
         tabIndex="0">
         <ChevronLeft20 />


### PR DESCRIPTION
### Related Ticket(s)

Add autoids to megamenu #3381

### Description

Fix format of mobile megamenu data-autoids.

### Changelog

**Changed**

- change position of `sidenav` in autoid: `dds--masthead-default__l0-sidenav` to `dds--masthead-default-sidenav__l0`
- ensure all instances of `<<SideNavMenuWithBackFoward />` get passed in `navType`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
