### PR TITLE
fix(MegaMenu): prevent shift of IBM logo when opening mobile nav

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -49,10 +49,6 @@ $search-transition-timing: 95ms;
     @include carbon--breakpoint-down(lg) {
       padding: 0 $carbon--spacing-05;
     }
-
-    @include carbon--breakpoint-between('md', 'lg') {
-      padding: 0 $carbon--spacing-05 0 $carbon--spacing-07;
-    }
   }
 }
 
@@ -392,6 +388,10 @@ $search-transition-timing: 95ms;
   }
   .#{$prefix}--header__action.#{$prefix}--overflow-menu {
     height: $spacing-09;
+  }
+
+  .#{$prefix}--header__action--active {
+    position: relative;
   }
 
   .#{$prefix}--masthead--hide-items .#{$prefix}--header__menu-toggle__hidden,


### PR DESCRIPTION
### Related Ticket(s)

[MM] IBM logo changing positions in L0 when mobile menu is opened #3657

### Description

IBM logo was shifting when opening the mobile nav.

BEFORE: 
![Aug-20-2020 18-50-15](https://user-images.githubusercontent.com/54281166/90833651-7b8f5c80-e316-11ea-8083-6103ce4b0f55.gif)

AFTER:
![Aug-20-2020 18-48-52](https://user-images.githubusercontent.com/54281166/90833654-7df1b680-e316-11ea-9a19-64b4a46ac511.gif)


### Changelog

**Changed**

- remove padding when in between `md` and `lg` breakpoints
- set the hamburger icon position to `relative` 

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
