### PR TITLE
fix(masthead-search): no redirect when search input empty

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -224,7 +224,7 @@ const MastheadSearch = ({
    *
    */
   function searchIconClick() {
-    if (state.isSearchOpen) {
+    if (state.isSearchOpen && state.val.length) {
       root.parent.location.href = getRedirect(state.val);
     } else {
       dispatch({ type: 'setSearchOpen' });


### PR DESCRIPTION
### Related Ticket(s)

React version fix of #3932

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
