### PR TITLE
feat(Masthead): add support for megamenu in masthead l1

### DIFF
--- a/packages/react/src/components/Masthead/MastheadL1.js
+++ b/packages/react/src/components/Masthead/MastheadL1.js
@@ -10,6 +10,7 @@ import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/setti
 import HeaderMenu from '../carbon-components-react/UIShell/HeaderMenu';
 import HeaderMenuItem from '../../internal/vendor/carbon-components-react/components/UIShell/HeaderMenuItem';
 import HeaderNavigation from '../../internal/vendor/carbon-components-react/components/UIShell/HeaderNavigation';
+import MegaMenu from './MastheadMegaMenu/MegaMenu';
 import PropTypes from 'prop-types';
 import React from 'react';
 import settings from 'carbon-components/es/globals/js/settings';
@@ -26,22 +27,23 @@ const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
   });
 
   const mastheadL1Links = navigationL1.map((link, index) => {
-    if (link.hasMenu) {
+    const autoid = `${stablePrefix}--masthead-${rest.navType}__l1-nav${index}`;
+    if (link.hasMenu || link.hasMegapanel) {
       return (
         <HeaderMenu
           aria-label={link.title}
           menuLinkName={link.title}
-          data-autoid={`${stablePrefix}--masthead-${rest.navType}__l1-nav${index}`}
+          className={cx({
+            [`${prefix}--masthead__megamenu__l1-nav`]: link.hasMegapanel,
+          })}
+          autoId={autoid}
           key={index}>
-          {renderNav(link.menuSections, rest.navType)}
+          {renderNav(link, rest.navType, autoid)}
         </HeaderMenu>
       );
     } else {
       return (
-        <HeaderMenuItem
-          href={link.url}
-          data-autoid={`${stablePrefix}--masthead-${rest.navType}__l1-nav${index}`}
-          key={index}>
+        <HeaderMenuItem href={link.url} data-autoid={autoid} key={index}>
           {link.title}
         </HeaderMenuItem>
       );
@@ -65,24 +67,29 @@ const MastheadL1 = ({ title, titleLink, navigationL1, ...rest }) => {
 /**
  * Loops through and renders a list of links for the masthead nav
  *
- * @param {Array} sections A list of links to be rendered
+ * @param {object} link A list of links to be rendered
  * @param {string} navType navigation type for autoids
+ * @param {string} autoid autoid predecessor for megamenu items/menu items data-autoids
  * @returns {object} JSX object
  */
-function renderNav(sections, navType) {
+function renderNav(link, navType, autoid) {
   const navItems = [];
-  sections.forEach((section, i) => {
-    section.menuItems.forEach((item, j) => {
-      navItems.push(
-        <HeaderMenuItem
-          href={item.url}
-          data-autoid={`${stablePrefix}--masthead-${navType}__l1-nav${i}-item${j}`}
-          key={item.title}>
-          {item.title}
-        </HeaderMenuItem>
-      );
+  if (link.hasMegapanel) {
+    navItems.push(<MegaMenu key={link.title} data={link} autoid={autoid} />);
+  } else {
+    link.menuSections.forEach((section, i) => {
+      section.menuItems.forEach((item, j) => {
+        navItems.push(
+          <HeaderMenuItem
+            href={item.url}
+            data-autoid={`${stablePrefix}--masthead-${navType}__l1-nav${i}-item${j}`}
+            key={item.title}>
+            {item.title}
+          </HeaderMenuItem>
+        );
+      });
     });
-  });
+  }
   return navItems;
 }
 

--- a/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/carbon-components-react/UIShell/HeaderMenu.js
@@ -140,6 +140,7 @@ class HeaderMenu extends React.Component {
       `${prefix}--masthead__megamenu__category-group`,
       `${prefix}--masthead__megamenu__view-all-cta`,
       `${prefix}--masthead__megamenu__l0-nav`,
+      `${prefix}--masthead__megamenu__l1-nav`,
       `${prefix}--header__menu`,
     ];
 

--- a/packages/styles/scss/components/masthead/_masthead-megamenu.scss
+++ b/packages/styles/scss/components/masthead/_masthead-megamenu.scss
@@ -7,6 +7,7 @@
 
 @mixin masthead-megamenu {
   $l0-nav-height: $spacing-09;
+  $l1-nav-height: rem(98px);
 
   @keyframes expand {
     0% {
@@ -31,6 +32,10 @@
   .#{$prefix}--header__nav
     .#{$prefix}--masthead__megamenu__l0-nav
     .#{$prefix}--header__menu-title[aria-expanded='true']
+    + .#{$prefix}--header__menu,
+  .#{$prefix}--header__nav
+    .#{$prefix}--masthead__megamenu__l1-nav
+    .#{$prefix}--header__menu-title[aria-expanded='true']
     + .#{$prefix}--header__menu {
     background-color: transparent;
     bottom: 0;
@@ -48,7 +53,8 @@
     @include box-shadow;
   }
 
-  .#{$prefix}--masthead__megamenu__l0-nav {
+  .#{$prefix}--masthead__megamenu__l0-nav,
+  .#{$prefix}--masthead__megamenu__l1-nav {
     .#{$prefix}--header__menu {
       position: fixed;
       display: block;
@@ -68,7 +74,6 @@
     .#{$prefix}--header__menu-title[aria-expanded='true']
       + .#{$prefix}--header__menu {
       position: fixed;
-      top: $l0-nav-height;
       left: 0;
       transform: translateZ(0);
       visibility: visible;
@@ -80,6 +85,18 @@
         animation: $transition--expansion motion(standard, expressive) expand;
       }
     }
+  }
+
+  .#{$prefix}--masthead__megamenu__l0-nav
+    .#{$prefix}--header__menu-title[aria-expanded='true']
+    + .#{$prefix}--header__menu {
+    top: $l0-nav-height;
+  }
+
+  .#{$prefix}--masthead__megamenu__l1-nav
+    .#{$prefix}--header__menu-title[aria-expanded='true']
+    + .#{$prefix}--header__menu {
+    top: $l1-nav-height;
   }
 
   .#{$prefix}--masthead__megamenu__container {

--- a/packages/styles/scss/components/masthead/_masthead.scss
+++ b/packages/styles/scss/components/masthead/_masthead.scss
@@ -173,16 +173,8 @@ $search-transition-timing: 95ms;
     }
   }
 
-  .#{$prefix}--masthead__l0-nav--selected a:first-of-type::after {
-    position: absolute;
-    display: block;
-    content: '';
-    bottom: -2px;
-    width: 100%;
-    height: 3px;
-    left: 0;
-    right: 0;
-    background-color: $interactive-01;
+  .#{$prefix}--masthead__l0-nav--selected a[aria-expanded='false'] {
+    border-bottom: solid 3px $interactive-01;
   }
 
   .#{$prefix}--header,


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Add support for megamenu in Masthead L1

<img width="1438" alt="Screen Shot 2020-09-30 at 5 42 19 PM" src="https://user-images.githubusercontent.com/54281166/94742861-6a3d6500-0344-11eb-9bc0-389c09f636b0.png">


### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
