### PR TITLE
test(integration-ui): add browser log

### DIFF
--- a/packages/web-components/tests/integration/ui/jest.config.js
+++ b/packages/web-components/tests/integration/ui/jest.config.js
@@ -9,6 +9,9 @@
 
 'use strict';
 
+if (!process.env.DEBUG) {
+  process.env.DEBUG = 'pw:browser*';
+}
 process.env.JEST_PLAYWRIGHT_CONFIG = `${__dirname}/jest-playwright.config.js`;
 
 module.exports = {


### PR DESCRIPTION
### Description

Temporarily adds browser's debug log in UI integration test, given we still have noticable failure rate. Though the failures won't block our CI, the high failure rate has made us ignore true positives that the test has captured. Good to have the test report only the true positives so it's obvious that we should act on.

### Changelog

**Changed**

- A change to emit browser debug log in UI integration test.