### PR TITLE
feat(search): add redirect and typeahead hooks

### DIFF
--- a/packages/react/.env.example
+++ b/packages/react/.env.example
@@ -8,7 +8,7 @@ SEARCH_REDIRECT_ENDPOINT=<endpoint for ibm.com search, e.g. https://www.ibm.com/
 
 # Search Typeahead
 SEARCH_TYPEAHEAD_VERSION=<api version for ibm.com search, e.g. v1>
-SEARCH_TYPEAHEAD_HOST=<host for ibm.com search, e.g. https://www-api.ibm.com>
+SEARCH_TYPEAHEAD_API=<host for ibm.com search, e.g. https://www-api.ibm.com>
 
 # Marketing Search
 MARKETING_SEARCH_VERSION=<api version for ibm.com marketing search, e.g. v3>

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -306,6 +306,12 @@ const Masthead = ({
                       searchOpenOnload={searchOpenOnload}
                       placeHolderText={placeHolderText}
                       navType={navType}
+                      {...(mastheadProps.customTypeaheadApi
+                        ? {
+                            customTypeaheadApi:
+                              mastheadProps.customTypeaheadApi,
+                          }
+                        : {})}
                     />
                   )}
                 </div>
@@ -477,6 +483,11 @@ Masthead.propTypes = {
       ),
     ]),
   }),
+
+  /**
+   * Custom typeahead API function
+   */
+  customTypeaheadApi: PropTypes.func,
 };
 
 Masthead.defaultProps = {

--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -100,6 +100,7 @@ const MastheadSearch = ({
   renderValue,
   searchOpenOnload,
   navType,
+  customTypeaheadApi,
 }) => {
   const { ref } = useSearchVisible(false);
 
@@ -318,7 +319,9 @@ const MastheadSearch = ({
 
     if (request.reason === 'input-changed') {
       // if the search input has changed
-      let response = await SearchTypeaheadAPI.getResults(searchValue);
+      let response = customTypeaheadApi
+        ? customTypeaheadApi(searchValue)
+        : await SearchTypeaheadAPI.getResults(searchValue);
 
       if (response !== undefined) {
         dispatch({
@@ -435,6 +438,11 @@ MastheadSearch.propTypes = {
    * navigation type for autoids
    */
   navType: PropTypes.oneOf(['default', 'alt', 'eco']),
+
+  /**
+   * Custom typeahead API function
+   */
+  customTypeaheadApi: PropTypes.func,
 };
 
 MastheadSearch.defaultProps = {

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -76,6 +76,60 @@ DDS_MASTHEAD_L1=true
 
 <Props of={Masthead} />
 
+## customTypeaheadApi
+
+The masthead search supports a user-defined redirect host URL and typeahead
+endpoint API.
+
+**Custom redirect URL endpoint**
+
+Changing the redirect host is as simple as adding an environment variable to
+your application.
+
+```
+SEARCH_REDIRECT_ENDPOINT=https://www.custom-redirect-endpoint.com
+```
+
+This will replace the default endpoint when creating redirect URLs.
+
+```javascript
+${SEARCH_REDIRECT_ENDPOINT}&q=${encodeURIComponent(value)}&lang=${state.lc}&cc=${state.cc}
+```
+
+**Custom typeahead API**
+
+To use a custom typeahead API, set the endpoint by adding an environment
+variable.
+
+```
+SEARCH_TYPEAHEAD_API=https://www.custom-typeahead-api.com
+```
+
+Then use the `customTypeaheadApi` prop to pass a promise-based method to fetch
+the results of the search value.
+
+```javascript
+let customTypeaheadApi = async searchVal => await response.json();
+
+<Masthead customTypeaheadApi={customTypeaheadApi} />;
+```
+
+In order for the typehead presentation layer to correctly display the results,
+here is how the response object should look:
+
+```javascript
+[
+  ['cloud', '0'],
+  ['cloud pak for data', '1'],
+  ['cloud pak', '2'],
+  ['cloud pak for integration', '3'],
+  ['cloud pak for automation', '4'],
+  ['cloud object storage', '5'],
+];
+```
+
+> 💡 A maximum of 10 results will be displayed.
+
 ## platform
 
 Includes platform name (only available with `default` and `custom navigation`).

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -114,7 +114,7 @@ let customTypeaheadApi = async searchVal => await response.json();
 <Masthead customTypeaheadApi={customTypeaheadApi} />;
 ```
 
-In order for the typehead presentation layer to correctly display the results,
+In order for the typeahead presentation layer to correctly display the results,
 here is how the response object should look:
 
 ```javascript

--- a/packages/services/.env.example
+++ b/packages/services/.env.example
@@ -4,7 +4,7 @@ THEMOVIEDB_HOST=<host for themoviedb.org, e.g. https://api.themoviedb.org>
 
 # Search Typeahead
 SEARCH_TYPEAHEAD_VERSION=v1
-SEARCH_TYPEAHEAD_HOST=<host for ibm.com search, e.g. https://www-api.ibm.com>
+SEARCH_TYPEAHEAD_API=<host for ibm.com search, e.g. https://www-api.ibm.com>
 
 # Marketing Search
 MARKETING_SEARCH_VERSION=v3

--- a/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
+++ b/packages/services/src/services/SearchTypeahead/SearchTypeahead.js
@@ -13,7 +13,7 @@ import { LocaleAPI } from '../Locale';
  * @private
  */
 const _host =
-  (process && process.env.SEARCH_TYPEAHEAD_HOST) || 'https://www-api.ibm.com';
+  (process && process.env.SEARCH_TYPEAHEAD_API) || 'https://www-api.ibm.com';
 
 /**
  * @constant {string | string} API version

--- a/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
+++ b/packages/services/src/services/SearchTypeahead/__tests__/SearchTypeahead.test.js
@@ -28,7 +28,7 @@ describe('SearchTypeaheadAPI', () => {
 
   it('should search for ibm.com results', async () => {
     const query = 'red hat';
-    const endpoint = `${process.env.SEARCH_TYPEAHEAD_HOST}/search/typeahead/${process.env.SEARCH_TYPEAHEAD_VERSION}`;
+    const endpoint = `${process.env.SEARCH_TYPEAHEAD_API}/search/typeahead/${process.env.SEARCH_TYPEAHEAD_VERSION}`;
     const fetchUrl = `${endpoint}?lang=${_lc}&cc=${_cc}&query=${encodeURIComponent(
       query
     )}`;

--- a/packages/vanilla/.env.example
+++ b/packages/vanilla/.env.example
@@ -9,7 +9,7 @@ SEARCH_REDIRECT_ENDPOINT=<endpoint for ibm.com search, e.g. https://www.ibm.com/
 
 # Search Typeahead
 SEARCH_TYPEAHEAD_VERSION=<api version for ibm.com search, e.g. v1>
-SEARCH_TYPEAHEAD_HOST=<host for ibm.com search, e.g. https://www-api.ibm.com>
+SEARCH_TYPEAHEAD_API=<host for ibm.com search, e.g. https://www-api.ibm.com>
 
 # Marketing Search
 MARKETING_SEARCH_VERSION=<api version for ibm.com marketing search, e.g. v3>

--- a/packages/web-components/src/globals/services-store/actions/searchAPI.ts
+++ b/packages/web-components/src/globals/services-store/actions/searchAPI.ts
@@ -18,7 +18,7 @@ import { SEARCH_API_ACTION, SearchAPIState } from '../types/searchAPI';
  */
 function getSearchEndpoint(language: string, searchQueryString: string) {
   const [primary, country] = language!.split('-');
-  return `${(process && process.env.SEARCH_TYPEAHEAD_HOST) ||
+  return `${(process && process.env.SEARCH_TYPEAHEAD_API) ||
     'https://www-api.ibm.com'}/search/typeahead/v1?lang=${primary}&cc=${country}&query=${searchQueryString}`;
 }
 

--- a/tasks/jest/env.js
+++ b/tasks/jest/env.js
@@ -11,7 +11,7 @@ const _version = 'v1';
 process.env.CORS_PROXY = process.env.CORS_PROXY || 'https://myproxy.com/';
 process.env.REACT_APP_CORS_PROXY =
   process.env.REACT_APP_CORS_PROXY || 'https://cra-myproxy.com/';
-process.env.SEARCH_TYPEAHEAD_HOST = process.env.SEARCH_TYPEAHEAD_HOST || _host;
+process.env.SEARCH_TYPEAHEAD_API = process.env.SEARCH_TYPEAHEAD_API || _host;
 process.env.SEARCH_TYPEAHEAD_VERSION =
   process.env.SEARCH_TYPEAHEAD_VERSION || _version;
 process.env.MARKETING_SEARCH_HOST = process.env.MARKETING_SEARCH_HOST || _host;


### PR DESCRIPTION
### Related Ticket(s)

#3766 

### Description

This adds custom typeahead API support to masthead search. Also includes updated documentation to implement `customTypeaheadApi` and custom search redirect URLs.

### Changelog

**New**

- masthead prop `customTypeaheadApi` for user-defined typeahead API support
- `Masthead` documentation for custom typeahead and redirect 

**Changed**

- `SEARCH_TYPEAHEAD_HOST` changed to `SEARCH_TYPEAHEAD_API`


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
