### PR TITLE
fix(Masthead): nav dropdowns should allow body scroll

### DIFF
--- a/packages/react/src/components/Masthead/MastheadTopNav.js
+++ b/packages/react/src/components/Masthead/MastheadTopNav.js
@@ -43,6 +43,7 @@ const MastheadTopNav = ({ navigation, ...topNavProps }) => {
           selected={selected}
           autoId={autoid}
           key={i}
+          disableScroll={link.hasMegapanel}
           setOverlay={setOverlay}>
           {renderNav(link, autoid)}
         </HeaderMenu>

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -59,6 +59,11 @@ class HeaderMenu extends React.Component {
     renderMenuContent: PropTypes.func,
 
     /**
+     * Determines whether to disable body scroll
+     */
+    disableScroll: PropTypes.bool,
+
+    /**
      * function to toogle overlay that appears when opening menu
      */
     setOverlay: PropTypes.func,
@@ -95,12 +100,14 @@ class HeaderMenu extends React.Component {
     this.menuLinkRef.current.focus();
 
     this.setState(prevState => {
-      if (prevState.expanded) {
-        this.props.setOverlay(false);
-        root.document?.body?.classList.remove(`${prefix}--body__lock-scroll`);
-      } else {
-        this.props.setOverlay(true);
-        root.document?.body?.classList.add(`${prefix}--body__lock-scroll`);
+      if (this.props.disableScroll) {
+        if (prevState.expanded) {
+          this.props.setOverlay(false);
+          root.document?.body?.classList.remove(`${prefix}--body__lock-scroll`);
+        } else {
+          this.props.setOverlay(true);
+          root.document?.body?.classList.add(`${prefix}--body__lock-scroll`);
+        }
       }
       return {
         expanded: !prevState.expanded,
@@ -149,7 +156,8 @@ class HeaderMenu extends React.Component {
   handleOnBlur = event => {
     if (!event.currentTarget.contains(event.relatedTarget)) {
       this.setState({ expanded: false, selectedIndex: null });
-      root.document?.body?.classList.remove(`${prefix}--body__lock-scroll`);
+      this.props.disableScroll &&
+        root.document?.body?.classList.remove(`${prefix}--body__lock-scroll`);
     }
 
     if (!event.relatedTarget || !this.checkMenuItems(event).length) {


### PR DESCRIPTION
### Related Ticket(s)

[Masthead]: when opening L1 dropdown, body scroll is disabled #3999 

### Description

Dropdown menus on the Masthead should allow for body scrolling as opposed to the MegaMenu which disables body scroll.

This PR passes in a `disableScroll` prop to the `<HeaderMenu />` component based on whether the menu is a MegaMenu or a regular dropdown. 

### Changelog

**New**

- `disableScroll` prop to the `<HeaderMenu />`

**Changed**

- use `disableScroll` to determine whether to disable scrolling


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
