### PR TITLE
chore(lint): lint old React vendor files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,11 +15,6 @@ packages/react/src/internal/vendor
 packages/storybook-addon-theme/es
 packages/storybook-addon-theme/node_modules
 
-# local carbon-components-react
-packages/react/src/components/carbon-components-react
-packages/react/src/internal/keyboard
-packages/react/src/prop-types
-
 # services
 packages/services/coverage
 packages/services/docs

--- a/.eslintrc
+++ b/.eslintrc
@@ -51,6 +51,18 @@
       }
     },
     {
+      "files": [
+        "packages/react/src/components/carbon-components-react/**/*.js",
+        "packages/react/src/internal/keyboard/**/*.js",
+        "packages/react/src/prop-types/**/*.js"
+      ],
+      "rules": {
+        "sort-imports": 0,
+        "jsdoc/require-param-description": 0,
+        "react/prop-types": 0
+      }
+    },
+    {
       "files": ["packages/react/tests/**/*.js"],
       "globals": {
         "describe": true,

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /* istanbul ignore file */
 
 /**
@@ -8,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import classnames from 'classnames';
 import ChevronDown20 from '@carbon/icons-react/es/chevron--down/20';
 import settings from 'carbon-components/es/globals/js/settings';
 import cx from 'classnames';
@@ -87,7 +85,7 @@ class HeaderMenu extends React.Component {
   /**
    * Toggle the expanded state of the menu on click.
    */
-  handleOnClick = event => {
+  handleOnClick = () => {
     this.menuLinkRef.current.focus();
 
     this.setState(prevState => {

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavIcon.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavIcon.js
@@ -1,8 +1,7 @@
-/* eslint-disable */
 /* istanbul ignore file */
 
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenu.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /* istanbul ignore file */
 
 /**
@@ -9,14 +8,12 @@
  */
 
 import ChevronDown20 from '@carbon/icons-react/es/chevron--down/20';
-import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import settings from 'carbon-components/es/globals/js/settings';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SideNavIcon from './SideNavIcon';
 
-const { stablePrefix } = ddsSettings;
 const { prefix } = settings;
 
 export class SideNavMenu extends React.Component {
@@ -148,7 +145,7 @@ export class SideNavMenu extends React.Component {
       isActive,
       title,
       large,
-      isbackbutton,
+      isbackbutton: _isbackbutton,
       ...rest
     } = this.props;
     const { isExpanded } = this.state;
@@ -209,7 +206,7 @@ export class SideNavMenu extends React.Component {
     );
   }
 
-  _renderSideNavItem = (item, index) => {
+  _renderSideNavItem = item => {
     if (item) {
       return React.cloneElement(item, {
         onClick:

--- a/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/SideNavMenuWithBackForward.js
@@ -12,7 +12,6 @@ import settings from 'carbon-components/es/globals/js/settings';
 import SideNavLink from '../../../internal/vendor/carbon-components-react/components/UIShell/SideNavLink';
 import SideNavMenu from './SideNavMenu';
 import SideNavMenuItem from '../../../internal/vendor/carbon-components-react/components/UIShell/SideNavMenuItem';
-import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback, useRef } from 'react';
 
@@ -32,11 +31,11 @@ const SideNavMenuWithBackForward = ({
   ...rest
 }) => {
   const refSideNavMenu = useRef(null);
-  const handleToggle = useCallback((event, detail) => {
+  const handleToggle = useCallback(() => {
     const { current: sideNavMenuNode } = refSideNavMenu;
     const sideNav = sideNavMenuNode.closest('.bx--side-nav');
     if (sideNav) {
-      const list = Array.prototype.forEach.call(
+      Array.prototype.forEach.call(
         sideNav.querySelectorAll('.bx--side-nav__menu'),
         elem => {
           const hasExpandedSubmenu = elem.querySelector(

--- a/packages/react/src/components/carbon-components-react/UIShell/index.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /* istanbul ignore file */
 
 /**


### PR DESCRIPTION
### Description

This change makes ESLint run against old React vendor files, a.k.a. `packages/react/src/components/carbon-components-react`.

Even though they are "vendor files", we seem to manually edit those files and good to catch errors there. Relaxed some rules for those files given the "vendor files" nature.

### Changelog

**New**

- A series of changes to make ESLint run against old React vendor files, a.k.a. `packages/react/src/components/carbon-components-react`.