### PR TITLE
fix(locale-modal): add missing text for unvailable locale

### DIFF
--- a/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal-composite.ts
@@ -110,7 +110,8 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
   renderLightDOM() {
     const { langDisplay, localeList, open } = this;
     const { localeModal, regionList } = localeList ?? {};
-    const { searchPlaceholder } = localeModal ?? {};
+    const { availabilityText, headerTitle, modalClose, searchClearText, searchLabel, searchPlaceholder, unavailabilityText } =
+      localeModal ?? {};
     const pageLangs: { [locale: string]: string } = altlangs();
     if (Object.keys(pageLangs).length === 0 && (regionList?.length as number) > 0) {
       const messages = [
@@ -138,7 +139,12 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
     }, [] as { href: string; locale: string; region: string; country: string; language: string }[]);
 
     return html`
-      <dds-locale-modal lang-display="${ifNonNull(langDisplay)}" ?open="${open}">
+      <dds-locale-modal
+        close-button-assistive-text="${ifNonNull(modalClose)}"
+        header-title="${ifNonNull(headerTitle)}"
+        lang-display="${ifNonNull(langDisplay)}"
+        ?open="${open}"
+      >
         <dds-regions>
           ${regionList?.map(
             ({ countryList, name }) => html`
@@ -146,7 +152,13 @@ class DDSLocaleModalComposite extends HybridRenderMixin(LitElement) {
             `
           )}
         </dds-regions>
-        <dds-locale-search placeholder="${ifNonNull(searchPlaceholder)}">
+        <dds-locale-search
+          close-button-assistive-text="${ifNonNull(searchClearText)}"
+          label-text="${ifNonNull(searchLabel)}"
+          placeholder="${ifNonNull(searchPlaceholder)}"
+          availability-label-text="${ifNonNull(availabilityText)}"
+          unavailability-label-text="${ifNonNull(unavailabilityText)}"
+        >
           ${massagedCountryList?.map(
             ({ country, href, language, locale, region }) => html`
               <dds-locale-item country="${country}" href="${href}" language="${language}" locale="${locale}" region="${region}">

--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -13,6 +13,7 @@ import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/setti
 import ArrowLeft20 from 'carbon-web-components/es/icons/arrow--left/20.js';
 import EarthFilled16 from 'carbon-web-components/es/icons/earth--filled/16.js';
 import HostListener from 'carbon-web-components/es/globals/decorators/host-listener';
+import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
 import DDSModal from '../modal/modal';
 import '../modal/modal-header';
 import '../modal/modal-heading';
@@ -133,6 +134,12 @@ class DDSLocaleModal extends DDSModal {
   }
 
   /**
+   * The assistive text for the close button.
+   */
+  @property({ attribute: 'close-button-assistive-text' })
+  closeButtonAssistiveText?: string;
+
+  /**
    * The header title.
    */
   @property({ attribute: 'header-title' })
@@ -145,9 +152,10 @@ class DDSLocaleModal extends DDSModal {
   langDisplay?: string;
 
   protected _renderHeader() {
+    const { closeButtonAssistiveText } = this;
     return html`
       <dds-modal-header>
-        <dds-modal-close-button></dds-modal-close-button>
+        <dds-modal-close-button assistive-text="${ifNonNull(closeButtonAssistiveText)}"></dds-modal-close-button>
         <dds-modal-heading>${this._renderHeading()}</dds-modal-heading>
       </dds-modal-header>
     `;

--- a/packages/web-components/src/components/locale-modal/locale-search.ts
+++ b/packages/web-components/src/components/locale-modal/locale-search.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, query, customElement, LitElement } from 'lit-element';
+import { html, property, internalProperty, query, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { INPUT_SIZE } from 'carbon-web-components/es/components/input/input.js';
@@ -47,6 +47,12 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
   private _listNode?: HTMLElement;
 
   /**
+   * `true` if there is one or more search result.
+   */
+  @internalProperty()
+  private _hasAvailableItem = true;
+
+  /**
    * The search box.
    */
   @query(`${prefix}-search`)
@@ -60,10 +66,16 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
   private _updateSearchResults(searchText: string) {
     const { selectorItem } = this.constructor as typeof DDSLocaleSearch;
     const { region: currentRegion } = this;
+    let hasMatch = false;
     forEach(this.querySelectorAll(selectorItem), item => {
       const { country, language, region } = item as DDSLocaleItem;
-      (item as HTMLElement).hidden = region !== currentRegion || !search([country, language], searchText);
+      const matches = region === currentRegion && search([country, language], searchText);
+      if (matches) {
+        hasMatch = true;
+      }
+      (item as HTMLElement).hidden = !matches;
     });
+    this._hasAvailableItem = hasMatch;
   }
 
   _handleThrottledInput(event: Event) {
@@ -113,6 +125,12 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
   slot = 'locales-selector';
 
   /**
+   * The text for the label for the UI showing no available locale.
+   */
+  @property({ attribute: 'unavailability-label-text' })
+  unavailabilityLabelText = 'This page is unavailable in your preferred location or language';
+
+  /**
    * Resets the search box and the scroll position.
    */
   reset() {
@@ -123,6 +141,13 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
     if (searchNode) {
       searchNode.value = '';
       this._updateSearchResults('');
+    }
+  }
+
+  firstUpdated() {
+    const { _searchNode: searchNode } = this;
+    if (searchNode) {
+      this._updateSearchResults(searchNode.value);
     }
   }
 
@@ -137,7 +162,14 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
   }
 
   render() {
-    const { availabilityLabelText, closeButtonAssistiveText, labelText, placeholder } = this;
+    const {
+      availabilityLabelText,
+      closeButtonAssistiveText,
+      labelText,
+      placeholder,
+      unavailabilityLabelText,
+      _hasAvailableItem: hasAvailableItem,
+    } = this;
     return html`
       <div class="${prefix}--locale-modal__filter">
         <div class="${prefix}--locale-modal__search">
@@ -152,7 +184,7 @@ class DDSLocaleSearch extends ThrottedInputMixin(LitElement) {
           >
           </bx-search>
           <p class="${prefix}--locale-modal__search-text">
-            ${availabilityLabelText}
+            ${hasAvailableItem ? availabilityLabelText : unavailabilityLabelText}
           </p>
         </div>
         <div role="listbox" class="${prefix}--locale-modal__list">

--- a/packages/web-components/tests/snapshots/dds-locale-modal-composite.md
+++ b/packages/web-components/tests/snapshots/dds-locale-modal-composite.md
@@ -6,12 +6,20 @@
 
 ```
 <dds-locale-modal
+  close-button-assistive-text="Close modal"
   data-autoid="dds--locale-modal"
+  header-title="Select region"
   tabindex="0"
 >
   <dds-regions>
   </dds-regions>
-  <dds-locale-search placeholder="Search by location or language">
+  <dds-locale-search
+    availability-label-text="This page is available in the following locations and languages"
+    close-button-assistive-text="Clear search input"
+    label-text="Search by location or language"
+    placeholder="Search by location or language"
+    unavailability-label-text="This page is unavailable in your preferred location or language"
+  >
   </dds-locale-search>
 </dds-locale-modal>
 
@@ -21,7 +29,9 @@
 
 ```
 <dds-locale-modal
+  close-button-assistive-text="modal-close-foo"
   data-autoid="dds--locale-modal"
+  header-title="header-title-foo"
   lang-display="lang-display-foo"
   open=""
   tabindex="0"
@@ -32,7 +42,13 @@
     <dds-region-item name="region-name-bar">
     </dds-region-item>
   </dds-regions>
-  <dds-locale-search placeholder="search-placeholder-foo">
+  <dds-locale-search
+    availability-label-text="availability-text-foo"
+    close-button-assistive-text="search-clear-text-foo"
+    label-text="search-label-foo"
+    placeholder="search-placeholder-foo"
+    unavailability-label-text="unavailability-text-foo"
+  >
     <dds-locale-item
       country="country-name-foo"
       href="https://example.com/locale-id-foo"


### PR DESCRIPTION
### Related Ticket(s)

Refs #3895.

### Description

This change adds `unavailability-label-text` attribute to `<dds-locale-search>` so it can show a different text when it gets an empty search result.

Also made some changes to ensure translation text for locale modal is in use fully.

### Changelog

**New**

- `unavailability-label-text` attribute to `<dds-locale-search>` so it can show a different text when it gets an empty search result.

**Changed**

- Some changes to ensure translation text for locale modal is in use fully.