### PR TITLE
fix(MegaMenu): account for focus within the megamenu component

### DIFF
--- a/packages/react/src/components/Masthead/MastheadMegaMenu/NavigationGroup.js
+++ b/packages/react/src/components/Masthead/MastheadMegaMenu/NavigationGroup.js
@@ -18,6 +18,7 @@ const { prefix } = settings;
  */
 const NavigationGroup = ({ hasHighlights, children, ...rest }) => (
   <section
+    tabIndex={-1}
     className={classnames(`${prefix}--masthead__megamenu`, {
       [`${prefix}--masthead__megamenu__container--hasHighlights`]: hasHighlights,
     })}

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -87,7 +87,9 @@ class HeaderMenu extends React.Component {
   /**
    * Toggle the expanded state of the menu on click.
    */
-  handleOnClick = index => {
+  handleOnClick = event => {
+    this.menuLinkRef.current.focus();
+
     this.setState(prevState => {
       if (prevState.expanded) {
         this.props.setOverlay(false);
@@ -127,6 +129,7 @@ class HeaderMenu extends React.Component {
       `${prefix}--masthead__megamenu__category-group`,
       `${prefix}--masthead__megamenu__view-all-cta`,
       `${prefix}--masthead__megamenu__l0-nav`,
+      `${prefix}--header__menu`,
     ];
 
     return megamenuItems.filter(item =>
@@ -194,14 +197,6 @@ class HeaderMenu extends React.Component {
     }
   };
 
-  /**
-   * This forces focus on the menu link when clicked on
-   */
-  handleFocus = event => {
-    event.preventDefault();
-    this.menuLinkRef.current.focus();
-  };
-
   render() {
     const {
       'aria-label': ariaLabel,
@@ -230,14 +225,13 @@ class HeaderMenu extends React.Component {
         className={className}
         data-autoid={autoId}
         onKeyDown={this.handleMenuClose}
-        onClick={this.handleOnClick}
         onBlur={this.handleOnBlur}>
         <a // eslint-disable-line jsx-a11y/role-supports-aria-props,jsx-a11y/anchor-is-valid
           aria-haspopup="menu" // eslint-disable-line jsx-a11y/aria-proptypes
           aria-expanded={this.state.expanded}
           className={`${prefix}--header__menu-item ${prefix}--header__menu-title`}
           href="#"
-          onClick={this.handleFocus}
+          onClick={this.handleOnClick}
           onKeyDown={this.handleOnKeyDown}
           ref={this.handleMenuButtonRef}
           role="menuitem"

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -41,6 +41,10 @@
     overflow-y: scroll;
     background-color: $ui-background;
 
+    &:focus {
+      outline: none;
+    }
+
     @include box-shadow;
   }
 


### PR DESCRIPTION
### Related Ticket(s)

[MM]: When clicking on empty space, megamenu does not close causing stacking #3758

### Description

When user clicked on the empty space within the megamenu, the focus on the L0 nav item was lost causing issues with the `onBlur()` event. Also the `onClick()` event was placed on the wrapper container of the `<HeaderMenu />` which caused the menu to open and close unnecessarily. 

The `onClick()` event has been moved to specifically  the anchor tag so that the menu does not toggle its expanded state when user clicks anywhere within the menu. Adding `tabIndex` to the `<NavigationGroup />` (which is the container component for the megamenu) so that when user clicks on it, it will be captured in `event.relatedTarget` used in the `onBlur()` method otherwise it will render null. 

**BEFORE:**
![Aug-27-2020 11-22-36](https://user-images.githubusercontent.com/54281166/91462012-ae29df80-e857-11ea-89b6-09d324bacb13.gif)



**AFTER:**
![Aug-27-2020 11-13-39](https://user-images.githubusercontent.com/54281166/91461796-6c009e00-e857-11ea-95cf-6109847696b1.gif)

### Changelog

**Changed**

- add the `bx--header-menu` class to the list of elements checked in the `onBlur()` event to ensure the overlay doesn't toggle when clicking within the menu
- moved the `onClick()` function to the specific anchor tag instead of the wrapper.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
