### PR TITLE
fix(Masthead): empty search handling

### DIFF
--- a/packages/react/src/components/Masthead/MastheadSearch.js
+++ b/packages/react/src/components/Masthead/MastheadSearch.js
@@ -224,7 +224,7 @@ const MastheadSearch = ({
    *
    */
   function searchIconClick() {
-    if (state.isSearchOpen && state.val.length) {
+    if (state.isSearchOpen && state.val.length > 1) {
       root.parent.location.href = getRedirect(state.val);
     } else {
       dispatch({ type: 'setSearchOpen' });


### PR DESCRIPTION
### Related Ticket(s)

#3990 

### Description

Before, when users clicked/pressed enter into an empty search bar, they would get redirected to a page with no results. While it is expected behavior (seeing as an empty query would return nothing), search conditions were changed so an empty search cannot happen at all in the first place.

### Changelog

**Changed**

- Added search condition where it only runs when there's text inputted in the search box.


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
