### PR TITLE
fix(locale-modal): add missing import

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -13,6 +13,9 @@ import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/setti
 import ArrowLeft20 from 'carbon-web-components/es/icons/arrow--left/20';
 import EarthFilled20 from 'carbon-web-components/es/icons/earth--filled/20';
 import DDSModal from '../modal/modal';
+import '../modal/modal-header';
+import '../modal/modal-heading';
+import '../modal/modal-close-button';
 import DDSLocaleSearch from './locale-search';
 import DDSRegionItem from './region-item';
 import styles from './locale-modal.scss';


### PR DESCRIPTION
### Description

`<dds-locale-modal>` renders several other components in shadow DOM, but those components were not declaraed as the dependencies. Fixed that problem.

### Changelog

**New**

- Add missing imports in `<dds-locale-modal>`.