### PR TITLE
fix(MegaMenu): add scroll for submenu

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -139,6 +139,7 @@
     &[aria-expanded='true'] {
       + .#{$prefix}--side-nav__menu[role='menu'] {
         position: absolute;
+        overflow-y: auto;
         padding-bottom: $layout-05;
         top: 0;
         background: $ui-background;


### PR DESCRIPTION
### Related Ticket(s)

[MM] In the hamburger menu, I'm unable to scroll down the menu for Learn & Support - What Is #3718

### Description

Add `overflow-y: auto` for the submenu as the "What is..." menu was not scrolling

![Aug-25-2020 11-47-00](https://user-images.githubusercontent.com/54281166/91197117-fcf53f00-e6c8-11ea-8979-39924534cc8a.gif)


### Changelog

**Changed**

- specify `overflow-y: auto` 


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
