### PR TITLE
fix(dotcom-shell): fix style imports

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell.scss
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/ibmdotcom-styles/scss/components/dotcom-shell/dotcom-shell';

--- a/packages/web-components/src/components/dotcom-shell/dotcom-shell.ts
+++ b/packages/web-components/src/components/dotcom-shell/dotcom-shell.ts
@@ -10,8 +10,8 @@
 import { html, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
-import styles from '@carbon/ibmdotcom-styles/scss/components/dotcom-shell/_dotcom-shell.scss';
 import StableSelectorMixin from '../../globals/mixins/stable-selector';
+import styles from './dotcom-shell.scss';
 
 const { prefix } = settings;
 const { stablePrefix: ddsPrefix } = ddsSettings;


### PR DESCRIPTION
### Description

This change fixes a problem where the `.css.js` file, the `lit-html` template for the compiled CSS, for `<dds-dotcom-shell>` was not generated by the build process. It caused an internal error in `lit-element` in an application.

This was caused by our JS code directly importing Sass code from `@carbon/ibmdotcom-styles`, where we should have had a corresponding `.scss` file in `@carbon/ibmdotcom-web-components`.

### Changelog

**New**

- `dotcom-shell.scss`, so our build process can generate `.css.js` file from `@carbon/ibmdotcom-styles/scss/components/dotcom-shell/_dotcom-shell.scss`.