### PR TITLE
fix(connect): look at store in initialization

### DIFF
--- a/packages/web-components/src/globals/mixins/connect.ts
+++ b/packages/web-components/src/globals/mixins/connect.ts
@@ -52,6 +52,7 @@ const ConnectMixin = <
       // TS seems to miss `HTMLElement.prototype.connectedCallback()` definition
       // @ts-ignore
       super.connectedCallback();
+      this._handleChangeStoreState(store.getState());
       const unsubscribe = store.subscribe(() => this._handleChangeStoreState(store.getState()));
       this._hStore = {
         release() {


### PR DESCRIPTION
### Related Ticket(s)

Refs #3589.

### Description

This change ensures that `<dds-footer-container>`, etc. properties are populated from Redux store when the component is initialized, in addotion to reacting to changes in Redux store.

Lack of such mechanism caused empty footer data when a new instance of `<dds-footer-container>` is created after Redux store has already loaded all data from the service.

### Changelog

**New**

- "Store to component props" logic at component initialization in `<dds-footer-container>`, etc.