### PR TITLE
fix(Footer): micro footer mobile layout styles

### DIFF
--- a/packages/styles/scss/components/footer/_locale-button.scss
+++ b/packages/styles/scss/components/footer/_locale-button.scss
@@ -22,7 +22,6 @@
       @include button;
       @include button-expressive;
       @include carbon--make-col-ready;
-      @include carbon--make-col(4, 4);
 
       margin-top: carbon--mini-units(2);
       padding-left: 0;


### PR DESCRIPTION
### Related Ticket(s)

#3771 

### Description

Update micro footer mobile layout styles causing locale button to position out of viewport

### Changelog

**Removed**

- `carbon--make-col` for `sm` breakpoint

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
