### PR TITLE
chore(devenv): fix footer size in dotcom shell

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -132,7 +132,7 @@ export default {
         logoHref: 'https://www.ibm.com',
       }),
       Footer: ({ groupId }) => ({
-        footerSize: select('Size (footer-size)', footerSizes, null, groupId),
+        size: select('Size (footer-size)', footerSizes, null, groupId),
       }),
     },
     props: (() => {


### PR DESCRIPTION
### Description

This change fixes a bug where Storybook knob for footer size in dotcom shell story was not working.

### Changelog

**Changed**

- A fix for a bug where Storybook knob for footer size in dotcom shell story was not working.