### PR TITLE
fix(Footer): add aria label to IBM logo in footer

### DIFF
--- a/packages/web-components/src/components/footer/footer-logo.ts
+++ b/packages/web-components/src/components/footer/footer-logo.ts
@@ -45,7 +45,9 @@ class DDSFooterLogo extends StableSelectorMixin(FocusMixin(LitElement)) {
   render() {
     const { href } = this;
     return html`
-      <a class="${prefix}--footer-logo__link" href="${ifNonNull(href)}">${IBM8BarLogoH65White()}<slot></slot></a>
+      <a class="${prefix}--footer-logo__link" aria-label="IBM logo" href="${ifNonNull(href)}"
+        >${IBM8BarLogoH65White()}<slot></slot
+      ></a>
     `;
   }
 

--- a/packages/web-components/tests/snapshots/dds-footer-logo.md
+++ b/packages/web-components/tests/snapshots/dds-footer-logo.md
@@ -6,6 +6,7 @@
 
 ```
 <a
+  aria-label="IBM logo"
   class="bx--footer-logo__link"
   href="https://www.ibm.com/"
 >
@@ -19,6 +20,7 @@
 
 ```
 <a
+  aria-label="IBM logo"
   class="bx--footer-logo__link"
   href="https://cloud.ibm.com/"
 >


### PR DESCRIPTION
### Related Ticket(s)

Web component: Footer - IBM logo link is announced as slash link on iPhone. #3609

### Description

Add aria-label to the IBM logo in the footer for iphone voiceover

### Changelog

**Changed**

- add aria-label to ibm logo


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
