### PR TITLE
test(integration-ui): navigation in beforeEach

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -117,21 +117,25 @@ jobs:
         env:
           DDS_UI_INTEGRATION_TEST_BROWSER: ${{ matrix.browser }}
           DDS_UI_INTEGRATION_TEST_TIMEOUT: 60000
+          LAUNCH_TIMEOUT: 600000
       - name: Run checks with xvfb (Web Components)
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run --auto-servernum yarn lerna run --stream --prefix --scope=@carbon/ibmdotcom-web-components test:integration:ui
         env:
           DDS_UI_INTEGRATION_TEST_BROWSER: ${{ matrix.browser }}
           DDS_UI_INTEGRATION_TEST_TIMEOUT: 60000
+          LAUNCH_TIMEOUT: 600000
       - name: Run checks without xvfb (React)
         if: matrix.os != 'ubuntu-latest'
         run: yarn lerna run --stream --prefix --scope=@carbon/ibmdotcom-react test:integration:ui
         env:
           DDS_UI_INTEGRATION_TEST_BROWSER: ${{ matrix.browser }}
           DDS_UI_INTEGRATION_TEST_TIMEOUT: 60000
+          LAUNCH_TIMEOUT: 600000
       - name: Run checks without xvfb (Web Components)
         if: matrix.os != 'ubuntu-latest'
         run: yarn lerna run --stream --prefix --scope=@carbon/ibmdotcom-web-components test:integration:ui
         env:
           DDS_UI_INTEGRATION_TEST_BROWSER: ${{ matrix.browser }}
           DDS_UI_INTEGRATION_TEST_TIMEOUT: 60000
+          LAUNCH_TIMEOUT: 600000

--- a/packages/react/tests/integration/ui/setup-env.js
+++ b/packages/react/tests/integration/ui/setup-env.js
@@ -9,5 +9,9 @@
 
 'use strict';
 
-const testTimeout = Number(process.env.DDS_UI_INTEGRATION_TEST_TIMEOUT);
-jest.setTimeout(isNaN(testTimeout) ? 30000 : testTimeout);
+/* global page */
+
+const testTimeoutEnv = Number(process.env.DDS_BUILD_INTEGRATION_TEST_TIMEOUT);
+const testTimeout = isNaN(testTimeoutEnv) ? 30000 : testTimeoutEnv;
+jest.setTimeout(testTimeout);
+page.setDefaultNavigationTimeout(testTimeout);

--- a/packages/web-components/src/components/masthead/__tests__/masthead.steps.js
+++ b/packages/web-components/src/components/masthead/__tests__/masthead.steps.js
@@ -8,16 +8,13 @@
  */
 
 describe('dds-masthead-*', () => {
-  let navigated;
-
   describe('With wide screen', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       await page.setViewportSize({ width: 1280, height: 720 });
       await page.goto(`http://localhost:${process.env.PORT}/iframe.html?id=components-masthead--default&mock`);
     });
 
     it('should support clicking the logo', async () => {
-      navigated = true;
       const promiseNavigation = page.waitForNavigation();
       await page.click('dds-masthead-logo');
       await promiseNavigation;
@@ -26,7 +23,6 @@ describe('dds-masthead-*', () => {
 
     it('should support navigating in profile menu', async () => {
       await page.click('dds-masthead-profile');
-      navigated = true;
       const promiseNavigation = page.waitForNavigation();
       await page.click('dds-masthead-profile-item[key="login"]');
       await promiseNavigation;
@@ -35,7 +31,6 @@ describe('dds-masthead-*', () => {
 
     it('should support navigating in top nav menu', async () => {
       await page.click('dds-top-nav-menu[menu-label="Products"]');
-      navigated = true;
       const promiseNavigation = page.waitForNavigation();
       await page.click('dds-top-nav-menu-item[title="Products"]');
       await promiseNavigation;
@@ -55,7 +50,7 @@ describe('dds-masthead-*', () => {
   });
 
   describe('With narrow screen', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       await page.setViewportSize({ width: 672, height: 720 });
       await page.goto(`http://localhost:${process.env.PORT}/iframe.html?id=components-masthead--default&mock`);
     });
@@ -63,18 +58,10 @@ describe('dds-masthead-*', () => {
     it('should support navigating in top nav menu', async () => {
       await page.click('dds-masthead-menu-button');
       await page.click('dds-left-nav-menu[title="Products"]');
-      navigated = true;
       const promiseNavigation = page.waitForNavigation();
       await page.click('dds-left-nav-menu-item[title="Products"]');
       await promiseNavigation;
       expect(await page.evaluate(() => window.location.href)).toMatch('https://www.ibm.com/products');
     });
-  });
-
-  afterEach(async () => {
-    if (navigated) {
-      await page.goto(`http://localhost:${process.env.PORT}/iframe.html?id=components-masthead--default&mock`);
-      navigated = false;
-    }
   });
 });

--- a/packages/web-components/tests/integration/build/setup-env.js
+++ b/packages/web-components/tests/integration/build/setup-env.js
@@ -9,5 +9,7 @@
 
 'use strict';
 
-const testTimeout = Number(process.env.DDS_BUILD_INTEGRATION_TEST_TIMEOUT);
-jest.setTimeout(isNaN(testTimeout) ? 30000 : testTimeout);
+const testTimeoutEnv = Number(process.env.DDS_BUILD_INTEGRATION_TEST_TIMEOUT);
+const testTimeout = isNaN(testTimeoutEnv) ? 30000 : testTimeoutEnv;
+jest.setTimeout(testTimeout);
+page.setDefaultNavigationTimeout(testTimeout);


### PR DESCRIPTION
### Description

This change attempts to further stabilize UI integration test in Web Components codebase, by avoiding to let `afterEach()` to reset the page and use `beforeEach()` for that instead.

Also increases the timeout for `page.goto()`.

### Changelog

**Changed**

- An attempt to further stabilize UI integration test in Web Components codebase, by avoiding to let `afterEach()` to reset the page and use `beforeEach()` for that instead.
- Increases the timeout for `page.goto()`.