### PR TITLE
feat(rfc-aem): rfc to support aem spa feature

### DIFF
--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -131,32 +131,55 @@ const ButtonGroup = ({ buttons, enableSizeByContent }) => {
         return (
           <Fragment key={key}>
             <li className={`${prefix}--buttongroup-item`}>
-              <Button
-                data-autoid={`${stablePrefix}--button-group-${key}`}
-                {...button}
-                type="button"
-                kind={key === buttons.length - 1 ? 'primary' : 'tertiary'}>
-                {button.copy}
-              </Button>
+              {buttonItem(buttons, button, key)}
             </li>
             {!shouldUseResizeObserver ? (
               undefined
             ) : (
               <li
                 className={`${prefix}--buttongroup-item ${prefix}--buttongroup-item--pseudo`}>
-                <Button
-                  tabIndex={-1}
-                  {...button}
-                  type="button"
-                  kind={key === buttons.length - 1 ? 'primary' : 'tertiary'}>
-                  {button.copy}
-                </Button>
+                {psuedoButtonItem(buttons, button, key)}
               </li>
             )}
           </Fragment>
         );
       })}
     </ol>
+  );
+};
+
+const buttonItem = (buttons, button, index) => {
+  return React.isValidElement(button) ? (
+    React.cloneElement(button, {
+      'data-autoid': `${stablePrefix}--button-group-${index}`,
+      type: 'button',
+      kind: index === buttons.length - 1 ? 'primary' : 'tertiary',
+    })
+  ) : (
+    <Button
+      data-autoid={`${stablePrefix}--button-group-${index}`}
+      {...button}
+      type="button"
+      kind={index === buttons.length - 1 ? 'primary' : 'tertiary'}>
+      {button.copy}
+    </Button>
+  );
+};
+
+const psuedoButtonItem = (buttons, button, index) => {
+  return React.isValidElement(button) ? (
+    React.cloneElement(button, {
+      type: 'button',
+      kind: index === buttons.length - 1 ? 'primary' : 'tertiary',
+    })
+  ) : (
+    <Button
+      tabIndex={-1}
+      {...button}
+      type="button"
+      kind={index === buttons.length - 1 ? 'primary' : 'tertiary'}>
+      {button.copy}
+    </Button>
   );
 };
 

--- a/packages/react/src/components/ButtonGroup/__stories__/ButtonGroup.stories.js
+++ b/packages/react/src/components/ButtonGroup/__stories__/ButtonGroup.stories.js
@@ -8,6 +8,7 @@
 import { number, select, text } from '@storybook/addon-knobs';
 import ArrowDown20 from '@carbon/icons-react/es/arrow--down/20';
 import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20';
+import Button from '../../../internal/vendor/carbon-components-react/components/Button/Button';
 import ButtonGroup from '../ButtonGroup';
 import Pdf20 from '@carbon/icons-react/es/PDF/20';
 import React from 'react';
@@ -93,6 +94,35 @@ export const Default = ({ parameters }) => {
         according to the text size
       </div>
       <ButtonGroup buttons={buttons} />
+    </div>
+  );
+};
+
+export const SubComponents = ({ parameters }) => {
+  const { buttons } = parameters?.props?.ButtonGroup ?? {};
+  const buttonElements = buttons.map(button => {
+    return <Button href={button.href}>{button.copy}</Button>;
+  });
+  return (
+    <div
+      className="bx-grid"
+      style={{
+        padding: 2 + `rem`,
+      }}>
+      <div>
+        This button group is wrapped within the grid to let the buttons shrink
+        when the text gets smaller
+      </div>
+      <div className="bx--row">
+        <div className="bx--col-lg-16 bx--col-md-6 bx--col-sm-16">
+          <ButtonGroup buttons={buttonElements} />
+        </div>
+      </div>
+      <div style={{ paddingTop: '20px' }}>
+        This button group is not using the grid, so the buttons won't shrink
+        according to the text size
+      </div>
+      <ButtonGroup buttons={buttonElements} />
     </div>
   );
 };

--- a/packages/react/src/components/CardGroup/CardGroup.js
+++ b/packages/react/src/components/CardGroup/CardGroup.js
@@ -75,50 +75,87 @@ const _renderCards = (cards, containerRef, cta) => (
     data-autoid={`${stablePrefix}--card-group`}
     className={`${prefix}--card-group__cards__row ${prefix}--row--condensed`}
     ref={containerRef}>
-    {cards.map((card, index) => {
-      return (
-        <div
-          key={index}
-          className={`${prefix}--card-group__cards__col`}
-          role="region"
-          aria-label={card.heading}>
-          <CTA
-            style="card"
-            key={index}
-            customClassName={`${prefix}--card-group__card`}
-            image={card.image}
-            media={card.media}
-            heading={card.heading}
-            eyebrow={card.eyebrow}
-            copy={card.copy}
-            pictogram={card.pictogram}
-            cta={{
-              ...card.cta,
-              icon: {
-                src: ArrowRight20,
-              },
-            }}
-            type={card.media ? 'video' : 'local'}
-          />
-        </div>
-      );
-    })}
-    {cta && (
-      <div className={`${prefix}--card-group__cards__col`}>
-        <Card
-          inverse={true}
-          heading={cta.heading}
-          cta={{
-            href: cta.cta.href,
-            icon: {
-              src: ArrowRight20,
-            },
-          }}
-        />
-      </div>
-    )}
+    {cardItems(cards)}
+    {cta && ctaItem(cta)}
   </div>
 );
+
+const cardItems = (cards, index) => {
+  return cards.map(card => {
+    const cardElement = React.isValidElement(card) ? (
+      React.cloneElement(card, {
+        style: 'card',
+        key: index,
+        customClassName: `${prefix}--card-group__card`,
+        cta: {
+          ...card.props.cta,
+          icon: {
+            src: ArrowRight20,
+          },
+        },
+        type: card.props.media ? 'video' : 'local',
+      })
+    ) : (
+      <CTA
+        style="card"
+        key={index}
+        customClassName={`${prefix}--card-group__card`}
+        image={card.image}
+        media={card.media}
+        heading={card.heading}
+        eyebrow={card.eyebrow}
+        copy={card.copy}
+        pictogram={card.pictogram}
+        cta={{
+          ...card.cta,
+          icon: {
+            src: ArrowRight20,
+          },
+        }}
+        type={card.media ? 'video' : 'local'}
+      />
+    );
+
+    return (
+      <div
+        key={index}
+        className={`${prefix}--card-group__cards__col`}
+        role="region"
+        aria-label={card.heading}>
+        {cardElement}
+      </div>
+    );
+  });
+};
+
+const ctaItem = cta => {
+  const ctaElement = React.isValidElement(cta) ? (
+    React.cloneElement(cta, {
+      inverse: true,
+      cta: {
+        href: cta.props.cta.href,
+        icon: {
+          src: ArrowRight20,
+        },
+      },
+    })
+  ) : (
+    <Card
+      inverse={true}
+      heading={cta.heading}
+      cta={{
+        href: cta.cta.href,
+        icon: {
+          src: ArrowRight20,
+        },
+      }}
+    />
+  );
+
+  return (
+    <div className={`${prefix}--card-group__cards__col`}>{ctaElement}</div>
+  );
+};
 
 CardGroup.propTypes = {
   /**

--- a/packages/react/src/components/CardGroup/__stories__/CardGroup.stories.js
+++ b/packages/react/src/components/CardGroup/__stories__/CardGroup.stories.js
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Card } from '../../Card';
 import CardGroup from '../CardGroup';
+import { CTA } from '../../CTA';
 import { number } from '@storybook/addon-knobs';
 import React from 'react';
 import readme from '../README.stories.mdx';
@@ -75,6 +77,13 @@ const defaultCard = {
   },
 };
 
+const cardElement = (
+  <CTA
+    heading="Nunc convallis lobortis"
+    copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+    cta={{ href: 'https://www.example.com' }}></CTA>
+);
+
 const cardWithImages = {
   image: {
     defaultSrc: 'https://dummyimage.com/1056x792/ee5396/161616&text=4:3',
@@ -93,6 +102,12 @@ const groupCTA = {
     href: 'https://www.example.com',
   },
 };
+
+const ctaElement = (
+  <Card
+    heading="Top level card link"
+    cta={{ href: 'https://www.example.com' }}></Card>
+);
 
 export const Default = ({ parameters }) => {
   const { cards: data, cta } = parameters?.props?.CardGroup ?? {};
@@ -195,6 +210,33 @@ WithImagesAndCTA.story = {
           length: number('Number of cards', 5, {}, groupId),
         }).map(_ => cardWithImages),
         cta: groupCTA,
+      }),
+    },
+  },
+};
+
+export const SubComponents = ({ parameters }) => {
+  const { cards: data, cta } = parameters?.props?.CardGroup ?? {};
+
+  return (
+    <div className="bx--grid bx--content-group-story">
+      <div className="bx--row">
+        <div className="bx--col-sm-4 bx--col-lg-12 bx--offset-lg-2">
+          <CardGroup cards={data} cta={cta} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+SubComponents.story = {
+  parameters: {
+    knobs: {
+      CardGroup: ({ groupId }) => ({
+        cards: Array.from({
+          length: number('Number of cards', 5, {}, groupId),
+        }).map(_ => cardElement),
+        cta: ctaElement,
       }),
     },
   },

--- a/packages/react/src/components/CardSectionSimple/CardSectionSimple.js
+++ b/packages/react/src/components/CardSectionSimple/CardSectionSimple.js
@@ -20,10 +20,15 @@ const { prefix } = settings;
  * CardSectionSimple pattern it is Cards without images.
  */
 const CardSectionSimple = ({ cards, cta, theme, ...otherProps }) => {
-  const cardsWithoutImages = cards.filter(
-    ({ image, heading, copy, cta: { href } }) =>
-      !image && heading && copy && href
-  );
+  const cardsWithoutImages = cards.filter(card => {
+    let {
+      image,
+      heading,
+      copy,
+      cta: { href },
+    } = React.isValidElement(card) ? card.props : card;
+    return !image && heading && copy && href;
+  });
 
   return (
     <ContentSection

--- a/packages/react/src/components/CardSectionSimple/__stories__/CardSectionSimple.stories.js
+++ b/packages/react/src/components/CardSectionSimple/__stories__/CardSectionSimple.stories.js
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Card } from '../../Card';
 import cards from '../../CardGroup/__stories__/data/cards.json';
 import CardSectionSimple from '../CardSectionSimple';
+import { CTA } from '../../CTA';
 import React from 'react';
 import readme from '../README.stories.mdx';
 import { text } from '@storybook/addon-knobs';
@@ -34,6 +36,19 @@ export default {
     ...readme.parameters,
   },
 };
+
+const cardElement = (
+  <CTA
+    heading="Nunc convallis lobortis"
+    copy="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero."
+    cta={{ href: 'https://www.example.com', copy: 'cta text here' }}></CTA>
+);
+
+const ctaElement = (
+  <Card
+    heading="Top level card link"
+    cta={{ href: 'https://www.example.com' }}></Card>
+);
 
 export const Default = ({ parameters }) => {
   const { heading, cards } = parameters?.props?.CardSectionSimple ?? {};
@@ -83,6 +98,49 @@ WithCTA.story = {
               href: 'https://www.example.com',
             },
           },
+        };
+      },
+    },
+    propsSet: {
+      default: {
+        CardSectionSimple: {
+          cta: {
+            heading: 'Top level card link',
+            cta: {
+              href: 'https://www.example.com',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const SubComponents = ({ parameters }) => {
+  const { heading, cards, cta } = parameters?.props?.CardSectionSimple ?? {};
+
+  const theme =
+    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
+  return (
+    <CardSectionSimple
+      heading={heading}
+      theme={theme}
+      cards={cards}
+      cta={cta}
+    />
+  );
+};
+
+SubComponents.story = {
+  parameters: {
+    knobs: {
+      CardSectionSimple: ({ groupId }) => {
+        const knobs = getBaseKnobs({ groupId });
+
+        return {
+          ...knobs,
+          cards: Array.from({ length: 5 }).map(_ => cardElement),
+          cta: ctaElement,
         };
       },
     },

--- a/packages/react/src/components/LeadSpace/__stories__/LeadSpace.stories.js
+++ b/packages/react/src/components/LeadSpace/__stories__/LeadSpace.stories.js
@@ -8,6 +8,7 @@
 import { boolean, number, select, text } from '@storybook/addon-knobs';
 import ArrowDown20 from '@carbon/icons-react/es/arrow--down/20';
 import ArrowRight20 from '@carbon/icons-react/es/arrow--right/20';
+import Button from '../../../internal/vendor/carbon-components-react/components/Button/Button';
 import LeadSpace from '../LeadSpace';
 import Pdf20 from '@carbon/icons-react/es/PDF/20';
 import React from 'react';
@@ -83,6 +84,70 @@ DefaultWithNoImage.story = {
             groupId
           ),
           buttons,
+        };
+      },
+    },
+  },
+};
+
+export const SubComponents = ({ parameters }) => {
+  const { title, copy, gradient, buttons, image } =
+    parameters?.props?.LeadSpace ?? {};
+  const theme =
+    document.documentElement.getAttribute('storybook-carbon-theme') || 'white';
+  return (
+    <LeadSpace
+      theme={theme}
+      title={title}
+      copy={copy}
+      gradient={gradient}
+      buttons={buttons}
+      image={image}
+    />
+  );
+};
+
+SubComponents.story = {
+  name: 'SubComponents',
+  parameters: {
+    knobs: {
+      LeadSpace: ({ groupId }) => {
+        const buttonCount = number('Number of buttons', 2, {}, groupId);
+        const buttons = [];
+
+        for (let i = 0; i < buttonCount; i++) {
+          buttons.push(
+            <Button
+              renderIcon={
+                iconMap[
+                  select(
+                    `Button Icon ${i + 1} (renderIcon)`,
+                    iconOptions,
+                    iconOptions.ArrowRight,
+                    groupId
+                  )
+                ]
+              }
+              href={text(
+                `Button link (href)`,
+                'https://www.example.com',
+                groupId
+              )}>
+              {text(`Button ${i + 1} (copy)`, `Button ${i + 1}`, groupId)}
+            </Button>
+          );
+        }
+
+        return {
+          title: text('title (title)', 'Lead space title', groupId),
+          copy: text(
+            'copy (copy)',
+            'Use this area for a short line of copy to support the title',
+            groupId
+          ),
+          buttons,
+          gradient: boolean('gradient overlay (gradient)', true, groupId),
+          image: images,
         };
       },
     },


### PR DESCRIPTION
## RFC: Example Updates to Support AEM SPA Feature

### Description

AEM has a feature that allows pages to be rendered almost entirely by React or Angular components.  AEM also supports contextually editing these components.  Proof of concepts have gotten both Carbon and IBM Dotcom Library components working with AEM, but there's one adjustment that would greatly improve how authors in AEM can edit these components.

The RFC allows 'container' components, components that leverage child components internally (Leadspace, CardGroup, ButtonGroup, CardSectionSimple, etc.), to accept full React elements on the properties for those sub-components.

e.g. Passing Button component instances into Lead Space or Button Group components; Passing Card/CTA component instances into Card Group or Card Section components.

This allows AEM authors to edit those child components independently from their container components.  (Example: Dropping new cards into a section, re-arranging cards, and updating properties on a single card in a group.).  Otherwise AEM authors would have to edit all the children components of a container within a single form dialog.

