### PR TITLE
fix(translation): adding string/replace of login url state param

### DIFF
--- a/packages/services/src/services/Translation/Translation.js
+++ b/packages/services/src/services/Translation/Translation.js
@@ -202,6 +202,18 @@ class TranslationAPI {
    * @returns {object} Translation data
    */
   static transformData(data) {
+    const signedout = data.profileMenu?.signedout;
+    const strReplace = 'state=https%3A%2F%2Fwww.ibm.com';
+    const loginIdx = signedout.findIndex(
+      elem => elem.url?.indexOf(strReplace) !== -1
+    );
+    if (loginIdx !== -1 && root.location) {
+      const location = encodeURIComponent(root.location.href);
+      data.profileMenu.signedout[loginIdx].url = signedout[
+        loginIdx
+      ].url.replace(strReplace, `state=${location}`);
+    }
+
     data.footerMenu.push(data.socialFollow);
     return data;
   }

--- a/packages/services/src/services/Translation/__tests__/Translation.test.js
+++ b/packages/services/src/services/Translation/__tests__/Translation.test.js
@@ -59,6 +59,29 @@ describe('TranslationAPI', () => {
     expect(response).toEqual(responseSuccess);
   });
 
+  it('should replace the signout url "state" param with current location', async () => {
+    Object.defineProperty(global, 'location', {
+      value: {
+        href: 'https://www.loremipsum.com',
+      },
+      writable: true,
+    });
+
+    // reinitializing import
+    const TranslationAPI = (await import('../Translation')).default;
+
+    const response = await TranslationAPI.getTranslation({
+      lc: 'en',
+      cc: 'us',
+    });
+
+    expect(
+      response.profileMenu.signedout[1].url.indexOf(
+        'https%3A%2F%2Fwww.loremipsum.com'
+      )
+    ).toBeGreaterThan(-1);
+  });
+
   xit('should fetch using REACT_APP_CORS_PROXY', async () => {
     // setting up individual test environment variables
     process.env.REACT_APP_CORS_PROXY = 'https://cra-myproxy.net/';

--- a/packages/services/src/services/Translation/__tests__/Translation.test.js
+++ b/packages/services/src/services/Translation/__tests__/Translation.test.js
@@ -7,6 +7,7 @@
 
 import mockAxios from 'axios';
 import responseSuccess from './data/response.json';
+import root from 'window-or-global';
 
 jest.mock('../../Locale', () => ({
   LocaleAPI: {
@@ -23,22 +24,42 @@ jest.mock('axios', () => {
 });
 
 describe('TranslationAPI', () => {
+  const { location } = root;
+
   afterEach(() => {
     jest.resetModules();
-    jest.clearAllMocks();
+    root.location = location;
+  });
+
+  it('should replace the signout url "state" param with current location', async () => {
+    delete root.location;
+
+    root.location = {
+      href: 'https://www.loremipsum.com',
+    };
+
+    // reinitializing import
+    const TranslationAPI = (await import('../Translation')).default;
+
+    const response = await TranslationAPI.getTranslation({
+      lc: 'en',
+      cc: 'us',
+    });
+
+    expect(
+      response.profileMenu.signedout[1].url.indexOf(
+        'https%3A%2F%2Fwww.loremipsum.com'
+      )
+    ).toBeGreaterThan(-1);
   });
 
   it('should fetch the i18n data', async () => {
-    // setting up individual test environment variables
-    delete process.env.REACT_APP_CORS_PROXY;
-    delete process.env.CORS_PROXY;
-
     // reinitializing import
     const TranslationAPI = (await import('../Translation')).default;
 
     // Expected endpoint called
     const endpoint = `${process.env.TRANSLATION_HOST}/common/v18/js/data/jsononly`;
-    const fetchUrl = `${endpoint}/usen.json`;
+    const fetchUrl = `${process.env.REACT_APP_CORS_PROXY}${endpoint}/usen.json`;
 
     const response = await TranslationAPI.getTranslation({
       lc: 'en',
@@ -57,29 +78,6 @@ describe('TranslationAPI', () => {
     });
 
     expect(response).toEqual(responseSuccess);
-  });
-
-  it('should replace the signout url "state" param with current location', async () => {
-    Object.defineProperty(global, 'location', {
-      value: {
-        href: 'https://www.loremipsum.com',
-      },
-      writable: true,
-    });
-
-    // reinitializing import
-    const TranslationAPI = (await import('../Translation')).default;
-
-    const response = await TranslationAPI.getTranslation({
-      lc: 'en',
-      cc: 'us',
-    });
-
-    expect(
-      response.profileMenu.signedout[1].url.indexOf(
-        'https%3A%2F%2Fwww.loremipsum.com'
-      )
-    ).toBeGreaterThan(-1);
   });
 
   xit('should fetch using REACT_APP_CORS_PROXY', async () => {

--- a/packages/services/src/services/Translation/__tests__/data/response.json
+++ b/packages/services/src/services/Translation/__tests__/data/response.json
@@ -1311,7 +1311,7 @@
       {
         "id": "signin",
         "title": "Log in",
-        "url": "https://idaas.iam.ibm.com/idaas/oidc/endpoint/default/authorize?response_type=token&client_id=v18loginprod&state={{window.location}}&redirect_uri=https://myibm.ibm.com/OIDCHandler.html&scope=openid&nonce=8675309"
+        "url": "https://idaas.iam.ibm.com/idaas/oidc/endpoint/default/authorize?response_type=token&client_id=v18loginprod&state=https%3A%2F%2Fwww.ibm.com&redirect_uri=https://myibm.ibm.com/OIDCHandler.html&scope=openid&nonce=8675309"
       }
     ],
     "signedin": [


### PR DESCRIPTION
### Related Ticket(s)

Refs #3851 

### Description

The original implementation of the signin url for ibm included a string
replace of `{{window.location}}`, which was not accounted for in the IBM
.com Library. This adds a transformation logic now to replace the
default value in the data (state=https%3A%2F%2Fwww.ibm.com) and replace
with `state=[the actual window.location value]` in the service before
reaching the presentation layer.

### Changelog

**Changed**

- transformation logic in TranslationAPI to dynamically update the login url