### PR TITLE
fix(MegaMenu): assign button role for the back button in mobile menu

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -111,7 +111,7 @@ export class SideNavMenu extends React.Component {
   };
 
   handleKeyToggleExpand = event => {
-    if (event.charCode === 'Enter' || event.charCode === ' ') {
+    if (event.charCode === 13 || event.charCode === ' ') {
       this.setState(state => ({ isExpanded: !state.isExpanded }));
     }
   };

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
@@ -38,6 +38,7 @@ const SideNavMenuWithBackForward = ({
         className={`${prefix}--masthead__side-nav--submemu-back`}
         data-autoid={`${stablePrefix}--masthead-${rest.navType}-sidenav__l0-back`}
         isbackbutton="true"
+        role="button"
         tabIndex="0">
         <ChevronLeft20 />
         {backButtonText}


### PR DESCRIPTION
### Related Ticket(s)

Mega Menu:- Accessibility :- Back link (issues related to hamburger menu once it is expanded) #3587

### Description

Add button `role` to the back button of the mobile menu nav.
Also check for the Enter `charCode` of `13` to make sure back button works on key press.

### Changelog

**Changed**

- add `role="button"` for the back button
- check for `13` when `Enter` key is pressed for back button

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
