### PR TITLE
fix(side-nav): cope with large list of parent menu items

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -69,6 +69,11 @@ export class SideNavMenu extends React.Component {
      * For submenu back button to toggle expand/collapse
      */
     isbackbutton: PropTypes.string,
+
+    /**
+     * A callback that is called when this side nav menu is toggled by user gesture.
+     */
+    onToggle: PropTypes.func,
   };
 
   static defaultProps = {
@@ -107,12 +112,30 @@ export class SideNavMenu extends React.Component {
   }
 
   handleToggleExpand = event => {
-    this.setState(state => ({ isExpanded: !state.isExpanded }));
+    const { onToggle } = this.props;
+    event.persist();
+    this.setState(
+      state => ({ isExpanded: !state.isExpanded }),
+      () => {
+        if (onToggle) {
+          onToggle(event, { isExpanded: this.state.isExpanded });
+        }
+      }
+    );
   };
 
   handleKeyToggleExpand = event => {
     if (event.charCode === 'Enter' || event.charCode === ' ') {
-      this.setState(state => ({ isExpanded: !state.isExpanded }));
+      const { onToggle } = this.props;
+      event.persist();
+      this.setState(
+        state => ({ isExpanded: !state.isExpanded }),
+        () => {
+          if (onToggle) {
+            onToggle(event, { isExpanded: this.state.isExpanded });
+          }
+        }
+      );
     }
   };
 

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
@@ -14,7 +14,7 @@ import SideNavMenu from './SideNavMenu';
 import SideNavMenuItem from '../../../internal/vendor/carbon-components-react/components/UIShell/SideNavMenuItem';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 
 const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
@@ -31,8 +31,31 @@ const SideNavMenuWithBackForward = ({
   children,
   ...rest
 }) => {
+  const refSideNavMenu = useRef(null);
+  const handleToggle = useCallback((event, detail) => {
+    const { current: sideNavMenuNode } = refSideNavMenu;
+    const sideNav = sideNavMenuNode.closest('.bx--side-nav');
+    if (sideNav) {
+      const list = Array.prototype.forEach.call(
+        sideNav.querySelectorAll('.bx--side-nav__menu'),
+        elem => {
+          const hasExpandedSubmenu = elem.querySelector(
+            '.bx--side-nav__submenu[aria-expanded="true"]'
+          );
+          elem.classList.toggle(
+            'bx--side-nav__menu--hasactivechildren',
+            hasExpandedSubmenu
+          );
+        }
+      );
+    }
+  }, []);
   return (
-    <SideNavMenu autoid={rest.autoid} title={title}>
+    <SideNavMenu
+      autoid={rest.autoid}
+      title={title}
+      onToggle={handleToggle}
+      ref={refSideNavMenu}>
       <SideNavMenuItem
         onClick={event => event.preventDefault()}
         className={`${prefix}--masthead__side-nav--submemu-back`}

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -112,6 +112,10 @@
     }
   }
 
+  .#{$prefix}--side-nav__menu--hasactivechildren {
+    overflow: hidden;
+  }
+
   a.#{$prefix}--side-nav__link {
     height: carbon--mini-units(6);
     @include carbon--type-style(body-short-02);


### PR DESCRIPTION
### Related Ticket(s)

Refs #3512.

### Description

This change fixes an issue where the list of parent menu items is larger than its overlayed child menu items and thus the bottom portion of the parent menu items is still shown even if child menu items are on top of them.

The problem is seen, at the point of the fix, when user navigates to "Products and Solutions" - "Supply Chain" and then user scrolls up the nav.

### Changelog

**New**

- `bx--side-nav__menu--hasactivechildren` CSS class and its corresponding CSS rules.
- `onToggle()` prop to `<SideNavMenu>`
- `<SideNavMenuWithBackForward>` code to add/remove `bx--side-nav__menu--hasactivechildren` CSS class upon `onToggle()` in `<SideNavMenu>`