### PR TITLE
fix(footer): adding locale modal import to the footer

### DIFF
--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -21,8 +21,8 @@ import { FOOTER_SIZE } from './footer';
 import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
 // Above import is interface-only ref and thus code won't be brought into the build
 import '../locale-modal/locale-modal-composite';
-import './footer';
 /* eslint-enable import/no-duplicates */
+import './footer';
 import './footer-logo';
 import './footer-nav';
 import './footer-nav-group';

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -25,7 +25,7 @@ import './locale-button';
 import './legal-nav';
 import './legal-nav-item';
 import './legal-nav-cookie-preferences-placeholder';
-import '../locale-modal/locale-modal-container';
+import '../locale-modal/locale-modal-composite';
 import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
 
 const { stablePrefix: ddsPrefix } = ddsSettings;

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -18,11 +18,12 @@ import { BasicLink, BasicLinkSet, Translation } from '../../globals/services-sto
 import Handle from '../../globals/internal/handle';
 /* eslint-disable import/no-duplicates */
 import { FOOTER_SIZE } from './footer';
+// Above import is interface-only ref and thus code won't be brought into the build
+import './footer';
 import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
 // Above import is interface-only ref and thus code won't be brought into the build
 import '../locale-modal/locale-modal-composite';
 /* eslint-enable import/no-duplicates */
-import './footer';
 import './footer-logo';
 import './footer-nav';
 import './footer-nav-group';

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -16,7 +16,13 @@ import ModalRenderMixin from '../../globals/mixins/modal-render';
 import { LocaleList } from '../../globals/services-store/types/localeAPI';
 import { BasicLink, BasicLinkSet, Translation } from '../../globals/services-store/types/translateAPI';
 import Handle from '../../globals/internal/handle';
+/* eslint-disable import/no-duplicates */
 import { FOOTER_SIZE } from './footer';
+import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
+// Above import is interface-only ref and thus code won't be brought into the build
+import '../locale-modal/locale-modal-composite';
+import './footer';
+/* eslint-enable import/no-duplicates */
 import './footer-logo';
 import './footer-nav';
 import './footer-nav-group';
@@ -25,11 +31,6 @@ import './locale-button';
 import './legal-nav';
 import './legal-nav-item';
 import './legal-nav-cookie-preferences-placeholder';
-/* eslint-disable import/no-duplicates */
-import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
-// Above import is interface-only ref and thus code won't be brought into the build
-import '../locale-modal/locale-modal-composite';
-/* eslint-enable import/no-duplicates */
 
 const { stablePrefix: ddsPrefix } = ddsSettings;
 

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -25,6 +25,7 @@ import './locale-button';
 import './legal-nav';
 import './legal-nav-item';
 import './legal-nav-cookie-preferences-placeholder';
+import '../locale-modal/locale-modal-container';
 import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
 
 const { stablePrefix: ddsPrefix } = ddsSettings;

--- a/packages/web-components/src/components/footer/footer-composite.ts
+++ b/packages/web-components/src/components/footer/footer-composite.ts
@@ -25,8 +25,11 @@ import './locale-button';
 import './legal-nav';
 import './legal-nav-item';
 import './legal-nav-cookie-preferences-placeholder';
-import '../locale-modal/locale-modal-composite';
+/* eslint-disable import/no-duplicates */
 import { LocaleModalLocaleList } from '../locale-modal/locale-modal-composite';
+// Above import is interface-only ref and thus code won't be brought into the build
+import '../locale-modal/locale-modal-composite';
+/* eslint-enable import/no-duplicates */
 
 const { stablePrefix: ddsPrefix } = ddsSettings;
 

--- a/packages/web-components/src/components/footer/locale-button.ts
+++ b/packages/web-components/src/components/footer/locale-button.ts
@@ -13,7 +13,6 @@ import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/setti
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus';
 import EarthFilled20 from 'carbon-web-components/es/icons/earth--filled/20';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
-import '../locale-modal/locale-modal-container';
 import styles from './footer.scss';
 
 const { prefix } = settings;

--- a/packages/web-components/src/components/footer/locale-button.ts
+++ b/packages/web-components/src/components/footer/locale-button.ts
@@ -13,6 +13,7 @@ import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/setti
 import FocusMixin from 'carbon-web-components/es/globals/mixins/focus';
 import EarthFilled20 from 'carbon-web-components/es/icons/earth--filled/20';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
+import '../locale-modal/locale-modal-container';
 import styles from './footer.scss';
 
 const { prefix } = settings;


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The footer is missing the import for the locale modal, so this includes it.

### Changelog

**Changed**

- Adding locale modal import to the footer.