### PR TITLE
feat(card-with-pictogram): adding new card variation

### DIFF
--- a/packages/react/src/components/Card/Card.js
+++ b/packages/react/src/components/Card/Card.js
@@ -31,6 +31,7 @@ export const Card = ({
   customClassName,
   copy,
   cta,
+  pictogram,
   ...props
 }) => {
   const TileType = props.disabled ? Tile : ClickableTile;
@@ -57,7 +58,7 @@ export const Card = ({
         {eyebrow && <p className={`${prefix}--card__eyebrow`}>{eyebrow}</p>}
         {heading && <h3 className={`${prefix}--card__heading`}>{heading}</h3>}
         {optionalContent(copy)}
-        {renderFooter(cta)}
+        {renderFooter(cta, pictogram)}
       </div>
     </TileType>
   );
@@ -85,7 +86,7 @@ function optionalContent(copy) {
  * @param {object} cta cta object
  * @returns {object} JSX object
  */
-function renderFooter(cta) {
+function renderFooter(cta, pictogram) {
   return (
     cta && (
       <div
@@ -99,6 +100,7 @@ function renderFooter(cta) {
         {cta.icon?.src && (
           <cta.icon.src className={`${prefix}--card__cta`} {...cta.icon} />
         )}
+        {pictogram && pictogram}
       </div>
     )
   );
@@ -125,6 +127,11 @@ export const cardPropTypes = {
    * Disable card link
    */
   disabled: PropTypes.bool,
+
+  /**
+   * Disable card linkaaas
+   */
+  pictogram: PropTypes.node,
 
   /**
    * CTA options. Has the following structure in summary:


### PR DESCRIPTION
### Description

This card has a pictogram at the bottom left side, as per the visual specs for the [Support Page](https://app.abstract.com/projects/7f83c114-7627-4169-8af7-6a85e7147ea6/branches/master/commits/latest/files/01ee3bd8-c63d-4b3b-bddb-aabaddb5c31d/layers/1FA6F2AC-E027-419F-8CEF-F58B3AE2E495?collectionId=c963cb53-73c2-42a5-af39-f5538e24c454&collectionLayerId=a278337e-62ec-464c-8ba6-b368d4b9ed64).

This variation was approved by Wonil, James, and Jeff and will be under a feature flag. Here's the [link to the Slack conversation](https://cognitive-app.slack.com/archives/G018JGL83QX/p1597692491002100).

<img width="352" alt="Captura de Tela 2020-08-19 às 17 52 10" src="https://user-images.githubusercontent.com/42848561/90688351-b7f28800-e244-11ea-9503-5ce7dacb8fea.png">