### PR TITLE
chore(devenv): change knob group names

### DIFF
--- a/packages/web-components/src/components/button/__stories__/button.stories.ts
+++ b/packages/web-components/src/components/button/__stories__/button.stories.ts
@@ -34,7 +34,7 @@ const sizes = {
 
 export const Default = ({ parameters }) => {
   const { autofocus, disabled, download, href, hreflang, kind, ping, rel, size, target, type, onClick } =
-    parameters?.props?.['dds-btn'] ?? {};
+    parameters?.props?.Button ?? {};
   return html`
     <dds-btn
       ?autofocus="${autofocus}"
@@ -56,7 +56,7 @@ export const Default = ({ parameters }) => {
 };
 
 export const icon = ({ parameters }) => {
-  const { kind, disabled, size, href, onClick } = parameters?.props?.['dds-btn'] ?? {};
+  const { kind, disabled, size, href, onClick } = parameters?.props?.Button ?? {};
   return html`
     <dds-btn
       kind=${ifNonNull(kind)}
@@ -71,7 +71,7 @@ export const icon = ({ parameters }) => {
 };
 
 export const textAndIcon = ({ parameters }) => {
-  const { kind, disabled, size, href, onClick } = parameters?.props?.['dds-btn'] ?? {};
+  const { kind, disabled, size, href, onClick } = parameters?.props?.Button ?? {};
   return html`
     <dds-btn
       kind=${ifNonNull(kind)}
@@ -94,11 +94,11 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      'dds-btn': () => ({
-        kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY),
-        disabled: boolean('Disabled (disabled)', false),
-        size: select('Button size (size)', sizes, null),
-        href: textNullable('Link href (href)', ''),
+      Button: ({ groupId }) => ({
+        kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY, groupId),
+        disabled: boolean('Disabled (disabled)', false, groupId),
+        size: select('Button size (size)', sizes, null, groupId),
+        href: textNullable('Link href (href)', '', groupId),
         onClick: action('click'),
       }),
     },

--- a/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
+++ b/packages/web-components/src/components/card-link/__stories__/card-link.stories.ts
@@ -17,7 +17,7 @@ import textNullable from '../../../../.storybook/knob-text-nullable';
 import '../card-link';
 
 export const Default = ({ parameters }) => {
-  const { disabled, href } = parameters?.props?.['dds-card-link'] ?? {};
+  const { disabled, href } = parameters?.props?.CardLink ?? {};
   return html`
     <dds-card-link ?disabled=${disabled} href=${ifNonNull(href || undefined)}>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
@@ -31,9 +31,9 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      'dds-card-link': () => ({
-        disabled: boolean('Disabled (disabled):', false),
-        href: textNullable('Card Href (href):', 'https://example.com'),
+      CardLink: ({ groupId }) => ({
+        disabled: boolean('Disabled (disabled):', false, groupId),
+        href: textNullable('Card Href (href):', 'https://example.com', groupId),
       }),
     },
   },

--- a/packages/web-components/src/components/cta/__stories__/cta.stories.ts
+++ b/packages/web-components/src/components/cta/__stories__/cta.stories.ts
@@ -45,7 +45,7 @@ const types = {
 };
 
 export const Default = ({ parameters }) => {
-  const { ctaStyle, item } = parameters?.props?.['dds-cta-container'] ?? {};
+  const { ctaStyle, item } = parameters?.props?.CTAContainer ?? {};
   return html`
     <dds-cta-container cta-style="${ctaStyle}" .item="${item}"></dds-cta-container>
   `;
@@ -68,7 +68,7 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      'dds-cta-container': ({ groupId }) => {
+      CTAContainer: ({ groupId }) => {
         const ctaStyle = select('Style (cta-style)', styles, CTA_STYLE.TEXT, groupId);
         const type = select('Type (item.type)', types, null, groupId);
         const href = textNullable(knobNamesForType[type ?? CTA_TYPE.REGULAR], hrefsForType[type ?? CTA_TYPE.REGULAR], groupId);

--- a/packages/web-components/src/components/cta/__tests__/cta-container.test.ts
+++ b/packages/web-components/src/components/cta/__tests__/cta-container.test.ts
@@ -23,7 +23,7 @@ const template = (props?) =>
   Default({
     parameters: {
       props: {
-        'dds-cta-container': props,
+        CTAContainer: props,
       },
     },
   });

--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -80,8 +80,9 @@ const StoryContent = () => html`
 `;
 
 export const Default = ({ parameters }) => {
-  const { brandName, userStatus, navLinks } = parameters?.props?.Masthead ?? {};
-  const { langDisplay, language, size: footerSize, legalLinks, links: footerLinks, localeList } = parameters?.props?.Footer ?? {};
+  const { brandName, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
+  const { langDisplay, language, size: footerSize, legalLinks, links: footerLinks, localeList } =
+    parameters?.props?.FooterComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -127,11 +128,11 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      Masthead: ({ groupId }) => ({
+      MastheadComposite: ({ groupId }) => ({
         brandName: textNullable('Brand name (brand-name)', '', groupId),
         logoHref: 'https://www.ibm.com',
       }),
-      Footer: ({ groupId }) => ({
+      FooterComposite: ({ groupId }) => ({
         footerSize: select('Size (footer-size)', footerSizes, null, groupId),
       }),
     },
@@ -140,10 +141,10 @@ export default {
       // if `CORS_PROXY` is set
       const useMock = !process.env.CORS_PROXY || inPercy() || new URLSearchParams(window.location.search).has('mock');
       return {
-        Masthead: {
+        MastheadComposite: {
           navLinks: !useMock ? undefined : mastheadLinks,
         },
-        Footer: {
+        FooterComposite: {
           langDisplay: !useMock ? undefined : 'United States - English',
           legalLinks: !useMock ? undefined : mockLegalLinks,
           links: !useMock ? undefined : mockFooterLinks,

--- a/packages/web-components/src/components/footer/__stories__/footer.stories.ts
+++ b/packages/web-components/src/components/footer/__stories__/footer.stories.ts
@@ -20,7 +20,7 @@ import mockLocaleList from '../../locale-modal/__stories__/locale-data.json';
 import readme from './README.stories.mdx';
 
 export const base = ({ parameters }) => {
-  const { langDisplay, language, size, legalLinks, links, localeList } = parameters?.props?.['dds-footer-composite'] ?? {};
+  const { langDisplay, language, size, legalLinks, links, localeList } = parameters?.props?.FooterComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -54,8 +54,8 @@ export const base = ({ parameters }) => {
 
 export const Default = ({ parameters }) => {
   const { props = {} } = parameters;
-  props['dds-footer-composite'] = {
-    ...(props['dds-footer-composite'] || {}),
+  props.FooterComposite = {
+    ...(props.FooterComposite || {}),
     size: FOOTER_SIZE.REGULAR,
   };
   return base({ parameters });
@@ -63,8 +63,8 @@ export const Default = ({ parameters }) => {
 
 export const short = ({ parameters }) => {
   const { props = {} } = parameters;
-  props['dds-footer-composite'] = {
-    ...(props['dds-footer-composite'] || {}),
+  props.FooterComposite = {
+    ...(props.FooterComposite || {}),
     size: FOOTER_SIZE.SHORT,
   };
   return base({ parameters });
@@ -78,7 +78,7 @@ export default {
       // Lets `<dds-footer-container>` load the footer links if `CORS_PROXY` is set
       const useMock = !process.env.CORS_PROXY || inPercy() || new URLSearchParams(window.location.search).has('mock');
       return {
-        'dds-footer-composite': {
+        FooterComposite: {
           langDisplay: !useMock ? undefined : 'United States - English',
           legalLinks: !useMock ? undefined : mockLegalLinks,
           links: !useMock ? undefined : mockLinks,

--- a/packages/web-components/src/components/footer/__tests__/footer-composite.test.ts
+++ b/packages/web-components/src/components/footer/__tests__/footer-composite.test.ts
@@ -102,7 +102,7 @@ const template = (props?) =>
   Default({
     parameters: {
       props: {
-        'dds-footer-composite': props,
+        FooterComposite: props,
         Other: {
           useMock: true,
         },

--- a/packages/web-components/src/components/footer/__tests__/footer-container.test.ts
+++ b/packages/web-components/src/components/footer/__tests__/footer-container.test.ts
@@ -23,7 +23,7 @@ const template = (props?) => {
   return Default({
     parameters: {
       props: {
-        'dds-footer-composite': props,
+        FooterComposite: props,
       },
     },
   });

--- a/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/__stories__/lightbox-media-viewer.stories.ts
@@ -19,8 +19,8 @@ import styles from './lightbox-media-viewer.stories.scss';
 import readme from './README.stories.mdx';
 
 export const EmbeddedVideoPlayer = ({ parameters }) => {
-  const { open, disableClose, onBeforeClose, onClose } = parameters?.props?.['dds-modal'] ?? {};
-  const { hideCaption, videoId } = parameters?.props?.['dds-lightbox-video-player-container'] ?? {};
+  const { open, disableClose, onBeforeClose, onClose } = parameters?.props?.Modal ?? {};
+  const { hideCaption, videoId } = parameters?.props?.LightboxVideoPlayerContainer ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose?.(event);
     if (disableClose) {
@@ -53,7 +53,7 @@ export default {
       skip: true,
     },
     knobs: {
-      'dds-modal': ({ groupId }) => ({
+      Modal: ({ groupId }) => ({
         open: boolean('Open (open)', true, groupId),
         disableClose: boolean(
           'Disable user-initiated close action (Call event.preventDefault() in dds-modal-beingclosed event)',
@@ -63,7 +63,7 @@ export default {
         onBeforeClose: action('dds-modal-beingclosed'),
         onClose: action('dds-modal-closed'),
       }),
-      'dds-lightbox-video-player-container': ({ groupId }) => ({
+      LightboxVideoPlayerContainer: ({ groupId }) => ({
         hideCaption: boolean('hide caption (hide-caption)', false, groupId),
         videoId: textNullable('Video ID (video-id)', '0_uka1msg4', groupId),
       }),

--- a/packages/web-components/src/components/lightbox-media-viewer/__tests__/lightbox-media-viewer-container.test.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/__tests__/lightbox-media-viewer-container.test.ts
@@ -15,7 +15,7 @@ const videoPlayerTemplate = (props?) =>
   EmbeddedVideoPlayer({
     parameters: {
       props: {
-        'dds-lightbox-video-player-container': props,
+        LightboxVideoPlayerContainer: props,
       },
     },
   });

--- a/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
+++ b/packages/web-components/src/components/link-with-icon/__stories__/link-with-icon.stories.ts
@@ -17,7 +17,7 @@ import '../link-with-icon';
 import readme from './README.stories.mdx';
 
 export const Default = ({ parameters }) => {
-  const { children, disabled, href, onClick } = parameters?.props?.['dds-link-with-icon'] ?? {};
+  const { children, disabled, href, onClick } = parameters?.props?.LinkWithIcon ?? {};
   return html`
     <dds-link-with-icon ?disabled="${disabled}" href="${ifNonNull(href)}" @click="${onClick}">
       ${children}${ArrowRight20({ slot: 'icon' })}
@@ -30,7 +30,7 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      'dds-link-with-icon': ({ groupId }) => ({
+      LinkWithIcon: ({ groupId }) => ({
         children: textNullable('Link text (unnamed slot)', 'Link text', groupId),
         disabled: boolean('Disabled (disabled)', false, groupId),
         href: textNullable('Link href (href)', 'https://github.com/carbon-design-system/carbon-web-components', groupId),

--- a/packages/web-components/src/components/link-with-icon/__tests__/link-with-icon.test.ts
+++ b/packages/web-components/src/components/link-with-icon/__tests__/link-with-icon.test.ts
@@ -15,7 +15,7 @@ const template = (props?) =>
   Default({
     parameters: {
       props: {
-        'dds-link-with-icon': props,
+        LinkWithIcon: props,
       },
     },
   });

--- a/packages/web-components/src/components/locale-modal/__stories__/locale-modal.stories.ts
+++ b/packages/web-components/src/components/locale-modal/__stories__/locale-modal.stories.ts
@@ -17,7 +17,7 @@ import styles from './locale-modal.stories.scss';
 import readme from './README.stories.mdx';
 
 export const Default = ({ parameters }) => {
-  const { langDisplay, localeList } = parameters?.props?.['dds-locale-modal-container'];
+  const { langDisplay, localeList } = parameters?.props?.LocaleModalComposite;
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -44,12 +44,12 @@ export default {
       const useMock = !process.env.CORS_PROXY || inPercy() || new URLSearchParams(window.location.search).has('mock');
       return {
         knobs: {
-          'dds-locale-modal-container': ({ groupId }) => ({
+          LocaleModalComposite: ({ groupId }) => ({
             langDisplay: textNullable('Display language (lang-display)', !useMock ? '' : 'United States — English', groupId),
           }),
         },
         props: {
-          'dds-locale-modal-container': {
+          LocaleModalComposite: {
             localeList: !useMock ? undefined : localeData,
           },
           Other: {

--- a/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
+++ b/packages/web-components/src/components/masthead/__stories__/masthead.stories.ts
@@ -76,7 +76,7 @@ const StoryContent = () => html`
 `;
 
 export const Default = ({ parameters }) => {
-  const { brandName, userStatus, navLinks } = parameters?.props?.['dds-masthead-container'] ?? {};
+  const { brandName, userStatus, navLinks } = parameters?.props?.MastheadComposite ?? {};
   const { useMock } = parameters?.props?.Other ?? {};
   return html`
     <style>
@@ -106,7 +106,7 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      'dds-masthead-container': ({ groupId }) => ({
+      MastheadComposite: ({ groupId }) => ({
         brandName: textNullable('Brand name (brand-name)', '', groupId),
         userStatus: select('The user authenticated status (user-status)', userStatuses, null, groupId),
         logoHref: textNullable('Logo href (logo-href)', 'https://www.ibm.com', groupId),
@@ -116,7 +116,7 @@ export default {
       // Lets `<dds-masthead-container>` load the nav links, etc. if `CORS_PROXY` is set
       const useMock = !process.env.CORS_PROXY || inPercy() || new URLSearchParams(window.location.search).has('mock');
       return {
-        'dds-masthead-container': {
+        MastheadComposite: {
           navLinks: !useMock ? undefined : links,
         },
         Other: {

--- a/packages/web-components/src/components/modal/__stories__/modal.stories.ts
+++ b/packages/web-components/src/components/modal/__stories__/modal.stories.ts
@@ -30,7 +30,7 @@ const sizes = {
 };
 
 export const Default = ({ parameters }) => {
-  const { open, disableClose, expressiveSize, onBeforeClose, onClose } = parameters?.props?.['dds-modal'] ?? {};
+  const { open, disableClose, expressiveSize, onBeforeClose, onClose } = parameters?.props?.Modal ?? {};
   const { buttonContent } = parameters?.props?.Other ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose?.(event);
@@ -73,7 +73,7 @@ export default {
   parameters: {
     ...readme.parameters,
     knobs: {
-      'dds-modal': ({ groupId }) => ({
+      Modal: ({ groupId }) => ({
         open: boolean('Open (open)', true, groupId),
         disableClose: boolean(
           'Disable user-initiated close action (Call event.preventDefault() in dds-modal-beingclosed event)',

--- a/packages/web-components/src/components/modal/__tests__/modal.test.ts
+++ b/packages/web-components/src/components/modal/__tests__/modal.test.ts
@@ -16,7 +16,7 @@ const template = (props?) =>
   Default({
     parameters: {
       props: {
-        'dds-modal': props,
+        Modal: props,
       },
     },
   });


### PR DESCRIPTION
### Description

The preference of knob group names in Web Components codebase seems pascal cased names rather than component tag names. Changes the stories as such.

### Changelog

**Changed**

- Change knob group names in Web Components codebase seems pascal cased names rather than component tag names.