### PR TITLE
fix(MegaMenu): explicity set focus to HeaderMenu L0 item when clicked

### DIFF
--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -81,6 +81,7 @@ class HeaderMenu extends React.Component {
       selectedIndex: null,
     };
     this.items = [];
+    this.menuLinkRef = React.createRef();
   }
 
   /**
@@ -125,6 +126,7 @@ class HeaderMenu extends React.Component {
       `${prefix}--masthead__megamenu__category-headline`,
       `${prefix}--masthead__megamenu__category-group`,
       `${prefix}--masthead__megamenu__view-all-cta`,
+      `${prefix}--masthead__megamenu__l0-nav`,
     ];
 
     return megamenuItems.filter(item =>
@@ -192,6 +194,14 @@ class HeaderMenu extends React.Component {
     }
   };
 
+  /**
+   * This forces focus on the menu link when clicked on
+   */
+  handleFocus = event => {
+    event.preventDefault();
+    this.menuLinkRef.current.focus();
+  };
+
   render() {
     const {
       'aria-label': ariaLabel,
@@ -227,11 +237,12 @@ class HeaderMenu extends React.Component {
           aria-expanded={this.state.expanded}
           className={`${prefix}--header__menu-item ${prefix}--header__menu-title`}
           href="#"
-          onClick={event => event.preventDefault()}
+          onClick={this.handleFocus}
           onKeyDown={this.handleOnKeyDown}
           ref={this.handleMenuButtonRef}
           role="menuitem"
           tabIndex={0}
+          ref={this.menuLinkRef}
           {...accessibilityLabel}>
           {menuLinkName}
           <MenuContent />


### PR DESCRIPTION
### Related Ticket(s)

[MM] My IBM maintaining focus when switching to mega menu #3617
[HP] [MM] multiple menus open at once #3731


### Description

The `<OverflowMenu />` component that we are using for the profile menu has logic to trap the focus when user clicks outside of the component. This affects the megamenu when user opens the profile menu, then clicks on the L0 nav item. The focus is trapped in the `<OverflowMenu />` which affects the `onBlur` event triggered used when opening another L0 nav item.

This PR forces focus on the L0 nav item when it is clicked.

**BEFORE:**
![Aug-26-2020 16-17-05](https://user-images.githubusercontent.com/54281166/91353175-e4fce880-e7b8-11ea-9d67-bf5c0b05101c.gif)

**AFTER:**
![Aug-26-2020 16-19-33](https://user-images.githubusercontent.com/54281166/91353192-e9c19c80-e7b8-11ea-823a-1a630b3beaf7.gif)


### Changelog

**Changed**

- force focus on the `HeaderMenu` L0 item



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
