### PR TITLE
docs(expressivetheme): updating docs for expressive theme

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -35,27 +35,30 @@ yarn add @carbon/ibmdotcom-react
 2. Components do not import any of the styles themselves, use the scss or css
    from `@carbon/ibmdotcom-styles` to bring in styling.
 
+### Styles
+
+Styles are in a separate package entirely, as they are considered to be
+framework agnostic and can be used with any framework.
+[Learn how to include styles here](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles/README.md).
+
 ## Usage
 
 ### List of Available Components
 
-View available React Components and patterns
-[here](https://ibmdotcom-react.mybluemix.net). You can see usage information in
-several ways:
+View available React Components [here](https://ibmdotcom-react.mybluemix.net).
+You can see usage information in several ways:
 
-1. Clicking the blue **Show Info** icon in the top right corner of the selected
-   component. You can see the list of available React props
+1. Clicking the **DOCS** tab in the top of the selected component. You can see
+   the list of available React props as well as how to use in your project.
 2. Clicking the **STORY** tab at the bottom. This tab contains the code that
    shows how the component is being used
 3. Clicking the **KNOBS** tab at the bottom and changing values there. Most
    knobs are shown as something like `Button kind (kind)`, where `kind` is the
    name of React prop
-4. Clicking the **ACTION LOGGER** tab at the bottom and interacting with the
-   selected component. You may see something like `onClick` which typically
-   indicates that the event handler (React prop) with the same name is called.
-   You can also expand the twistie to see the details of the event
-5. Clicking the **README** tab at the bottom. You can see some more document for
-   some components
+4. Clicking the **CARBON THEME** tab at the bottom and interacting with the
+   selected component. You can see what the component looks like in the four
+   available Carbon themes (NOTE: not all components are available in all
+   themes).
 
 ## Documentation
 

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -18,6 +18,62 @@ instead:
 yarn add @carbon/ibmdotcom-styles
 ```
 
+## Expressive Theme
+
+The IBM.com Library runs optimally with the expressive theme enabled.
+
+### Step 1: CSS Custom Properties
+
+In order for the expressive theme to work, CSS Custom Properties needs to be
+enabled. This needs to be introduced before any other imports:
+
+```scss
+$feature-flags: (
+  enable-css-custom-properties: true,
+);
+```
+
+This can also be added in webpack configurations:
+
+```javascript
+const sassLoader = {
+  loader: 'sass-loader',
+  options: {
+    includePaths: [path.resolve(__dirname, '..', 'node_modules')],
+    data: `
+        $feature-flags: (
+          enable-css-custom-properties: true
+        );
+      `,
+    sourceMap: true,
+  },
+};
+```
+
+### Step 2: CSS Import
+
+This includes the expressive theme that would be applied to all Carbon
+components, as well as adjustments to the core type scale for IBM.com Library
+components and patterns.
+
+```css
+@import '@carbon/ibmdotcom-styles/scss/themes/expressive/index';
+```
+
+### Learn More
+
+To read more about the expressive theme, visit
+https://www.ibm.com/standards/web/guidelines/expressive-theme.
+
+To see a storybook output of the Carbon components with the expressive theme
+applied, run the following command:
+
+```bash
+$ yarn storybook
+```
+
+This can also be viewed [here](https://carbon-expressive.mybluemix.net).
+
 ## Usage
 
 Import the package css into the top of your main CSS file.
@@ -27,7 +83,7 @@ Import the package css into the top of your main CSS file.
 ```
 
 In Webpack, the full package can also be included to the root of your
-application:
+application (though is recommended only for testing):
 
 ```javascript
 import '@carbon/ibmdotcom-styles';
@@ -43,20 +99,6 @@ SASS_PATH=node_modules:src
 
 💡 If importing `carbon-components.min.css`, remember to import our CSS after
 it.
-
-## Expressive Theme
-
-In addition to styles for IBM.com Library components and patterns, this package
-includes the
-[expressive theme](https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/styles/scss/themes/expressive)
-for all Carbon components. To see a storybook output of the Carbon components
-with the expressive theme applied, run the following command:
-
-```bash
-$ yarn storybook
-```
-
-This can also be viewed [here](https://carbon-expressive.mybluemix.net).
 
 ## Documentation
 

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -75,6 +75,13 @@ Once you do that, you can use our components as easy as using HTML tags, like:
 > [CodeSandbox](https://githubbox.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/web-components/examples/codesandbox/components/masthead)
 > example implementation.
 
+### Expressive Theme
+
+While styles are included as part of the web components, the expressive theme
+for Carbon requires the `CSS Custom Properties` flag in Carbon to be enabled.
+
+[Learn how to activate CSS Custom Properties here](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/styles/README.md).
+
 ## Browser support
 
 Based on [ibm.com browser support](https://www.ibm.com/standards/web/browser-support/):


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

These are updated documentation for adopters on how to use the expressive theme. Since we have discovered that CSS custom properties needs to be enabled for it to work, this documentation needed to be included.

### Changelog

**Changed**

- READMEs changes