### PR TITLE
fix(ipcinfo): setting domain for the ipcinfo cookie

### DIFF
--- a/packages/utilities/src/utilities/ipcinfoCookie/ipcinfoCookie.js
+++ b/packages/utilities/src/utilities/ipcinfoCookie/ipcinfoCookie.js
@@ -65,12 +65,10 @@ class ipcinfoCookie {
   static set({ cc, lc }) {
     const info = `cc=${cc};lc=${lc}`;
 
-    Cookies.set(
-      _cookieName,
-      encodeURIComponent(info),
-      { expires: 365 },
-      { secure: true }
-    );
+    Cookies.set(_cookieName, encodeURIComponent(info), {
+      expires: 365,
+      domain: '.ibm.com',
+    });
   }
 }
 


### PR DESCRIPTION
### Related Ticket(s)

Refs #3838


### Description

There was a discrepency identified where the cookie was being set under
`www.ibm.com` domain on the IBM.com homepage, whereas v18 was setting it
 under `.ibm.com` on all other pages. When returning to the homepage and
  clicking the logo, this caused the server-side level redirect rule to
  kick in and create a garbled homepage url and causing a 404 to occur.

### Changelog

**Changed**

- Set the explicit domain when setting `ipcinfo` cookie