### PR TITLE
chore(content-group): drift away from BEM concatenation

### DIFF
--- a/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
+++ b/packages/styles/scss/components/content-group-cards/_content-group-cards.scss
@@ -12,21 +12,21 @@
 
 @mixin content-group-cards {
   .#{$prefix}--content-group-cards {
-    &__row {
-      @include carbon--make-row;
-    }
-
-    &-item__col {
-      margin-top: $carbon--grid-gutter--condensed / 2;
-      margin-bottom: $carbon--grid-gutter--condensed / 2;
-      @include carbon--make-col-ready;
-
-      @include carbon--breakpoint(lg) {
-        @include carbon--make-col(8, 16);
-      }
-    }
-
     @include themed-items;
+  }
+
+  .#{$prefix}--content-group-cards__row {
+    @include carbon--make-row;
+  }
+
+  .#{$prefix}--content-group-cards-item__col {
+    margin-top: $carbon--grid-gutter--condensed / 2;
+    margin-bottom: $carbon--grid-gutter--condensed / 2;
+    @include carbon--make-col-ready;
+
+    @include carbon--breakpoint(lg) {
+      @include carbon--make-col(8, 16);
+    }
   }
 }
 @include exports('content-group-cards') {

--- a/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
+++ b/packages/styles/scss/components/content-group-pictograms/_content-group-pictograms.scss
@@ -14,14 +14,15 @@
         margin-bottom: $spacing-07;
       }
     }
+  }
 
-    &__item:last-child {
-      .#{$prefix}--content-item {
-        margin-bottom: 0;
-      }
+  .#{$prefix}--content-group-pictograms__item:last-child {
+    .#{$prefix}--content-item {
+      margin-bottom: 0;
     }
   }
 }
+
 @include exports('content-group-pictograms') {
   @include content-group-pictograms;
 }


### PR DESCRIPTION
### Description

This change to content group style drifts away from BEM concatenation, so the style can be reused with Web Components.

### Changelog

**Changed**

- A change to content group style drifts away from BEM concatenation, so the style can be reused with Web Components.