### PR TITLE
chore(locale-modal): warn missing links for alternate language

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
@@ -189,6 +189,13 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
     const { localeModal: localeModalI18N, regionList } = localeList ?? {};
     const { searchPlaceholder } = localeModalI18N ?? {};
     const pageLangs: { [locale: string]: string } = altlangs();
+    if (Object.keys(pageLangs).length === 0 && (regionList?.length as number) > 0) {
+      const messages = [
+        'Detected that `<link rel="alternate">` is likely missing.',
+        'The locale search UI will yeild to an empty result.',
+      ];
+      console.warn(messages.join(' ')); // eslint-disable-line no-console
+    }
     const massagedCountryList = regionList?.reduce((acc, { countryList, name: region }) => {
       this._sortCountries(countryList).forEach(({ name: country, locale: localeItems }) => {
         localeItems.forEach(([locale, language]) => {


### PR DESCRIPTION
### Related Ticket(s)

Refs #3833.

### Description

Adds a logic to emit a console warning when `<link rel="alternate">` for alternate language is missing, that yeilds to an empty result in `<dds-locale-search>`.

### Changelog

**New**

- A logic to emit a console warning when `<link rel="alternate">` for alternate language is missing.