### PR TITLE
fix(MegaMenu): disable scrolling for mobile nav

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -246,95 +246,104 @@ const Masthead = ({
 
   return (
     <HeaderContainer
-      render={({ isSideNavExpanded, onClickSideNavExpand }) => (
-        <div
-          className={cx(`${prefix}--masthead ${mastheadSticky}`, {
-            [`${prefix}--masthead--hide-items`]: hideNavItems,
-          })}
-          ref={stickyRef}>
-          <div className={`${prefix}--masthead__l0`}>
-            <Header aria-label="IBM" data-autoid={`${stablePrefix}--masthead`}>
-              <SkipToContent />
+      render={({ isSideNavExpanded, onClickSideNavExpand }) => {
+        if (isSideNavExpanded) {
+          root.document.body.classList.add(`${prefix}--body__lock-scroll`);
+        } else {
+          root.document.body.classList.remove(`${prefix}--body__lock-scroll`);
+        }
+        return (
+          <div
+            className={cx(`${prefix}--masthead ${mastheadSticky}`, {
+              [`${prefix}--masthead--hide-items`]: hideNavItems,
+            })}
+            ref={stickyRef}>
+            <div className={`${prefix}--masthead__l0`}>
+              <Header
+                aria-label="IBM"
+                data-autoid={`${stablePrefix}--masthead`}>
+                <SkipToContent />
 
-              {(mastheadL1Data || navigation) && (
-                <HeaderMenuButton
-                  aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
-                  data-autoid={`${stablePrefix}--masthead-${navType}-sidenav__l0-menu`}
-                  onClick={onClickSideNavExpand}
-                  isActive={isSideNavExpanded}
+                {(mastheadL1Data || navigation) && (
+                  <HeaderMenuButton
+                    aria-label={isSideNavExpanded ? 'Close menu' : 'Open menu'}
+                    data-autoid={`${stablePrefix}--masthead-${navType}-sidenav__l0-menu`}
+                    onClick={onClickSideNavExpand}
+                    isActive={isSideNavExpanded}
+                  />
+                )}
+
+                {(navigation || mastheadL1Data) && isSideNavExpanded && (
+                  <MastheadLeftNav
+                    {...mastheadProps}
+                    backButtonText="Back"
+                    platform={platform}
+                    navigation={mastheadL1Data?.navigationL1 ?? mastheadData}
+                    isSideNavExpanded={isSideNavExpanded}
+                    navType={navType}
+                  />
+                )}
+
+                <IbmLogo
+                  autoid={`${stablePrefix}--masthead-${navType}__l0-logo`}
                 />
-              )}
 
-              {(navigation || mastheadL1Data) && isSideNavExpanded && (
-                <MastheadLeftNav
-                  {...mastheadProps}
-                  backButtonText="Back"
-                  platform={platform}
-                  navigation={mastheadL1Data?.navigationL1 ?? mastheadData}
-                  isSideNavExpanded={isSideNavExpanded}
+                <div className={`${prefix}--header__search ${hasPlatform}`}>
+                  {navigation && !mastheadL1Data && (
+                    <MastheadTopNav
+                      {...mastheadProps}
+                      platform={platform}
+                      navigation={mastheadData}
+                      navType={navType}
+                    />
+                  )}
+                  {hasSearch && (
+                    <MastheadSearch
+                      searchOpenOnload={searchOpenOnload}
+                      placeHolderText={placeHolderText}
+                      navType={navType}
+                    />
+                  )}
+                </div>
+
+                {hasProfile && (
+                  <HeaderGlobalBar>
+                    <MastheadProfile
+                      overflowMenuProps={{
+                        ariaLabel: 'User Profile',
+                        'data-autoid': `${stablePrefix}--masthead-${navType}__l0-account`,
+                        flipped: true,
+                        style: { width: '3rem' },
+                        onOpen: () => _setProfileListPosition(),
+                        renderIcon: () =>
+                          isAuthenticated ? <UserOnline20 /> : <User20 />,
+                      }}
+                      overflowMenuItemProps={{
+                        wrapperClassName: `${prefix}--masthead__profile-item`,
+                      }}
+                      profileMenu={
+                        isAuthenticated
+                          ? profileData.signedin
+                          : profileData.signedout
+                      }
+                      navType={navType}
+                    />
+                  </HeaderGlobalBar>
+                )}
+              </Header>
+            </div>
+            {mastheadL1Data && DDS_MASTHEAD_L1 && (
+              <div ref={mastheadL1Ref}>
+                <MastheadL1
+                  {...mastheadL1Data}
+                  isShort={isMastheadSticky}
                   navType={navType}
                 />
-              )}
-
-              <IbmLogo
-                autoid={`${stablePrefix}--masthead-${navType}__l0-logo`}
-              />
-
-              <div className={`${prefix}--header__search ${hasPlatform}`}>
-                {navigation && !mastheadL1Data && (
-                  <MastheadTopNav
-                    {...mastheadProps}
-                    platform={platform}
-                    navigation={mastheadData}
-                    navType={navType}
-                  />
-                )}
-                {hasSearch && (
-                  <MastheadSearch
-                    searchOpenOnload={searchOpenOnload}
-                    placeHolderText={placeHolderText}
-                    navType={navType}
-                  />
-                )}
               </div>
-
-              {hasProfile && (
-                <HeaderGlobalBar>
-                  <MastheadProfile
-                    overflowMenuProps={{
-                      ariaLabel: 'User Profile',
-                      'data-autoid': `${stablePrefix}--masthead-${navType}__l0-account`,
-                      flipped: true,
-                      style: { width: '3rem' },
-                      onOpen: () => _setProfileListPosition(),
-                      renderIcon: () =>
-                        isAuthenticated ? <UserOnline20 /> : <User20 />,
-                    }}
-                    overflowMenuItemProps={{
-                      wrapperClassName: `${prefix}--masthead__profile-item`,
-                    }}
-                    profileMenu={
-                      isAuthenticated
-                        ? profileData.signedin
-                        : profileData.signedout
-                    }
-                    navType={navType}
-                  />
-                </HeaderGlobalBar>
-              )}
-            </Header>
+            )}
           </div>
-          {mastheadL1Data && DDS_MASTHEAD_L1 && (
-            <div ref={mastheadL1Ref}>
-              <MastheadL1
-                {...mastheadL1Data}
-                isShort={isMastheadSticky}
-                navType={navType}
-              />
-            </div>
-          )}
-        </div>
-      )}
+        );
+      }}
     />
   );
 };

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -90,10 +90,10 @@ class HeaderMenu extends React.Component {
     this.setState(prevState => {
       if (prevState.expanded) {
         this.props.setOverlay(false);
-        root.document.body.style.overflowY = 'auto';
+        root.document.body.classList.remove(`${prefix}--body__lock-scroll`);
       } else {
         this.props.setOverlay(true);
-        root.document.body.style.overflowY = 'hidden';
+        root.document.body.classList.add(`${prefix}--body__lock-scroll`);
       }
       return {
         expanded: !prevState.expanded,
@@ -140,7 +140,7 @@ class HeaderMenu extends React.Component {
   handleOnBlur = event => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
       this.setState({ expanded: false, selectedIndex: null });
-      root.document.body.style.overflowY = 'auto';
+      root.document.body.classList.remove(`${prefix}--body__lock-scroll`);
     }
 
     const megamenuItems = [

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -133,6 +133,7 @@
     &[aria-expanded='true'] {
       + .#{$prefix}--side-nav__menu[role='menu'] {
         position: absolute;
+        padding-bottom: $layout-05;
         top: 0;
         background: $ui-background;
         z-index: 1;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -94,6 +94,8 @@
     }
 
     &--expanded {
+      overflow-y: auto;
+
       @include carbon--breakpoint-down(md) {
         max-width: 100vw;
         width: 100vw;

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -137,7 +137,7 @@
         background: $ui-background;
         z-index: 1;
         width: 100%;
-        height: 100%;
+        min-height: 100%;
         transform: translateX(0);
         transition-timing-function: $search-transition;
         transition-duration: $search-transition-timing;

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -405,6 +405,11 @@ $search-transition-timing: 95ms;
   .#{$prefix}--masthead--hide-items .#{$prefix}--header__nav-container {
     display: none;
   }
+
+  .#{$prefix}--body__lock-scroll {
+    position: relative;
+    overflow: hidden;
+  }
 }
 
 @include exports('masthead') {


### PR DESCRIPTION
### Related Ticket(s)

Component:- Masthead/Dotcom Shell(Stage) :- Scroll is not working on mega menu #3661

### Description

When user has mobile nav open and scrolls, the body scroll was getting triggered. Disable the body scroll when mobile nav is open.

<img width="414" alt="Screen Shot 2020-08-24 at 11 05 28 AM" src="https://user-images.githubusercontent.com/54281166/91061115-c69cbe80-e5f9-11ea-8446-5a5a67900162.png">

### Changelog

**Changed**

- add `${prefix}--body__lock-scroll` class to the `body` when mobile nav is open. 
- `${prefix}--body__lock-scroll` sets the body to `overflow: hidden`
- add `64px` to the bottom of the mobile nav so that last menu item for menus that overflow can be seen when there is a bottom nav bar from browser


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
