### PR TITLE
docs(lang): updated documentation for setting the page language/locale

### DIFF
--- a/docs/building-for-ibm-dotcom.md
+++ b/docs/building-for-ibm-dotcom.md
@@ -6,8 +6,9 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [Page Language](#page-language)
 - [Digital data object](#digital-data-object)
+- [Page Language](#page-language)
+  - [Configuring available languages](#configuring-available-languages)
 - [Meta Tags](#meta-tags)
 - [IBM.com Tag Management and Site Analytics](#ibmcom-tag-management-and-site-analytics)
 
@@ -19,10 +20,88 @@
 When developing a page on IBM.com, there are several items that will be 
 necessary to include in addition to your application code. 
 
+## Digital data object
+
+The Digital Data Object (DDO) is a critical part of any page. It is a flexible, 
+customizable collection of metadata that also provides tools and services such 
+as live chat and analytics to page authors. All pages require the DDO, but that 
+certainly doesn't need to get in the way of development. Get started creating 
+your page and add the DDO when you're ready. Some metadata will need to come 
+from the page owner, and a full list of properties can be viewed on the 
+[Digital Behavior website](https://pages.github.ibm.com/digital-behavior/docs/stds-ddo.html).
+
+The standardized/reserved properties of the digitalData object are the 
+`page.category` property and `page.pageInfo` children. These are the 
+reserved/preset industry standard metadata properties. The `pageInfo.ibm` 
+property is ours (IBM) where any and all IBM-specific and custom metadata can 
+go.
+
+Below is the digitalData object and properties needed for an IBM.com page with 
+sample values. The same rules for required vs. optional metadata, and default 
+value vs. omitted tags still apply and haven't changed, metadata is simply in a 
+different format/code language. Ensure you change and set the values properly 
+for your page:
+
+```html
+<script>
+  digitalData = {
+    page: {
+        category: {
+            primaryCategory: '' // e.g. SB03
+        },
+        pageInfo: {
+            effectiveDate: '', // e.g. 2014-11-19
+            expiryDate: '', // e.g. 2017-11-19
+            language: '', // e.g. en-US
+            publishDate: '', // e.g. 2014-11-19
+            publisher: '', // e.g. IBM Corporation
+            version: 'IBM.com Library',
+            ibm: {
+                contentDelivery: '', // e.g. ECM/Filegen
+                contentProducer: '', // e.g. ECM/IConS Adopter 34 - GS83J2343G3H3ERG - 11/19/2014 05:14:02 PM
+                country: '', // e.g. US
+                industry: '', // e.g. B,U
+                owner: '', // e.g. Some Person/City/IBM
+                siteID: '', // e.g. MySiteID
+                subject: '', // e.g. SW492
+                type: '' // e.g CT305
+            }
+        }
+    }
+  };
+</script>
+```
+
 ## Page Language
 
 The page language is a requirement in order to define what language the current 
-page is translated in. This can be set with the following:
+page is translated in. 
+
+The primary method of setting the page language is through the `digitalData` 
+(DDO) object. The highlighted fields below are necessary:
+
+```html
+<script>
+  digitalData = {
+    page: {
+        ...
+        pageInfo: {
+            ...            
+            language: 'en-US',
+            ...
+            ibm: {
+                ...
+                country: 'US',
+                ...
+            }
+        }
+    }
+  };
+</script>
+```
+
+Alternatively, if the digitalData object is not set, the language will fallback
+to fetching from the `lang` attribute in the `<html>` tag on the page:
 
 ```html
 <html lang="lc-CC">
@@ -62,58 +141,6 @@ For example:
 <link rel="alternate" hreflang="fr-dz" href="https://www.ibm.com/dz-fr">
 ...
 
-```
-
-## Digital data object
-
-The Digital Data Object (DDO) is a critical part of any page. It is a flexible, 
-customizable collection of metadata that also provides tools and services such 
-as live chat and analytics to page authors. All pages require the DDO, but that 
-certainly doesn't need to get in the way of development. Get started creating 
-your page and add the DDO when you're ready. Some metadata will need to come 
-from the page owner, and a full list of properties can be viewed on the 
-[Digital Behavior website](https://pages.github.ibm.com/digital-behavior/docs/stds-ddo.html).
-
-The standardized/reserved properties of the digitalData object are the 
-`page.category` property and `page.pageInfo` children. These are the 
-reserved/preset industry standard metadata properties. The `pageInfo.ibm` 
-property is ours (IBM) where any and all IBM-specific and custom metadata can 
-go.
-
-Below is the digitalData object and properties needed for an IBM.com page with 
-sample values. The same rules for required vs. optional metadata, and default 
-value vs. omitted tags still apply and haven't changed, metadata is simply in a 
-different format/code language. Ensure you change and set the values properly 
-for your page:
-
-```html
-<script>
-  digitalData = {
-    page: {
-        category: {
-            primaryCategory: '' // e.g. SB03
-        },
-        pageInfo: {
-            effectiveDate: '', // e.g. 2014-11-19
-            expiryDate: '', // e.g. 2017-11-19
-            language: '', // e.g. en-US
-            publishDate: '', // e.g. 2014-11-19
-            publisher: '', // e.g. IBM Corporation
-            version: '', // e.g. dds.v1.0.0. NOTE: This is dynamically set by the IBM.com Library
-            ibm: {
-                contentDelivery: '', // e.g. ECM/Filegen
-                contentProducer: '', // e.g. ECM/IConS Adopter 34 - GS83J2343G3H3ERG - 11/19/2014 05:14:02 PM
-                country: '', // e.g. US
-                industry: '', // e.g. B,U
-                owner: '', // e.g. Some Person/City/IBM
-                siteID: '', // e.g. MySiteID
-                subject: '', // e.g. SW492
-                type: '' // e.g CT305
-            }
-        }
-    }
-  };
-</script>
 ```
 
 ## Meta Tags

--- a/docs/building-for-ibm-dotcom.md
+++ b/docs/building-for-ibm-dotcom.md
@@ -55,7 +55,7 @@ for your page:
             language: '', // e.g. en-US
             publishDate: '', // e.g. 2014-11-19
             publisher: '', // e.g. IBM Corporation
-            version: 'IBM.com Library',
+            version: 'Carbon:IBM.com Library',
             ibm: {
                 contentDelivery: '', // e.g. ECM/Filegen
                 contentProducer: '', // e.g. ECM/IConS Adopter 34 - GS83J2343G3H3ERG - 11/19/2014 05:14:02 PM

--- a/docs/contributing-license.md
+++ b/docs/contributing-license.md
@@ -1,3 +1,12 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [🙌 Contributing](#-contributing)
+- [📝 License](#-license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## 🙌 Contributing
 
 We're always looking for contributors to help us fix bugs, build new features,

--- a/docs/cors-proxy.md
+++ b/docs/cors-proxy.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [CORS Proxy](#cors-proxy)
+  - [How It Works](#how-it-works)
+  - [Available CORS Proxy server for local development](#available-cors-proxy-server-for-local-development)
+  - [Alternative approach](#alternative-approach)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## CORS Proxy
 
 Various components make cross-origin requests to `www.ibm.com`, which will 

--- a/packages/utilities/src/utilities/settings/settings.js
+++ b/packages/utilities/src/utilities/settings/settings.js
@@ -15,7 +15,7 @@
  *
  */
 const settings = {
-  version: 'dds.v1.10.1',
+  version: 'Carbon:IBM.com Library v1.10.1',
   stablePrefix: 'dds',
 };
 

--- a/packages/web-components/examples/codesandbox/components/dotcom-shell/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/dotcom-shell/src/index.js
@@ -16,6 +16,7 @@ window.digitalData = {
     pageInfo: {
       language: 'en-US',
       ibm: {
+        country: 'US',
         siteID: 'IBMTESTWWW',
       },
     },

--- a/packages/web-components/examples/codesandbox/components/footer/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/footer/src/index.js
@@ -14,6 +14,7 @@ window.digitalData = {
     pageInfo: {
       language: 'en-US',
       ibm: {
+        country: 'US',
         siteID: 'IBMTESTWWW',
       },
     },

--- a/packages/web-components/examples/codesandbox/components/masthead/src/index.js
+++ b/packages/web-components/examples/codesandbox/components/masthead/src/index.js
@@ -16,6 +16,7 @@ window.digitalData = {
     pageInfo: {
       language: 'en-US',
       ibm: {
+        country: 'US',
         siteID: 'IBMTESTWWW',
       },
     },


### PR DESCRIPTION
### Related Ticket(s)

Refs #3754 

### Description

The documentation for how `LocaleAPI` is fetching the language has been
updated. This reflects the logic where the `digitalData` is the first
source of the language/locale, followed by the html lang attribute.
Because of this, it was necessary to explain what the `digitalData`
object is first, before pointing out the specific fields that the
service is looking for.

Additionally, we will be setting `Carbon:IBM.com Library` as the default value
for the `version` that's being set in the `digitalData` object, as we have worked with 
Analytics team and want to set a default value based on the data we're seeing
in the analytics results.

### Changelog

**Changed**

- Updated documentation on setting language for the page
- Updated documentation for the version setting in DDO