### PR TITLE
fix(MegaMenu): set correct aria label to hamburger menu when open/closed

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -258,7 +258,7 @@ const Masthead = ({
 
               {(mastheadL1Data || navigation) && (
                 <HeaderMenuButton
-                  aria-label="Open menu"
+                  aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
                   data-autoid={`${stablePrefix}--masthead__hamburger`}
                   onClick={onClickSideNavExpand}
                   isActive={isSideNavExpanded}


### PR DESCRIPTION
### Related Ticket(s)

Mega Menu:- Accessibility :- Close icon (issues related to hamburger menu once it is expanded) #3584

### Description

Screen reader is reading the hamburger menu as "Open menu" even when the menu has been opened and the icon has changed to the `X` icon. Should change to "Close menu" when the hamburger menu is open.

### Changelog

**Changed**

- toggle `aria-label` of hamburger menu when menu is opened/closed


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
