### PR TITLE
chore(masthead): drift away from BEM concatenation

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-l1.scss
+++ b/packages/styles/scss/components/masthead/_masthead-l1.scss
@@ -23,30 +23,30 @@ $search-transition-timing: 95ms;
     background-color: $ui-01;
     transition-timing-function: $search-transition;
 
-    &--short {
-      height: carbon--mini-units(6);
-
-      .#{$prefix}--masthead__l1-name {
-        min-width: rem(208px);
-        padding-left: 0;
-
-        .#{$prefix}--masthead__l1-name-eyebrow {
-          display: none;
-        }
-
-        .#{$prefix}--masthead__l1-name-title {
-          &::after {
-            bottom: 0;
-          }
-
-          line-height: inherit;
-          padding-bottom: $carbon--spacing-05;
-        }
-      }
-    }
-
     @include carbon--breakpoint-down(lg) {
       height: carbon--mini-units(6);
+    }
+  }
+
+  .#{$prefix}--masthead__l1--short {
+    height: carbon--mini-units(6);
+
+    .#{$prefix}--masthead__l1-name {
+      min-width: rem(208px);
+      padding-left: 0;
+
+      .#{$prefix}--masthead__l1-name-eyebrow {
+        display: none;
+      }
+
+      .#{$prefix}--masthead__l1-name-title {
+        &::after {
+          bottom: 0;
+        }
+
+        line-height: inherit;
+        padding-bottom: $carbon--spacing-05;
+      }
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead-leftnav.scss
+++ b/packages/styles/scss/components/masthead/_masthead-leftnav.scss
@@ -74,13 +74,27 @@
     margin-bottom: 0;
   }
 
-  .#{$prefix}--masthead .#{$prefix}--side-nav {
-    &__items {
+  .#{$prefix}--masthead {
+    .#{$prefix}--side-nav {
+      &:not(.#{$prefix}--side-nav--fixed):hover {
+        @include carbon--breakpoint-down(md) {
+          max-width: 100vw;
+          width: 100vw;
+        }
+      }
+
+      .#{$prefix}--header__logo {
+        height: 3rem;
+        padding-left: $carbon--spacing-09;
+      }
+    }
+
+    .#{$prefix}--side-nav__items {
       padding-top: 0;
       height: 100%;
     }
 
-    &__overlay {
+    .#{$prefix}--side-nav__overlay {
       top: 0;
       z-index: 1000;
       @include carbon--breakpoint-down(md) {
@@ -88,14 +102,7 @@
       }
     }
 
-    &:not(.#{$prefix}--side-nav--fixed):hover {
-      @include carbon--breakpoint-down(md) {
-        max-width: 100vw;
-        width: 100vw;
-      }
-    }
-
-    &--expanded {
+    .#{$prefix}--side-nav--expanded {
       overflow-y: auto;
 
       @include carbon--breakpoint-down(md) {
@@ -105,16 +112,11 @@
       }
     }
 
-    .#{$prefix}--header__logo {
-      height: 3rem;
-      padding-left: $carbon--spacing-09;
-    }
-  }
-
-  .#{$prefix}--masthead .#{$prefix}--side-nav--ux {
-    .#{$prefix}--side-nav__item,
-    .#{$prefix}--side-nav__menu-item:not(.#{$prefix}--masthead__side-nav--submemu-back) {
-      border-bottom: 1px solid $ui-03;
+    .#{$prefix}--side-nav--ux {
+      .#{$prefix}--side-nav__item,
+      .#{$prefix}--side-nav__menu-item:not(.#{$prefix}--masthead__side-nav--submemu-back) {
+        border-bottom: 1px solid $ui-03;
+      }
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -65,12 +65,6 @@
       }
     }
 
-    &--actions {
-      position: absolute;
-      top: 0;
-      right: 0;
-    }
-
     .#{$prefix}--header__nav {
       &::before {
         content: '';
@@ -88,6 +82,12 @@
     a.#{$prefix}--header__name {
       @include masthead-top-nav-name;
     }
+  }
+
+  .#{$prefix}--header__search--actions {
+    position: absolute;
+    top: 0;
+    right: 0;
   }
 
   // search container
@@ -176,56 +176,54 @@
     }
   }
 
-  .react-autosuggest {
-    &__container {
+  .react-autosuggest__container {
+    display: flex;
+    justify-content: flex-end;
+    position: relative;
+    height: $carbon--spacing-09;
+  }
+
+  .react-autosuggest__suggestions-container {
+    position: absolute;
+    top: $carbon--spacing-09;
+    left: 0;
+    width: 100%;
+  }
+
+  .react-autosuggest__suggestions-list {
+    background-color: $ui-background;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
+  }
+
+  .react-autosuggest__suggestion {
+    height: $carbon--spacing-09;
+    display: flex;
+    span {
+      font-weight: 600;
+    }
+
+    .#{$prefix}--container-class {
       display: flex;
-      justify-content: flex-end;
-      position: relative;
-      height: $carbon--spacing-09;
+      border-bottom: 1px solid $ui-01;
+      flex: 1;
+      padding: 0 $carbon--spacing-05;
+      align-items: center;
+
+      &:focus {
+        outline: none;
+      }
     }
 
-    &__suggestions-container {
-      position: absolute;
-      top: $carbon--spacing-09;
-      left: 0;
-      width: 100%;
+    &:hover {
+      cursor: pointer;
+      background-color: $ui-01;
+      transition: $search-transition-timing;
     }
 
-    &__suggestions-list {
-      background-color: $ui-background;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
-    }
-
-    &__suggestion {
-      height: $carbon--spacing-09;
-      display: flex;
-      span {
-        font-weight: 600;
-      }
-
-      .#{$prefix}--container-class {
-        display: flex;
-        border-bottom: 1px solid $ui-01;
-        flex: 1;
-        padding: 0 $carbon--spacing-05;
-        align-items: center;
-
-        &:focus {
-          outline: none;
-        }
-      }
-
-      &:hover {
-        cursor: pointer;
-        background-color: $ui-01;
-        transition: $search-transition-timing;
-      }
-
-      .#{$prefix}--container-highlight-class:not(:hover),
-      &:focus,
-      &:active {
-        outline: 2px solid $focus;
-      }
+    .#{$prefix}--container-highlight-class:not(:hover),
+    &:focus,
+    &:active {
+      outline: 2px solid $focus;
     }
   }
 

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -197,168 +197,169 @@ $search-transition-timing: 95ms;
     position: relative;
     z-index: 5999;
 
-    &__logo {
-      @include masthead-logo;
-    }
-
-    &__global {
-      flex: 0;
-    }
-
-    &__nav-container {
-      height: 100%;
-      @include carbon--breakpoint(md) {
-        display: flex;
-      }
-    }
-
-    &__nav {
-      a.#{$prefix}--header__menu-item {
-        @include masthead-top-nav-link;
-      }
-
-      .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true'] {
-        background-color: $ui-01;
-        + .#{$prefix}--header__menu {
-          background-color: $ui-02;
-          box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
-          bottom: -1px;
-          li {
-            @include masthead-top-nav-menu-item;
-          }
-          .#{$prefix}--header__menu-item {
-            border: none;
-            position: relative;
-
-            &:hover {
-              color: $text-01;
-              background-color: $hover-ui;
-            }
-
-            &:focus {
-              &::before {
-                border: 2px solid $interactive-01;
-                box-sizing: border-box;
-              }
-            }
-
-            &::before {
-              content: '';
-              position: absolute;
-              width: 100%;
-              height: 100%;
-              top: 0;
-              left: 0;
-            }
-          }
-        }
-      }
-
-      &::before {
-        display: none;
-      }
-    }
-
-    &__action {
-      border: 2px solid transparent;
-      > {
-        svg {
-          position: relative;
-          fill: currentColor;
-          top: 2px;
-        }
-      }
-      &:hover {
-        background-color: $hover-ui;
-        transition-duration: $search-transition-timing;
-        > {
-          svg {
-            fill: $text-01;
-          }
-        }
-      }
-
-      &:focus,
-      &:active {
-        border-color: $focus;
-        background-color: $hover-ui;
-      }
-
-      .#{$prefix}--overflow-menu {
-        width: 100%;
-        height: 100%;
-
-        &.#{$prefix}--overflow-menu--open {
-          box-shadow: none;
-          outline: 2px solid $interactive-01;
-          outline-offset: 0;
-        }
-
-        &:hover {
-          background: none;
-        }
-
-        &:focus {
-          outline: none;
-          box-shadow: none;
-        }
-      }
-
-      &--active {
-        border: 2px solid $interactive-01;
-        background-color: $hover-ui;
-
-        @include carbon--breakpoint-up(sm) {
-          position: absolute;
-          top: 0;
-          z-index: 6001;
-        }
-      }
-    }
-
-    &__menu[role='menu'] {
-      li {
-        &:hover {
-          background-color: $ui-01;
-        }
-
-        &:last-of-type {
-          .#{$prefix}--header__menu-item {
-            &::after {
-              display: none;
-            }
-          }
-        }
-      }
-
-      .#{$prefix}--header__menu-item {
-        position: relative;
-      }
-    }
-
     .#{$prefix}--header__menu-arrow {
       fill: $text-01;
       &:hover {
         fill: $text-01;
       }
     }
+  }
 
-    &__search--close {
-      overflow: hidden;
-      width: 0;
-      border: none;
-      display: none;
+  .#{$prefix}--header__logo {
+    @include masthead-logo;
+  }
 
-      svg {
-        position: relative;
-        top: 2px;
+  .#{$prefix}--header__global {
+    flex: 0;
+  }
+
+  .#{$prefix}--header__nav-container {
+    height: 100%;
+    @include carbon--breakpoint(md) {
+      display: flex;
+    }
+  }
+
+  .#{$prefix}--header__nav {
+    a.#{$prefix}--header__menu-item {
+      @include masthead-top-nav-link;
+    }
+
+    .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true'] {
+      background-color: $ui-01;
+      + .#{$prefix}--header__menu {
+        background-color: $ui-02;
+        box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
+        bottom: -1px;
+        li {
+          @include masthead-top-nav-menu-item;
+        }
+        .#{$prefix}--header__menu-item {
+          border: none;
+          position: relative;
+
+          &:hover {
+            color: $text-01;
+            background-color: $hover-ui;
+          }
+
+          &:focus {
+            &::before {
+              border: 2px solid $interactive-01;
+              box-sizing: border-box;
+            }
+          }
+
+          &::before {
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+          }
+        }
       }
     }
 
-    &__search--search {
-      outline: none;
-      width: $carbon--spacing-09;
+    &::before {
+      display: none;
     }
+  }
+
+  .#{$prefix}--header__action {
+    border: 2px solid transparent;
+    > {
+      svg {
+        position: relative;
+        fill: currentColor;
+        top: 2px;
+      }
+    }
+    &:hover {
+      background-color: $hover-ui;
+      transition-duration: $search-transition-timing;
+      > {
+        svg {
+          fill: $text-01;
+        }
+      }
+    }
+
+    &:focus,
+    &:active {
+      border-color: $focus;
+      background-color: $hover-ui;
+    }
+
+    .#{$prefix}--overflow-menu {
+      width: 100%;
+      height: 100%;
+
+      &.#{$prefix}--overflow-menu--open {
+        box-shadow: none;
+        outline: 2px solid $interactive-01;
+        outline-offset: 0;
+      }
+
+      &:hover {
+        background: none;
+      }
+
+      &:focus {
+        outline: none;
+        box-shadow: none;
+      }
+    }
+  }
+
+  .#{$prefix}--header__action--active {
+    position: relative;
+    border: 2px solid $interactive-01;
+    background-color: $hover-ui;
+
+    @include carbon--breakpoint-up(sm) {
+      position: absolute;
+      top: 0;
+      z-index: 6001;
+    }
+  }
+
+  .#{$prefix}--header__menu[role='menu'] {
+    li {
+      &:hover {
+        background-color: $ui-01;
+      }
+
+      &:last-of-type {
+        .#{$prefix}--header__menu-item {
+          &::after {
+            display: none;
+          }
+        }
+      }
+    }
+
+    .#{$prefix}--header__menu-item {
+      position: relative;
+    }
+  }
+
+  .#{$prefix}--header__search--close {
+    overflow: hidden;
+    width: 0;
+    border: none;
+    display: none;
+
+    svg {
+      position: relative;
+      top: 2px;
+    }
+  }
+
+  .#{$prefix}--header__search--search {
+    outline: none;
+    width: $carbon--spacing-09;
   }
 
   // masthead profile menu
@@ -370,40 +371,39 @@ $search-transition-timing: 95ms;
     left: 0 !important;
     */
 
-    &__btn {
-      @include carbon--type-style(body-short-02, true);
-
-      color: $text-01;
-      text-decoration: none;
-
-      &:hover {
-        background-color: $ui-01;
-      }
-    }
-
-    &__option {
-      height: $layout-04;
-      &:hover {
-        background-color: $ui-01;
-      }
-    }
     &:focus {
       outline: none;
     }
+
     &::after {
       display: none;
     }
   }
+
+  .#{$prefix}--overflow-menu-options__btn {
+    @include carbon--type-style(body-short-02, true);
+
+    color: $text-01;
+    text-decoration: none;
+
+    &:hover {
+      background-color: $ui-01;
+    }
+  }
+
+  .#{$prefix}--overflow-menu-options__option {
+    height: $layout-04;
+    &:hover {
+      background-color: $ui-01;
+    }
+  }
+
   .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open {
     box-shadow: none;
     background-color: $hover-ui;
   }
   .#{$prefix}--header__action.#{$prefix}--overflow-menu {
     height: $spacing-09;
-  }
-
-  .#{$prefix}--header__action--active {
-    position: relative;
   }
 
   .#{$prefix}--masthead--hide-items .#{$prefix}--header__menu-toggle__hidden,


### PR DESCRIPTION
### Related Ticket(s)

Refs #3471.

### Description

This change to masthead style drifts away from BEM concatenation, so the style can be reused with Web Components.

### Changelog

**Changed**

- A change to masthead style drifts away from BEM concatenation, so the style can be reused with Web Components.