### PR TITLE
fix(expressivetheme): enable css custom properties with the theme

### DIFF
--- a/packages/react/.storybook/webpack.config.js
+++ b/packages/react/.storybook/webpack.config.js
@@ -14,14 +14,6 @@ const rtlcss = require('rtlcss');
 const NODE_ENV = 'development';
 
 /**
- * Flag to enable the expressive theme
- *
- * @type {boolean}
- */
-const useCarbonExpressive =
-  process.env.REACT_STORYBOOK_CARBON_EXPRESSIVE === 'true';
-
-/**
  * Flag to switch to use the miniextract plugin
  *
  * @type {boolean}
@@ -126,9 +118,6 @@ module.exports = ({ config, mode }) => {
         $feature-flags: (
           enable-css-custom-properties: true
         );
-        $dds-feature-flags: (
-          carbon-expressive: ${useCarbonExpressive},
-        );
       `,
       sourceMap: useStyleSourceMap,
     },
@@ -144,9 +133,6 @@ module.exports = ({ config, mode }) => {
       data: `
       $feature-flags: (
         enable-css-custom-properties: true
-      );
-      $dds-feature-flags: (
-        carbon-expressive: ${useCarbonExpressive},
       );
     `,
     },

--- a/packages/styles/.storybook/_container.scss
+++ b/packages/styles/.storybook/_container.scss
@@ -9,10 +9,6 @@
 // as `src` directory is _not_ meant to be shipped in our NPM package.
 // Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
 
-$feature-flags: (
-  enable-css-custom-properties: true,
-);
-
 // Carbon Fonts
 @import '~@carbon/type/scss/font-face/mono';
 @import '~@carbon/type/scss/font-face/sans';

--- a/packages/styles/.storybook/webpack.config.js
+++ b/packages/styles/.storybook/webpack.config.js
@@ -71,12 +71,6 @@ const styleLoaders = [
         path.resolve(__dirname, '..', 'node_modules'),
         path.resolve(__dirname, '../../../', 'node_modules'),
       ],
-      data: `
-        $feature-flags: (
-          ui-shell: true,
-          enable-css-custom-properties: true
-        );
-      `,
       sourceMap: useStyleSourceMap,
     },
   },

--- a/packages/styles/.storybook/webpack.config.js
+++ b/packages/styles/.storybook/webpack.config.js
@@ -71,6 +71,11 @@ const styleLoaders = [
         path.resolve(__dirname, '..', 'node_modules'),
         path.resolve(__dirname, '../../../', 'node_modules'),
       ],
+      data: `
+        $feature-flags: (
+          enable-css-custom-properties: true
+        );
+      `,
       sourceMap: useStyleSourceMap,
     },
   },

--- a/packages/styles/scss/themes/expressive/README.md
+++ b/packages/styles/scss/themes/expressive/README.md
@@ -18,6 +18,36 @@ yarn add @carbon/ibmdotcom-styles
 
 ## Usage
 
+### CSS Custom Properties
+
+In order for the expressive theme to work, CSS Custom Properties needs to be
+enabled. This needs to be introduced before any other imports:
+
+```scss
+$feature-flags: (
+  enable-css-custom-properties: true,
+);
+```
+
+This can also be added in webpack configurations:
+
+```javascript
+const sassLoader = {
+  loader: 'sass-loader',
+  options: {
+    includePaths: [path.resolve(__dirname, '..', 'node_modules')],
+    data: `
+        $feature-flags: (
+          enable-css-custom-properties: true
+        );
+      `,
+    sourceMap: true,
+  },
+};
+```
+
+### CSS Import
+
 This includes the expressive theme that would be applied to all Carbon
 components, as well as adjustments to the core type scale for IBM.com Library
 components and patterns.

--- a/packages/styles/scss/themes/expressive/index.scss
+++ b/packages/styles/scss/themes/expressive/index.scss
@@ -43,12 +43,6 @@
 // Expressive Theme
 //-------------------------
 
-// CSS Custom Properties need to be enabled in order for the expressive theme
-// to work.
-$feature-flags: (
-  enable-css-custom-properties: true,
-);
-
 // This includes an overall expressive theme throughout the carbon design
 // system. In addition to the global changes in typography sizes, this also
 // addresses per-component container and icon spacing to account for the size

--- a/packages/styles/scss/themes/expressive/index.scss
+++ b/packages/styles/scss/themes/expressive/index.scss
@@ -43,6 +43,12 @@
 // Expressive Theme
 //-------------------------
 
+// CSS Custom Properties need to be enabled in order for the expressive theme
+// to work.
+$feature-flags: (
+  enable-css-custom-properties: true,
+);
+
 // This includes an overall expressive theme throughout the carbon design
 // system. In addition to the global changes in typography sizes, this also
 // addresses per-component container and icon spacing to account for the size


### PR DESCRIPTION
### Related Ticket(s)

Refs #3698, #3643

### Description

Currently the only way for the theme to work is to enable CSS custom
properties in Carbon.

~This is a test to enable CSS Custom properties by default in the expressive theme.~
This approach does not work, so adding documentation on how to enable by default.

### Changelog

**Changed**

- enable `enable-css-custom-properties` by default