### PR TITLE
fix(MegaMenu): add tabindex attr for safari not detecting event

### DIFF
--- a/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/packages/react/src/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1171,12 +1171,14 @@ exports[`Storyshots Components|CTA Text 1`] = `
                       className="bx--link-with-icon"
                       href="https://www.example.com"
                       onClick={[Function]}
+                      tabIndex={0}
                       target={null}
                     >
                       <a
                         className="bx--link bx--link-with-icon"
                         href="https://www.example.com"
                         onClick={[Function]}
+                        tabIndex={0}
                         target={null}
                       >
                         <span>
@@ -1840,12 +1842,14 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                                   className="bx--link-with-icon"
                                   href="https://example.com/"
                                   onClick={[Function]}
+                                  tabIndex={0}
                                   target={null}
                                 >
                                   <a
                                     className="bx--link bx--link-with-icon"
                                     href="https://example.com/"
                                     onClick={[Function]}
+                                    tabIndex={0}
                                     target={null}
                                   >
                                     <span>
@@ -1959,12 +1963,14 @@ exports[`Storyshots Components|CTASection With Content Items 1`] = `
                                   className="bx--link-with-icon"
                                   href="https://example.com/"
                                   onClick={[Function]}
+                                  tabIndex={0}
                                   target={null}
                                 >
                                   <a
                                     className="bx--link bx--link-with-icon"
                                     href="https://example.com/"
                                     onClick={[Function]}
+                                    tabIndex={0}
                                     target={null}
                                   >
                                     <span>
@@ -2155,10 +2161,12 @@ exports[`Storyshots Components|CalloutQuote Default 1`] = `
                                 <Link
                                   className="bx--link-with-icon"
                                   href="https://example.com"
+                                  tabIndex={0}
                                 >
                                   <a
                                     className="bx--link bx--link-with-icon"
                                     href="https://example.com"
+                                    tabIndex={0}
                                   >
                                     <span>
                                       Link with Icon
@@ -20504,12 +20512,14 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--link-with-icon"
                                                       href="https://www.ibm.com"
                                                       onClick={[Function]}
+                                                      tabIndex={0}
                                                       target={null}
                                                     >
                                                       <a
                                                         className="bx--link bx--link-with-icon"
                                                         href="https://www.ibm.com"
                                                         onClick={[Function]}
+                                                        tabIndex={0}
                                                         target={null}
                                                       >
                                                         <span>
@@ -20704,12 +20714,14 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--link-with-icon"
                                                       href="https://www.ibm.com"
                                                       onClick={[Function]}
+                                                      tabIndex={0}
                                                       target={null}
                                                     >
                                                       <a
                                                         className="bx--link bx--link-with-icon"
                                                         href="https://www.ibm.com"
                                                         onClick={[Function]}
+                                                        tabIndex={0}
                                                         target={null}
                                                       >
                                                         <span>
@@ -20903,12 +20915,14 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                       className="bx--link-with-icon"
                                                       href="https://www.ibm.com"
                                                       onClick={[Function]}
+                                                      tabIndex={0}
                                                       target={null}
                                                     >
                                                       <a
                                                         className="bx--link bx--link-with-icon"
                                                         href="https://www.ibm.com"
                                                         onClick={[Function]}
+                                                        tabIndex={0}
                                                         target={null}
                                                       >
                                                         <span>
@@ -22500,12 +22514,14 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                               className="bx--link-with-icon"
                                                               href="https://www.ibm.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <a
                                                                 className="bx--link bx--link-with-icon"
                                                                 href="https://www.ibm.com"
                                                                 onClick={[Function]}
+                                                                tabIndex={0}
                                                                 target={null}
                                                               >
                                                                 <span>
@@ -22700,12 +22716,14 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                               className="bx--link-with-icon"
                                                               href="https://www.ibm.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <a
                                                                 className="bx--link bx--link-with-icon"
                                                                 href="https://www.ibm.com"
                                                                 onClick={[Function]}
+                                                                tabIndex={0}
                                                                 target={null}
                                                               >
                                                                 <span>
@@ -22899,12 +22917,14 @@ Lorem ipsum dolor sit amet, [consectetur adipiscing](https://www.ibm.com) elit. 
                                                               className="bx--link-with-icon"
                                                               href="https://www.ibm.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <a
                                                                 className="bx--link bx--link-with-icon"
                                                                 href="https://www.ibm.com"
                                                                 onClick={[Function]}
+                                                                tabIndex={0}
                                                                 target={null}
                                                               >
                                                                 <span>
@@ -24139,12 +24159,14 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                       className="bx--link-with-icon"
                                       href="https://example.com"
                                       onClick={[Function]}
+                                      tabIndex={0}
                                       target={null}
                                     >
                                       <a
                                         className="bx--link bx--link-with-icon"
                                         href="https://example.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <span>
@@ -24371,12 +24393,14 @@ exports[`Storyshots Components|ContentBlockSegmented Default 1`] = `
                                       className="bx--link-with-icon"
                                       href="https://example.com"
                                       onClick={[Function]}
+                                      tabIndex={0}
                                       target={null}
                                     >
                                       <a
                                         className="bx--link bx--link-with-icon"
                                         href="https://example.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <span>
@@ -24885,12 +24909,14 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                       className="bx--link-with-icon"
                                       href="https://example.com"
                                       onClick={[Function]}
+                                      tabIndex={0}
                                       target={null}
                                     >
                                       <a
                                         className="bx--link bx--link-with-icon"
                                         href="https://example.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <span>
@@ -25117,12 +25143,14 @@ exports[`Storyshots Components|ContentBlockSegmented With Video 1`] = `
                                       className="bx--link-with-icon"
                                       href="https://example.com"
                                       onClick={[Function]}
+                                      tabIndex={0}
                                       target={null}
                                     >
                                       <a
                                         className="bx--link bx--link-with-icon"
                                         href="https://example.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <span>
@@ -29311,12 +29339,14 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                   className="bx--link-with-icon"
                                                   href="https://example.com"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <a
                                                     className="bx--link bx--link-with-icon"
                                                     href="https://example.com"
                                                     onClick={[Function]}
+                                                    tabIndex={0}
                                                     target={null}
                                                   >
                                                     <span>
@@ -29411,12 +29441,14 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                   className="bx--link-with-icon"
                                                   href="https://example.com"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target="_blank"
                                                 >
                                                   <a
                                                     className="bx--link bx--link-with-icon"
                                                     href="https://example.com"
                                                     onClick={[Function]}
+                                                    tabIndex={0}
                                                     target="_blank"
                                                   >
                                                     <span>
@@ -29618,12 +29650,14 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                   className="bx--link-with-icon"
                                                   href="https://example.com"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <a
                                                     className="bx--link bx--link-with-icon"
                                                     href="https://example.com"
                                                     onClick={[Function]}
+                                                    tabIndex={0}
                                                     target={null}
                                                   >
                                                     <span>
@@ -29718,12 +29752,14 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                   className="bx--link-with-icon"
                                                   href="https://example.com"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target="_blank"
                                                 >
                                                   <a
                                                     className="bx--link bx--link-with-icon"
                                                     href="https://example.com"
                                                     onClick={[Function]}
+                                                    tabIndex={0}
                                                     target="_blank"
                                                   >
                                                     <span>
@@ -29911,12 +29947,14 @@ exports[`Storyshots Components|ContentGroupHorizontal Default 1`] = `
                                                   className="bx--link-with-icon"
                                                   href="https://example.com"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <a
                                                     className="bx--link bx--link-with-icon"
                                                     href="https://example.com"
                                                     onClick={[Function]}
+                                                    tabIndex={0}
                                                     target={null}
                                                   >
                                                     <span>
@@ -31887,12 +31925,14 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://www.ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://www.ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -31987,12 +32027,14 @@ exports[`Storyshots Components|ContentItemHorizontal Default 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://www.ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target="_blank"
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://www.ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target="_blank"
                                         >
                                           <span>
@@ -32904,12 +32946,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                     className="bx--link-with-icon"
                                                                     href="https://ibm.com"
                                                                     onClick={[Function]}
+                                                                    tabIndex={0}
                                                                     target={null}
                                                                   >
                                                                     <a
                                                                       className="bx--link bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <span>
@@ -33004,12 +33048,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                     className="bx--link-with-icon"
                                                                     href="https://ibm.com"
                                                                     onClick={[Function]}
+                                                                    tabIndex={0}
                                                                     target={null}
                                                                   >
                                                                     <a
                                                                       className="bx--link bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <span>
@@ -33104,12 +33150,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                     className="bx--link-with-icon"
                                                                     href="https://ibm.com"
                                                                     onClick={[Function]}
+                                                                    tabIndex={0}
                                                                     target={null}
                                                                   >
                                                                     <a
                                                                       className="bx--link bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <span>
@@ -33482,12 +33530,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           className="bx--link-with-icon"
                                                           href="https://example.com"
                                                           onClick={[Function]}
+                                                          tabIndex={0}
                                                           target={null}
                                                         >
                                                           <a
                                                             className="bx--link bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <span>
@@ -33669,12 +33719,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           className="bx--link-with-icon"
                                                           href="https://example.com"
                                                           onClick={[Function]}
+                                                          tabIndex={0}
                                                           target={null}
                                                         >
                                                           <a
                                                             className="bx--link bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <span>
@@ -34232,12 +34284,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                           className="bx--link-with-icon"
                                                           href="https://example.com"
                                                           onClick={[Function]}
+                                                          tabIndex={0}
                                                           target={null}
                                                         >
                                                           <a
                                                             className="bx--link bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <span>
@@ -34967,12 +35021,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://example.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -35057,12 +35113,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://example.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target="_blank"
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <span>
@@ -35250,12 +35308,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://example.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -35340,12 +35400,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://example.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target="_blank"
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <span>
@@ -36836,10 +36898,12 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                                     <Link
                                                       className="bx--link-with-icon"
                                                       href="https://example.com"
+                                                      tabIndex={0}
                                                     >
                                                       <a
                                                         className="bx--link bx--link-with-icon"
                                                         href="https://example.com"
+                                                        tabIndex={0}
                                                       >
                                                         <span>
                                                           Link with Icon
@@ -37223,12 +37287,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               className="bx--link-with-icon"
                                               href="https://example.com/"
                                               onClick={[Function]}
+                                              tabIndex={0}
                                               target={null}
                                             >
                                               <a
                                                 className="bx--link bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <span>
@@ -37342,12 +37408,14 @@ exports[`Storyshots Components|Dotcom Shell Default 1`] = `
                                               className="bx--link-with-icon"
                                               href="https://example.com/"
                                               onClick={[Function]}
+                                              tabIndex={0}
                                               target={null}
                                             >
                                               <a
                                                 className="bx--link bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <span>
@@ -38614,12 +38682,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -38714,12 +38784,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -38814,12 +38886,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -39192,12 +39266,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -39379,12 +39455,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -39942,12 +40020,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -40677,12 +40757,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target={null}
                                                                         >
                                                                           <span>
@@ -40767,12 +40849,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target="_blank"
                                                                         >
                                                                           <span>
@@ -40960,12 +41044,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target={null}
                                                                         >
                                                                           <span>
@@ -41050,12 +41136,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target="_blank"
                                                                         >
                                                                           <span>
@@ -42546,10 +42634,12 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                       <Link
                                                         className="bx--link-with-icon"
                                                         href="https://example.com"
+                                                        tabIndex={0}
                                                       >
                                                         <a
                                                           className="bx--link bx--link-with-icon"
                                                           href="https://example.com"
+                                                          tabIndex={0}
                                                         >
                                                           <span>
                                                             Link with Icon
@@ -42933,12 +43023,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                 className="bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <a
                                                   className="bx--link bx--link-with-icon"
                                                   href="https://example.com/"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <span>
@@ -43052,12 +43144,14 @@ exports[`Storyshots Components|Dotcom Shell Search open 1`] = `
                                                 className="bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <a
                                                   className="bx--link bx--link-with-icon"
                                                   href="https://example.com/"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <span>
@@ -44189,12 +44283,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -44289,12 +44385,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -44389,12 +44487,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -44767,12 +44867,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -44954,12 +45056,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -45517,12 +45621,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -46252,12 +46358,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target={null}
                                                                         >
                                                                           <span>
@@ -46342,12 +46450,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target="_blank"
                                                                         >
                                                                           <span>
@@ -46535,12 +46645,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target={null}
                                                                         >
                                                                           <span>
@@ -46625,12 +46737,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target="_blank"
                                                                         >
                                                                           <span>
@@ -48121,10 +48235,12 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                       <Link
                                                         className="bx--link-with-icon"
                                                         href="https://example.com"
+                                                        tabIndex={0}
                                                       >
                                                         <a
                                                           className="bx--link bx--link-with-icon"
                                                           href="https://example.com"
+                                                          tabIndex={0}
                                                         >
                                                           <span>
                                                             Link with Icon
@@ -48508,12 +48624,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                 className="bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <a
                                                   className="bx--link bx--link-with-icon"
                                                   href="https://example.com/"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <span>
@@ -48627,12 +48745,14 @@ exports[`Storyshots Components|Dotcom Shell With platform 1`] = `
                                                 className="bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <a
                                                   className="bx--link bx--link-with-icon"
                                                   href="https://example.com/"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <span>
@@ -49730,12 +49850,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -49830,12 +49952,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -49930,12 +50054,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                       className="bx--link-with-icon"
                                                                       href="https://ibm.com"
                                                                       onClick={[Function]}
+                                                                      tabIndex={0}
                                                                       target={null}
                                                                     >
                                                                       <a
                                                                         className="bx--link bx--link-with-icon"
                                                                         href="https://ibm.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <span>
@@ -50308,12 +50434,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -50495,12 +50623,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -51058,12 +51188,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                             className="bx--link-with-icon"
                                                             href="https://example.com"
                                                             onClick={[Function]}
+                                                            tabIndex={0}
                                                             target={null}
                                                           >
                                                             <a
                                                               className="bx--link bx--link-with-icon"
                                                               href="https://example.com"
                                                               onClick={[Function]}
+                                                              tabIndex={0}
                                                               target={null}
                                                             >
                                                               <span>
@@ -51793,12 +51925,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target={null}
                                                                         >
                                                                           <span>
@@ -51883,12 +52017,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target="_blank"
                                                                         >
                                                                           <span>
@@ -52076,12 +52212,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target={null}
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target={null}
                                                                         >
                                                                           <span>
@@ -52166,12 +52304,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                                         className="bx--link-with-icon"
                                                                         href="https://example.com"
                                                                         onClick={[Function]}
+                                                                        tabIndex={0}
                                                                         target="_blank"
                                                                       >
                                                                         <a
                                                                           className="bx--link bx--link-with-icon"
                                                                           href="https://example.com"
                                                                           onClick={[Function]}
+                                                                          tabIndex={0}
                                                                           target="_blank"
                                                                         >
                                                                           <span>
@@ -53662,10 +53802,12 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                       <Link
                                                         className="bx--link-with-icon"
                                                         href="https://example.com"
+                                                        tabIndex={0}
                                                       >
                                                         <a
                                                           className="bx--link bx--link-with-icon"
                                                           href="https://example.com"
+                                                          tabIndex={0}
                                                         >
                                                           <span>
                                                             Link with Icon
@@ -54049,12 +54191,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                 className="bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <a
                                                   className="bx--link bx--link-with-icon"
                                                   href="https://example.com/"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <span>
@@ -54168,12 +54312,14 @@ exports[`Storyshots Components|Dotcom Shell With short footer 1`] = `
                                                 className="bx--link-with-icon"
                                                 href="https://example.com/"
                                                 onClick={[Function]}
+                                                tabIndex={0}
                                                 target={null}
                                               >
                                                 <a
                                                   className="bx--link bx--link-with-icon"
                                                   href="https://example.com/"
                                                   onClick={[Function]}
+                                                  tabIndex={0}
                                                   target={null}
                                                 >
                                                   <span>
@@ -58362,12 +58508,14 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -58462,12 +58610,14 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -58562,12 +58712,14 @@ exports[`Storyshots Components|LeadSpaceBlock Default 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -59066,12 +59218,14 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -59166,12 +59320,14 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -59266,12 +59422,14 @@ exports[`Storyshots Components|LeadSpaceBlock With Video 1`] = `
                                         className="bx--link-with-icon"
                                         href="https://ibm.com"
                                         onClick={[Function]}
+                                        tabIndex={0}
                                         target={null}
                                       >
                                         <a
                                           className="bx--link bx--link-with-icon"
                                           href="https://ibm.com"
                                           onClick={[Function]}
+                                          tabIndex={0}
                                           target={null}
                                         >
                                           <span>
@@ -60826,12 +60984,14 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                               className="bx--link-with-icon"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -60926,12 +61086,14 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                               className="bx--link-with-icon"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -61029,12 +61191,14 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                               className="bx--link-with-icon"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target="_blank"
                             >
                               <a
                                 className="bx--link bx--link-with-icon"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target="_blank"
                               >
                                 <span>
@@ -61134,11 +61298,13 @@ exports[`Storyshots Components|LinkList End Of Section 1`] = `
                                 className="bx--link-with-icon"
                                 href="#"
                                 onClick={[Function]}
+                                tabIndex={0}
                               >
                                 <a
                                   className="bx--link bx--link-with-icon"
                                   href="#"
                                   onClick={[Function]}
+                                  tabIndex={0}
                                 >
                                   <span>
                                      
@@ -61304,12 +61470,14 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                               className="bx--link-with-icon"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -61405,12 +61573,14 @@ exports[`Storyshots Components|LinkList Horizontal 1`] = `
                               className="bx--link-with-icon"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -61590,12 +61760,14 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                               className="bx--link-with-icon bx--link-with-icon__icon-left"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -61691,12 +61863,14 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                               className="bx--link-with-icon bx--link-with-icon__icon-left"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -61795,12 +61969,14 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                               className="bx--link-with-icon bx--link-with-icon__icon-left"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target="_blank"
                             >
                               <a
                                 className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target="_blank"
                               >
                                 <span>
@@ -61901,11 +62077,13 @@ exports[`Storyshots Components|LinkList Vertical 1`] = `
                                 className="bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="#"
                                 onClick={[Function]}
+                                tabIndex={0}
                               >
                                 <a
                                   className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                   href="#"
                                   onClick={[Function]}
+                                  tabIndex={0}
                                 >
                                   <span>
                                      
@@ -62085,12 +62263,14 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               className="bx--link-with-icon bx--link-with-icon__icon-left"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -62186,12 +62366,14 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               className="bx--link-with-icon bx--link-with-icon__icon-left"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target={null}
                             >
                               <a
                                 className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target={null}
                               >
                                 <span>
@@ -62290,12 +62472,14 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                               className="bx--link-with-icon bx--link-with-icon__icon-left"
                               href="https://ibm.com"
                               onClick={[Function]}
+                              tabIndex={0}
                               target="_blank"
                             >
                               <a
                                 className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="https://ibm.com"
                                 onClick={[Function]}
+                                tabIndex={0}
                                 target="_blank"
                               >
                                 <span>
@@ -62396,11 +62580,13 @@ exports[`Storyshots Components|LinkList Vertical With Cards 1`] = `
                                 className="bx--link-with-icon bx--link-with-icon__icon-left"
                                 href="#"
                                 onClick={[Function]}
+                                tabIndex={0}
                               >
                                 <a
                                   className="bx--link bx--link-with-icon bx--link-with-icon__icon-left"
                                   href="#"
                                   onClick={[Function]}
+                                  tabIndex={0}
                                 >
                                   <span>
                                      
@@ -63267,10 +63453,12 @@ exports[`Storyshots Components|LinkwithIcon Default 1`] = `
           <Link
             className="bx--link-with-icon"
             href="https://www.example.com"
+            tabIndex={0}
           >
             <a
               className="bx--link bx--link-with-icon"
               href="https://www.example.com"
+              tabIndex={0}
             >
               <span>
                 Link text
@@ -65888,12 +66076,14 @@ exports[`Storyshots Components|PictogramItem Default 1`] = `
                                   className="bx--link-with-icon"
                                   href="https://www.example.com"
                                   onClick={[Function]}
+                                  tabIndex={0}
                                   target={null}
                                 >
                                   <a
                                     className="bx--link bx--link-with-icon"
                                     href="https://www.example.com"
                                     onClick={[Function]}
+                                    tabIndex={0}
                                     target={null}
                                   >
                                     <span>
@@ -66049,10 +66239,12 @@ exports[`Storyshots Components|Quote Default 1`] = `
                     <Link
                       className="bx--link-with-icon"
                       href="https://example.com"
+                      tabIndex={0}
                     >
                       <a
                         className="bx--link bx--link-with-icon"
                         href="https://example.com"
+                        tabIndex={0}
                       >
                         <span>
                           Link with Icon

--- a/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
+++ b/packages/react/src/components/LinkWithIcon/LinkWithIcon.js
@@ -37,6 +37,7 @@ const LinkWithIcon = ({
       )}
       data-autoid={`${stablePrefix}--link-with-icon`}>
       <Link
+        tabIndex={0}
         href={href}
         className={classNames(`${prefix}--link-with-icon`, {
           [`${prefix}--link-with-icon__icon-left`]: iconPlacement === 'left',

--- a/packages/react/src/components/Masthead/MastheadMegaMenu/CategoryLink.js
+++ b/packages/react/src/components/Masthead/MastheadMegaMenu/CategoryLink.js
@@ -15,6 +15,7 @@ const { prefix } = settings;
  */
 const CategoryLink = ({ href, title, ...rest }) => (
   <a
+    tabIndex={0}
     href={href}
     className={`${prefix}--masthead__megamenu__category-sublink`}
     data-autoid={`${rest.autoid}-item${rest.index}`}>


### PR DESCRIPTION
### Related Ticket(s)

[MM] When I scroll down and then up a menu, clicking on a mega menu doesn't take me to the destination - Safari only #3641

### Description

When clicking on a link in the megamenu, it triggers the `onBlur` function which checks for the `event.relatedTarget`. This is coming back null on safari. Adding `tabIndex={0}` makes the element appear in the `event.relatedTarget`

https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null

### Changelog


**Changed**

- add `tabIndex={0}` to the megamenu links


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
