### PR TITLE
fix(card-footer): fix duplicate content

### DIFF
--- a/packages/web-components/src/components/card/card-footer.ts
+++ b/packages/web-components/src/components/card/card-footer.ts
@@ -101,7 +101,7 @@ class DDSCardFooter extends DDSLinkWithIcon {
     const { _shouldUseParentLink: shouldUseParentLink } = this;
     return shouldUseParentLink
       ? html`
-          <span class="${ddsPrefix}-ce--card__footer--static">${this._renderContent()}${this._renderInner()}</span>
+          <span class="${ddsPrefix}-ce--card__footer--static">${this._renderInner()}</span>
         `
       : super.render();
   }


### PR DESCRIPTION
### Description

This change fixes duplicate content shown in `<dds-card-cta-footer>`, was noticed in its video mode, showing video duration as `1:001:00` where it should have been `1:00`.

The change removes `_renderContent()` from the `render()`. The super class (`<dds-link-with-icon>`)'s `_renderInner()` takes care of running `_renderContent()`.

### Changelog

**Changed**

- A fix for duplicate content in `<dds-card-cta-footer>`.