### PR TITLE
chore(dotcom-shell): avoid redundant prop sent for standalont footer

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell-container.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell-container.ts
@@ -41,9 +41,13 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 export function mapStateToProps(
   state: MastheadContainerState & FooterContainerState
 ): MastheadContainerStateProps & FooterContainerStateProps {
+  const footerProps = mapStateToPropsFooter(state);
   return {
     ...mapStateToPropsMasthead(state),
-    ...mapStateToPropsFooter(state),
+    ...Object.keys(footerProps).reduce((acc, key) => {
+      acc[key !== 'links' ? key : 'footerLinks'] = footerProps[key];
+      return acc;
+    }, {}),
   };
 }
 

--- a/packages/web-components/src/components/footer/footer-container.ts
+++ b/packages/web-components/src/components/footer/footer-container.ts
@@ -107,7 +107,6 @@ export function mapStateToProps(state: FooterContainerState): FooterContainerSta
     langDisplay,
     localeList: !language ? undefined : localeLists?.[language],
     links: !language ? undefined : translations?.[language]?.footerMenu,
-    footerLinks: !language ? undefined : translations?.[language]?.footerMenu,
     legalLinks: !language ? undefined : translations?.[language]?.footerThin,
   });
 }


### PR DESCRIPTION
### Description

We made a quick fix to dotcom shell (in #3595) in a way that sends redundant property (`footerLinks`) to `<dds-footer-container>`, in standalone footer story. This change fixes the problem by having `<dds-dotcom-shell-container>`'s `mapStateToProps()` rename `links` property that `<dds-footer-container>`'s `mapStateToProps()` generates.

### Changelog

**Changed**

- A fix to ensure redundant property is not sent to `<dds-footer-container>` in standalone footer story.