### PR TITLE
fix(MegaMenu): disable body scroll when megamenu is open

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -19,6 +19,7 @@ import {
   matches,
 } from '../../../internal/vendor/carbon-components-react/internal/keyboard';
 import { AriaLabelPropType } from '../../../internal/vendor/carbon-components-react/prop-types/AriaPropTypes';
+import root from 'window-or-global';
 
 const { prefix } = settings;
 
@@ -87,8 +88,13 @@ class HeaderMenu extends React.Component {
    */
   handleOnClick = index => {
     this.setState(prevState => {
-      if (prevState.expanded) this.props.setOverlay(false);
-      else this.props.setOverlay(true);
+      if (prevState.expanded) {
+        this.props.setOverlay(false);
+        root.document.body.style.overflowY = 'auto';
+      } else {
+        this.props.setOverlay(true);
+        root.document.body.style.overflowY = 'hidden';
+      }
       return {
         expanded: !prevState.expanded,
       };
@@ -134,6 +140,7 @@ class HeaderMenu extends React.Component {
   handleOnBlur = event => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
       this.setState({ expanded: false, selectedIndex: null });
+      root.document.body.style.overflowY = 'auto';
     }
 
     const megamenuItems = [


### PR DESCRIPTION
### Related Ticket(s)

[MM] Attempting to scroll through the mega menu and the home page scrolls instead #3633

### Description

Disable the body scroll when user has megamenu open on desktop

### Changelog

**Changed**

- when megamenu is expanded, set body overflow-y style to `hidden`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
