### PR TITLE
chore(masthead): fix to nav type proptype definition

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -434,7 +434,7 @@ MastheadSearch.propTypes = {
   /**
    * navigation type for autoids
    */
-  navType: PropTypes.oneOf(['default, alt, eco']),
+  navType: PropTypes.oneOf(['default', 'alt', 'eco']),
 };
 
 MastheadSearch.defaultProps = {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Spotted a misaligned proptype definition for `MastheadSearch`.

### Changelog

**Changed**

- MastheadSearch propTypes