### PR TITLE
chore(devenv): fix footer size

### DIFF
--- a/packages/web-components/src/components/footer/__stories__/footer.stories.ts
+++ b/packages/web-components/src/components/footer/__stories__/footer.stories.ts
@@ -19,7 +19,7 @@ import mockLegalLinks from './legal-links';
 import mockLocaleList from '../../locale-modal/__stories__/locale-data.json';
 import readme from './README.stories.mdx';
 
-export const Default = ({ parameters }) => {
+export const base = ({ parameters }) => {
   const { langDisplay, language, size, legalLinks, links, localeList } = parameters?.props?.['dds-footer-composite'] ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
@@ -52,13 +52,22 @@ export const Default = ({ parameters }) => {
   `;
 };
 
+export const Default = ({ parameters }) => {
+  const { props = {} } = parameters;
+  props['dds-footer-composite'] = {
+    ...(props['dds-footer-composite'] || {}),
+    size: FOOTER_SIZE.REGULAR,
+  };
+  return base({ parameters });
+};
+
 export const short = ({ parameters }) => {
   const { props = {} } = parameters;
   props['dds-footer-composite'] = {
     ...(props['dds-footer-composite'] || {}),
     size: FOOTER_SIZE.SHORT,
   };
-  return Default({ parameters });
+  return base({ parameters });
 };
 
 export default {
@@ -81,4 +90,5 @@ export default {
       };
     })(),
   },
+  excludeStories: ['base'],
 };

--- a/packages/web-components/tests/snapshots/dds-footer-composite.md
+++ b/packages/web-components/tests/snapshots/dds-footer-composite.md
@@ -2,13 +2,14 @@
 
 ## `Misc attributes`
 
-#### `should render minimum attributes`
+####   `should render minimum attributes`
 
 ```
-<dds-footer-composite>
+<dds-footer-composite size="">
   <dds-footer
     data-auto-id="dds--footer"
     role="footer"
+    size=""
   >
     <dds-footer-logo data-auto-id="dds--footer-logo">
     </dds-footer-logo>
@@ -29,16 +30,18 @@
 
 ```
 
-#### `should render various attributes`
+####   `should render various attributes`
 
 ```
 <dds-footer-composite
   lang-display="lang-display-foo"
   language="ko-KR"
+  size=""
 >
   <dds-footer
     data-auto-id="dds--footer"
     role="footer"
+    size=""
   >
     <dds-footer-logo data-auto-id="dds--footer-logo">
     </dds-footer-logo>
@@ -107,3 +110,4 @@
 </dds-footer-composite>
 
 ```
+


### PR DESCRIPTION
### Description

This change ensures that the default footer story uses regular size.

Lack of this change caused the default footer story use short size when going to short story and then default story.

### Changelog

**New**

-  Code to ensure that the default footer story uses regular size.