### PR TITLE
fix(LinkList): update styles in aside element

### DIFF
--- a/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
+++ b/packages/styles/scss/components/content-block-simple/_content-block-simple.scss
@@ -9,6 +9,14 @@
   .#{$prefix}--content-block {
     // empty for now
   }
+
+  .#{$prefix}--content-block-simple__content {
+    .#{$prefix}--content-item {
+      &:first-of-type {
+        margin-top: 0;
+      }
+    }
+  }
 }
 
 @include exports('content-block-simple') {

--- a/packages/styles/scss/internal/content-block/_content-block.scss
+++ b/packages/styles/scss/internal/content-block/_content-block.scss
@@ -65,8 +65,11 @@
     }
     @include carbon--breakpoint('lg') {
       .#{$prefix}--link-list {
-        padding-top: 0;
         margin-right: -$carbon--spacing-05;
+
+        &:first-of-type {
+          padding-top: 0;
+        }
       }
     }
     .#{$prefix}--hr {


### PR DESCRIPTION
### Related Ticket(s)

#3454

### Description

Fixes `LinkList` spacing when used in `aside` element of `ContentBlock`

### Changelog

**Changed**

- update spacing in `ContentBlock` `<aside />` for `lg` breakpoint.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
