### PR TITLE
fix(left-nav): change element order

### DIFF
--- a/packages/web-components/src/components/masthead/masthead-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-composite.ts
@@ -278,6 +278,15 @@ class DDSMastheadComposite extends LitElement {
     const authenticated = userStatus === USER_AUTHENTICATION_STATUS.AUTHENTICATED;
     const profileItems = authenticated ? authenticatedProfileItems : unauthenticatedProfileItems;
     return html`
+      <dds-left-nav-overlay></dds-left-nav-overlay>
+      <dds-left-nav>
+        ${!brandName
+          ? undefined
+          : html`
+              <dds-left-nav-name>${brandName}</dds-left-nav-name>
+            `}
+        ${this._renderNavItems({ target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV })}
+      </dds-left-nav>
       <dds-masthead aria-label="${ifNonNull(mastheadAssistiveText)}">
         <dds-masthead-menu-button
           button-label-active="${ifNonNull(menuButtonAssistiveTextActive)}"
@@ -312,15 +321,6 @@ class DDSMastheadComposite extends LitElement {
           </dds-masthead-profile>
         </dds-masthead-global-bar>
       </dds-masthead>
-      <dds-left-nav-overlay></dds-left-nav-overlay>
-      <dds-left-nav>
-        ${!brandName
-          ? undefined
-          : html`
-              <dds-left-nav-name>${brandName}</dds-left-nav-name>
-            `}
-        ${this._renderNavItems({ target: NAV_ITEMS_RENDER_TARGET.LEFT_NAV })}
-      </dds-left-nav>
     `;
   }
 

--- a/packages/web-components/src/components/masthead/masthead-menu-button.ts
+++ b/packages/web-components/src/components/masthead/masthead-menu-button.ts
@@ -93,16 +93,31 @@ class DDSMastheadMenuButton extends HostListenerMixin(BXHeaderMenuButton) {
   }
 
   render() {
-    const { _hasSearchActive: hasSearchActive } = this;
+    const { active, _hasSearchActive: hasSearchActive } = this;
     const classes = classMap({
       [`${ddsPrefix}-ce--header__menu-trigger__container`]: true,
       [`${ddsPrefix}-ce--header__menu-trigger__container--has-search-active`]: hasSearchActive,
     });
+    const sentinelTabIndex = !active ? -1 : 0;
     return html`
       <div class="${classes}">
-        <a id="start-sentinel" class="${prefix}--visually-hidden" href="javascript:void 0" role="navigation"> </a>
+        <a
+          id="start-sentinel"
+          tabindex="${sentinelTabIndex}"
+          class="${prefix}--visually-hidden"
+          href="javascript:void 0"
+          role="navigation"
+        >
+        </a>
         ${super.render()}
-        <a id="end-sentinel" class="${prefix}--visually-hidden" href="javascript:void 0" role="navigation"> </a>
+        <a
+          id="end-sentinel"
+          tabindex="${sentinelTabIndex}"
+          class="${prefix}--visually-hidden"
+          href="javascript:void 0"
+          role="navigation"
+        >
+        </a>
       </div>
     `;
   }


### PR DESCRIPTION
### Related Ticket(s)

Refs #3940.

### Description

Changes the element order of `<dds-left-nav>` vs. the rest of the masthead so VoiceOver cursor won't immediately go out as user moves VoiceOver cursor after opening left nav.

Also, deactivates the focus sentinel of `<dds-masthead-menu-button>` given it's not needed unless left nav opens and using it while left nav is closed adds redundant tab-stop.

### Changelog

**Changed**

- The element order of `<dds-left-nav>`.
- A change to deactivate the focus sentinel of `<dds-masthead-menu-button>` while left nav is closed.