### PR TITLE
fix(styles): adjusting carbon-components-react to dev dependency

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -40,8 +40,7 @@
     "@carbon/motion": "10.9.0",
     "@carbon/themes": "10.18.0",
     "@carbon/type": "10.15.0",
-    "carbon-components": "10.19.0",
-    "carbon-components-react": "7.19.0"
+    "carbon-components": "10.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",
@@ -60,6 +59,7 @@
     "babel-loader": "^8.0.6",
     "browserslist-config-carbon": "^10.4.0",
     "carbon-components": "10.19.0",
+    "carbon-components-react": "7.19.0",
     "del": "^3.0.0",
     "fast-sass-loader": "^1.5.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

It was reported that the styles package was pulling in `carbon-components-react`, which is not necessary for the styles package itself but for the storybook generation for the expressive theme. This moves this dependency to `devDependencies` instead.

### Changelog

**Changed**

- Moved `carbon-components-react` to `devDependencies` for the styles package
