### PR TITLE
fix(Masthead): keep focus in sub menus

### DIFF
--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -31,14 +31,6 @@ const MastheadLeftNav = ({
 }) => {
   const sideNavRef = useRef();
 
-  const preventOutFocus = () => {
-    if (isSideNavExpanded && useRef) {
-      sideNavRef.current?.parentNode
-        .querySelector(`.${prefix}--header__menu-toggle`)
-        .focus();
-    }
-  };
-
   /**
    * Left side navigation
    *
@@ -65,7 +57,14 @@ const MastheadLeftNav = ({
             </SideNavMenuWithBackFoward>
             <button
               className={`${prefix}--masthead__focus`}
-              onFocus={preventOutFocus}
+              onFocus={() => {
+                preventOutFocus(
+                  sideNavRef.current?.parentNode.querySelector(
+                    `.${prefix}--header__menu-toggle`
+                  ),
+                  isSideNavExpanded
+                );
+              }}
               aria-hidden={true}></button>
           </>
         );
@@ -96,10 +95,16 @@ const MastheadLeftNav = ({
               {link.title}
             </SideNavLink>
             <button
-              className={`${prefix}--masthead__focus}`}
-              onFocus={preventOutFocus}
-              aria-hidden={true}
-              href="#"></button>
+              className={`${prefix}--masthead__focus`}
+              onFocus={() => {
+                preventOutFocus(
+                  sideNavRef.current?.parentNode.querySelector(
+                    `.${prefix}--header__menu-toggle`
+                  ),
+                  isSideNavExpanded
+                );
+              }}
+              aria-hidden={true}></button>
           </>
         );
       }
@@ -139,6 +144,12 @@ const MastheadLeftNav = ({
   );
 };
 
+const preventOutFocus = (target, isSideNavExpanded) => {
+  if (isSideNavExpanded) {
+    target.focus();
+  }
+};
+
 /**
  * Loops through and renders a list of links for the side nav
  *
@@ -173,6 +184,17 @@ function renderNavSections(sections, backButtonText, autoid, navType) {
             key={item.title}>
             {item.title}
           </SideNavMenuItem>
+        );
+      }
+
+      if (j === section.menuItems.length - 1) {
+        sectionItems.push(
+          <button
+            className={`${prefix}--masthead__focus`}
+            onFocus={e => {
+              preventOutFocus(e.target.parentElement.querySelector('a'), true);
+            }}
+            aria-hidden={true}></button>
         );
       }
     });

--- a/packages/react/src/components/Masthead/MastheadLeftNav.js
+++ b/packages/react/src/components/Masthead/MastheadLeftNav.js
@@ -174,6 +174,15 @@ function renderNavSections(sections, backButtonText, autoid, navType) {
             navType={navType}
             key={j}>
             {renderNavItem(item.megapanelContent.quickLinks.links, dataAutoId)}
+            <button
+              className={`${prefix}--masthead__focus`}
+              onFocus={e => {
+                preventOutFocus(
+                  e.target.parentElement.querySelector('a'),
+                  true
+                );
+              }}
+              aria-hidden={true}></button>
           </SideNavMenuWithBackFoward>
         );
       } else {

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -21,6 +21,9 @@
 
   .#{$prefix}--masthead__focus {
     opacity: 0;
+    padding: 0;
+    height: 0;
+    width: 0;
   }
 
   .#{$prefix}--masthead .#{$prefix}--side-nav__navigation {


### PR DESCRIPTION
### Related Ticket(s)

#3663

### Description

Added a sentinel in order to keep focus on the currently selected sub menu