### PR TITLE
fix(AsideElement): top alignment

### DIFF
--- a/packages/react/src/internal/components/ContentBlock/ContentBlock.js
+++ b/packages/react/src/internal/components/ContentBlock/ContentBlock.js
@@ -30,7 +30,8 @@ const ContentBlock = ({
   aside,
   border,
 }) => {
-  const linkListModifierClass = aside && `${prefix}--content-block_linkList`;
+  const linkListModifierClass =
+    aside && `${prefix}--content-block_has-linkList`;
   const classnames = cx(
     `${prefix}--content-block`,
     customClassName,

--- a/packages/react/src/internal/components/ContentBlock/ContentBlock.js
+++ b/packages/react/src/internal/components/ContentBlock/ContentBlock.js
@@ -30,7 +30,12 @@ const ContentBlock = ({
   aside,
   border,
 }) => {
-  const classnames = cx(`${prefix}--content-block`, customClassName);
+  const linkListModifierClass = aside && `${prefix}--content-block_linkList`;
+  const classnames = cx(
+    `${prefix}--content-block`,
+    customClassName,
+    linkListModifierClass
+  );
   const setborder = aside ? false : border;
   const content = (
     <>

--- a/packages/styles/scss/components/content-block-media/_content-block-media.scss
+++ b/packages/styles/scss/components/content-block-media/_content-block-media.scss
@@ -22,6 +22,9 @@
     .#{$prefix}--content-group:last-child {
       margin-bottom: 0;
     }
+    .#{$prefix}--feature-card-block-medium {
+      margin-bottom: 0;
+    }
   }
 
   .#{$prefix}--content-block-media--g100 {

--- a/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
@@ -14,12 +14,6 @@
         margin-bottom: $spacing-07;
       }
     }
-
-    &__item:last-child {
-      .#{$prefix}--content-item {
-        margin-bottom: 0;
-      }
-    }
   }
 }
 @include exports('content-group-pictograms') {

--- a/packages/styles/scss/components/ctasection/_ctasection.scss
+++ b/packages/styles/scss/components/ctasection/_ctasection.scss
@@ -93,10 +93,9 @@
 
         .#{$prefix}--content-item {
           width: 100%;
-          margin-bottom: 0;
-          padding-bottom: $carbon--spacing-05;
+          margin-top: $carbon--spacing-05;
+          margin-bottom: $carbon--spacing-05;
           position: relative;
-
           @include carbon--make-col-ready;
 
           &__heading {
@@ -116,6 +115,7 @@
           }
 
           @include carbon--breakpoint('md') {
+            margin-top: $carbon--spacing-07;
             @include carbon--make-col(4, 8);
 
             &__heading {
@@ -127,12 +127,7 @@
             }
           }
 
-          &:last-of-type {
-            margin-top: $carbon--spacing-05;
-
-            @include carbon--breakpoint('md') {
-              margin-top: $carbon--spacing-07;
-            }
+          @include carbon--breakpoint('md') {
           }
         }
       }

--- a/packages/styles/scss/components/link-list/_link-list.scss
+++ b/packages/styles/scss/components/link-list/_link-list.scss
@@ -7,10 +7,11 @@
 
 @mixin link-list {
   .#{$prefix}--link-list {
-    padding-bottom: $carbon--layout-05;
-
-    &:first-of-type {
-      padding-top: $carbon--layout-05;
+    @include carbon--breakpoint-down('lg') {
+      &:first-of-type {
+        padding-top: $carbon--layout-05;
+        padding-bottom: $carbon--layout-05;
+      }
     }
 
     &__heading {

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -12,15 +12,17 @@
 
 @mixin content-block {
   .#{$prefix}--content-block {
-    padding-top: $carbon--layout-03;
-    padding-bottom: $carbon--layout-05;
-    @include carbon--breakpoint('md') {
-      padding-top: $carbon--layout-05;
-      padding-bottom: $carbon--layout-06;
+    padding-top: $layout-05;
+    padding-bottom: $layout-07;
+
+    @include carbon--breakpoint-down('lg') {
+      padding-bottom: $layout-03;
+
+      &:not(.#{$prefix}--content-block_linkList) {
+        padding-bottom: $layout-06;
+      }
     }
-    @include carbon--breakpoint('max') {
-      padding-bottom: $carbon--layout-07;
-    }
+
     &__heading,
     &__copy {
       @include content-width;

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -18,8 +18,16 @@
     @include carbon--breakpoint-down('lg') {
       padding-bottom: $layout-03;
 
-      &:not(.#{$prefix}--content-block_linkList) {
+      &:not(.#{$prefix}--content-block_has-linkList) {
         padding-bottom: $layout-06;
+      }
+    }
+
+    @include carbon--breakpoint-down('md') {
+      padding-top: $layout-03;
+
+      &:not(.#{$prefix}--content-block_has-linkList) {
+        padding-bottom: $layout-05;
       }
     }
 

--- a/packages/styles/scss/internal/content-item/_content-item.scss
+++ b/packages/styles/scss/internal/content-item/_content-item.scss
@@ -20,8 +20,6 @@
     color: $text-04;
   }
   .#{$prefix}--content-item {
-    margin-top: $carbon--spacing-07;
-    margin-bottom: $carbon--spacing-07;
     &__heading,
     &__copy {
       @include carbon--breakpoint(md) {


### PR DESCRIPTION
### Related Ticket(s)

Content block aside elements not aligning correctly #3454

### Description

Changed a lot of spacing so I can achieve the top position of aside element (Link List component), in other words, it can be aligned with the text right before it and changed other spacing to be according what designers would.

I talked to Lara offline and she said me: 

- When there isn't the stacked Link List, in other words, when Link List isn't below everything should have 160px padding after the card. But on `medium` it should be 96px and smaller resolutions should be 64px. However LinkList starts to be stacked on `large` breakpoint that's why on the code 96px of padding is applied on `large` breakpoint and 64px of padding is applied on `medium` breakpoint, because the `carbon--breakpoint-down` mixin didn't handle `small` breakpoint.

- When there are links that stack at the bottom on smaller breakpoints, it should have the same top and bottom padding as the other designs. 64px top, 96px bottom.



