### PR TITLE
chore(components): use internalProperty decorator

### DIFF
--- a/packages/web-components/docs/coding-conventions.md
+++ b/packages/web-components/docs/coding-conventions.md
@@ -426,9 +426,7 @@ If you get TypeScript "may be null" errors, think twice to see if there is such 
 
 ## Updating view upon change in `private`/`protected` properties
 
-`lit-element` observes for changes in declared properties for updating the view. `@carbon/ibmdotcom-web-components` codebase doesn't use this feature simply to get properties observed. Specifically, `@carbon/ibmdotcom-web-components` doesn't set `private`/`protected` properties as declared. Whenever change in `private`/`protected` should cause update in the view, we take manual approach (`.requestUpdate()`).
-
-> 💡 [`2.3.0` version of `lit-element` introduced `@internalProperty()` decorator](https://github.com/Polymer/lit-element/blob/v2.4.0/CHANGELOG.md#added-1) that takes care of `.requestUpdate()` automatically. Migration to this approach will happen soon.
+To cause re-rendering upon change in `private`/`protected` properties, use `internalProperty()` decorator (instead of `@property()`). This is [a new feature in `2.3.0` version of `lit-element`](https://github.com/Polymer/lit-element/blob/v2.4.0/CHANGELOG.md#added-1).
 
 ## Avoiding global `document`/`window` reference
 

--- a/packages/web-components/src/components/card/card-footer.ts
+++ b/packages/web-components/src/components/card/card-footer.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, query, customElement, TemplateResult } from 'lit-element';
+import { html, property, internalProperty, query, customElement, TemplateResult } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import DDSLinkWithIcon from '../link-with-icon/link-with-icon';
@@ -48,6 +48,7 @@ class DDSCardFooter extends DDSLinkWithIcon {
   /**
    * `true` if there is copy content.
    */
+  @internalProperty()
   protected _hasCopy = false;
 
   /**
@@ -67,7 +68,6 @@ class DDSCardFooter extends DDSLinkWithIcon {
         .assignedNodes()
         .some(node => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim());
       this._hasCopy = hasContent;
-      this.requestUpdate();
     }
   }
 

--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, customElement, TemplateResult } from 'lit-element';
+import { html, property, internalProperty, customElement, TemplateResult } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import { BASIC_COLOR_SCHEME } from '../../globals/shared-enums';
@@ -37,22 +37,26 @@ class DDSCard extends DDSLink {
   /**
    * `true` if there is eyebrow content.
    */
-  protected _hasEyebrow;
+  @internalProperty()
+  protected _hasEyebrow = false;
 
   /**
    * `true` if there is heading content.
    */
-  protected _hasHeading;
+  @internalProperty()
+  protected _hasHeading = false;
 
   /**
    * `true` if there is image content.
    */
-  protected _hasImage;
+  @internalProperty()
+  protected _hasImage = false;
 
   /**
    * `true` if there is copy content.
    */
-  protected _hasCopy;
+  @internalProperty()
+  protected _hasCopy = false;
 
   /**
    * Handles `slotchange` event.
@@ -63,7 +67,6 @@ class DDSCard extends DDSLink {
       .assignedNodes()
       .some(node => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim());
     this[slotExistencePropertyNames[name] || '_hasCopy'] = hasContent;
-    this.requestUpdate();
   }
 
   /**

--- a/packages/web-components/src/components/footer/footer-nav-group.ts
+++ b/packages/web-components/src/components/footer/footer-nav-group.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, customElement, LitElement } from 'lit-element';
+import { html, property, internalProperty, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ChevronRight16 from 'carbon-web-components/es/icons/chevron--right/16.js';
@@ -33,6 +33,7 @@ class DDSFooterNavGroup extends StableSelectorMixin(LitElement) {
   /**
    * `true` to make the accordion item stick expanded.
    */
+  @internalProperty()
   private _shouldStickExpanded = false;
 
   /**
@@ -80,9 +81,7 @@ class DDSFooterNavGroup extends StableSelectorMixin(LitElement) {
    * @param event The event.
    */
   private _handleChangeMediaQuery = (event: MediaQueryListEvent) => {
-    const { _shouldStickExpanded: oldshouldStickExpanded } = this;
     this._shouldStickExpanded = event.matches;
-    this.requestUpdate('_shouldStickExpanded', oldshouldStickExpanded);
   };
 
   /**

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, customElement, LitElement } from 'lit-element';
+import { html, property, internalProperty, customElement, LitElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import styles from './image.scss';
@@ -24,6 +24,7 @@ class DDSImage extends LitElement {
   /**
    * The image data, harvested from `<dds-image-item>`.
    */
+  @internalProperty()
   private _images: HTMLElement[] = [];
 
   /**
@@ -34,7 +35,6 @@ class DDSImage extends LitElement {
     this._images = (target as HTMLSlotElement)
       .assignedNodes()
       .filter(node => node.nodeType === Node.ELEMENT_NODE && (node as Element).matches(selectorItem)) as HTMLElement[];
-    this.requestUpdate();
   }
 
   /**

--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, customElement } from 'lit-element';
+import { html, property, internalProperty, customElement } from 'lit-element';
 import settings from 'carbon-components/es/globals/js/settings';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import ArrowLeft20 from 'carbon-web-components/es/icons/arrow--left/20.js';
@@ -36,6 +36,7 @@ class DDSLocaleModal extends DDSModal {
   /**
    * The current region.
    */
+  @internalProperty()
   private _currentRegion?: string;
 
   /**
@@ -43,7 +44,6 @@ class DDSLocaleModal extends DDSModal {
    */
   private _handleClickBackButton() {
     this._currentRegion = undefined;
-    this.requestUpdate();
   }
 
   /**
@@ -52,9 +52,7 @@ class DDSLocaleModal extends DDSModal {
    * @param event The event.
    */
   private _handleClickRegionSelector(event: MouseEvent) {
-    const { _currentRegion: currentRegion } = this;
     this._currentRegion = (event.target as DDSRegionItem).name;
-    this.requestUpdate('_currentRegion', currentRegion);
   }
 
   @HostListener('eventClose')

--- a/packages/web-components/src/components/modal/modal.ts
+++ b/packages/web-components/src/components/modal/modal.ts
@@ -8,7 +8,7 @@
  */
 
 import { classMap } from 'lit-html/directives/class-map';
-import { html, customElement, property, TemplateResult, SVGTemplateResult } from 'lit-element';
+import { html, customElement, property, internalProperty, TemplateResult, SVGTemplateResult } from 'lit-element';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings.js';
 import settings from 'carbon-components/es/globals/js/settings';
 import BXModal from 'carbon-web-components/es/components/modal/modal.js';
@@ -34,6 +34,14 @@ export enum DDS_MODAL_SIZE {
 }
 
 /**
+ * The table mapping slot name with the private property name that indicates the existence of the slot content.
+ */
+const slotExistencePropertyNames = {
+  header: '_hasHeader',
+  footer: '_hasFooter',
+};
+
+/**
  * Expressive modal.
  *
  * @element dds-modal
@@ -49,16 +57,19 @@ class DDSModal extends StableSelectorMixin(BXModal) {
   /**
    * `true` if there is a header content.
    */
+  @internalProperty()
   private _hasHeader = false;
 
   /**
    * `true` if there is a body content.
    */
+  @internalProperty()
   private _hasBody = false;
 
   /**
    * `true` if there is a footer content.
    */
+  @internalProperty()
   private _hasFooter = false;
 
   /**
@@ -80,18 +91,7 @@ class DDSModal extends StableSelectorMixin(BXModal) {
     const hasContent = (target as HTMLSlotElement)
       .assignedNodes()
       .some(node => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim());
-    switch (name) {
-      case 'header':
-        this._hasHeader = hasContent;
-        break;
-      case 'footer':
-        this._hasFooter = hasContent;
-        break;
-      default:
-        this._hasBody = hasContent;
-        break;
-    }
-    this.requestUpdate();
+    this[slotExistencePropertyNames[name] || '_hasBody'] = hasContent;
   }
 
   /**


### PR DESCRIPTION
### Description

Starts using `@internalProperty()` decorator for all components so we don't have to manually call `requestUpdate()` to re-render the view upon change in `private`/`proptected` properties.

### Changelog

**Changed**

- A series of changes to use `@internalProperty()` decorator for all components.