### PR TITLE
fix(devenv): use ibm-common.js

### DIFF
--- a/packages/services/src/services/DDO/DDO.js
+++ b/packages/services/src/services/DDO/DDO.js
@@ -36,7 +36,9 @@ let _dataLayerReadyPromise;
  * Timeout loop to check if the digitalData object is ready.
  * This is the only way to achieve this without jQuery, as the event trigger
  * is fired from jQuery's custom event layer as
- * $(document).trigger('datalayer_ready')
+ * $(document).trigger('datalayer_ready').
+ *
+ * Application should `window.digitalData` up-front, e.g. in a `<script>` tag in `<head>`, that eliminates the polling.
  *
  * @private
  */
@@ -89,7 +91,9 @@ class DDOAPI {
   }
 
   /**
-   * Gets the full digitalData (DDO) object
+   * Gets the full digitalData (DDO) object.
+   * Application should `window.digitalData` up-front, e.g. in a `<script>` tag in `<head>`.
+   * For quick developerment purpose, what `ibm-common.js` automatically populates can be used.
    *
    * @returns {Promise<*>} Promise object
    */
@@ -104,7 +108,9 @@ class DDOAPI {
   }
 
   /**
-   * Sets the version of the library to the DDO
+   * Sets the version of the library to the DDO.
+   * Application should `window.digitalData` up-front, e.g. in a `<script>` tag in `<head>`.
+   * For quick developerment purpose, what `ibm-common.js` automatically populates can be used.
    *
    * @returns {Promise<any>} Promise object
    */
@@ -115,7 +121,9 @@ class DDOAPI {
   }
 
   /**
-   * Gets the locale for the current page based on the language set as metadata
+   * Gets the locale for the current page based on the language set as metadata.
+   * Application should `window.digitalData` up-front, e.g. in a `<script>` tag in `<head>`.
+   * For quick developerment purpose, what `ibm-common.js` automatically populates can be used.
    *
    * @returns {Promise<*>} Promise object
    */

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -135,3 +135,6 @@
 <script type="text/javascript">
   document.documentElement.setAttribute('lang', 'en');
 </script>
+
+<!-- IBM Tag Management and Site Analytics -->
+<script src="//1.www.s81c.com/common/stats/ibm-common.js" defer></script>


### PR DESCRIPTION
### Related Ticket(s)

Refs #3575.

### Description

This change adds `ibm-common.js` to Web Components' storybook, that populates DDO.

This fixes a bug of slow loading of masthead menu data caused by `DDOAPI.getAll()` polling for `window.digitalData` until its timed out.

### Changelog

**New**

- `ibm-common.js` to Web Components' storybook, that populates DDO.