### PR TITLE
chore(dotcomshell): fixed import reference in codesandbox example

### DIFF
--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/src/index.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/index';
+import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell-container';
 import links from './links';
 import './index.scss';
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The codesandbox looked out of date, fixing the import reference for the `dotcom-shell-container`.

### Changelog

**Changed**

- codesandbox for dotcomshell