### PR TITLE
docs(examples): lock browserlist version

### DIFF
--- a/packages/react/examples/codesandbox/components/DotcomShell/package.json
+++ b/packages/react/examples/codesandbox/components/DotcomShell/package.json
@@ -19,6 +19,10 @@
     "parcel-bundler": "^1.12.0",
     "sass": "^1.26.9"
   },
+  "resolutions": {
+    "browserslist": "4.14.2",
+    "caniuse-lite": "1.0.30001129"
+  },
   "sass": {
     "includePaths": [
       "./node_modules"

--- a/packages/react/examples/codesandbox/components/Footer/package.json
+++ b/packages/react/examples/codesandbox/components/Footer/package.json
@@ -19,6 +19,10 @@
     "parcel-bundler": "^1.12.0",
     "sass": "^1.26.9"
   },
+  "resolutions": {
+    "browserslist": "4.14.2",
+    "caniuse-lite": "1.0.30001129"
+  },
   "sass": {
     "includePaths": [
       "./node_modules"

--- a/packages/react/examples/codesandbox/components/Masthead/package.json
+++ b/packages/react/examples/codesandbox/components/Masthead/package.json
@@ -19,6 +19,10 @@
     "parcel-bundler": "^1.12.0",
     "sass": "^1.26.9"
   },
+  "resolutions": {
+    "browserslist": "4.14.2",
+    "caniuse-lite": "1.0.30001129"
+  },
   "sass": {
     "includePaths": [
       "./node_modules"


### PR DESCRIPTION
### Description

This change locks `browserlist` and `caniuse-lite` versions to work around a bug that is recently introduced in either of the packages, that broke our build integration tests.

### Changelog

**Changed**

- A change to kock `browserlist` and `caniuse-lite`.