### PR TITLE
docs(components): add JSDoc comments for named slots

### DIFF
--- a/packages/web-components/src/components/card/card.ts
+++ b/packages/web-components/src/components/card/card.ts
@@ -31,6 +31,10 @@ const slotExistencePropertyNames = {
  * Card.
  *
  * @element dds-card
+ * @slot eyebrow - The eyebrow content.
+ * @slot heading - The heading content.
+ * @slot image - The image content.
+ * @slot footer - The footer content.
  */
 @customElement(`${ddsPrefix}-card`)
 class DDSCard extends DDSLink {

--- a/packages/web-components/src/components/content-block-simple/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/content-block-simple/__stories__/README.stories.mdx
@@ -1,5 +1,5 @@
 import { Props, Description } from '@storybook/addon-docs/blocks';
-import contributing from '../../../../../docs/contributing-license.md';
+import contributing from '../../../../../../docs/contributing-license.md';
 
 # `<dds-content-block-simple>`
 

--- a/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
+++ b/packages/web-components/src/components/content-block-simple/__stories__/content-block-simple.stories.ts
@@ -10,7 +10,7 @@
 import { select } from '@storybook/addon-knobs';
 import { html } from 'lit-element';
 import ifNonNull from 'carbon-web-components/es/globals/directives/if-non-null.js';
-// import readme from './README.stories.mdx';
+import readme from './README.stories.mdx';
 import textNullable from '../../../../.storybook/knob-text-nullable';
 import { CTA_TYPE } from '../../cta/shared-enums';
 import '../../image/image';
@@ -141,7 +141,7 @@ export default {
     `,
   ],
   parameters: {
-    // ...readme.parameters,
+    ...readme.parameters,
     gridLargeColumnClass: 'bx--col-lg-8',
     knobs: {
       ContentBlockSimple: ({ groupId }) => ({

--- a/packages/web-components/src/components/content-block-simple/content-block-simple.ts
+++ b/packages/web-components/src/components/content-block-simple/content-block-simple.ts
@@ -23,6 +23,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Simple version of content block.
  *
  * @element dds-content-block-simple
+ * @slot media - The media content.
  */
 @customElement(`${ddsPrefix}-content-block-simple`)
 class DDSContentBlockSimple extends StableSelectorMixin(DDSContentBlock) {

--- a/packages/web-components/src/components/content-block/content-block.ts
+++ b/packages/web-components/src/components/content-block/content-block.ts
@@ -45,6 +45,9 @@ export enum CONTENT_BLOCK_COMPLEMENTARY_STYLE_SCHEME {
 /**
  * Content block.
  *
+ * @slot heading - The heading content.
+ * @slot cta - The footer (CTA) content.
+ * @slot complementary - The complementary (aside) content.
  * @abstract
  */
 class DDSContentBlock extends LitElement {

--- a/packages/web-components/src/components/content-item/content-item.ts
+++ b/packages/web-components/src/components/content-item/content-item.ts
@@ -29,6 +29,9 @@ const slotExistencePropertyNames = {
  * Content item.
  *
  * @element dds-content-item
+ * @slot media - The media content.
+ * @slot heading - The heading content.
+ * @slot cta - The footer (CTA) content.
  */
 @customElement(`${ddsPrefix}-content-item`)
 class DDSContentItem extends StableSelectorMixin(LitElement) {

--- a/packages/web-components/src/components/feature-card-block-medium/feature-card-block-medium.ts
+++ b/packages/web-components/src/components/feature-card-block-medium/feature-card-block-medium.ts
@@ -17,6 +17,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Feature Card Block Medium
  *
  * @element dds-feature-card-block-medium
+ * @slot heading - The heading content.
  */
 @customElement(`${ddsPrefix}-feature-card-block-medium`)
 class DDSFeatureCardBlockMedium extends LitElement {

--- a/packages/web-components/src/components/footer/footer-nav-group.ts
+++ b/packages/web-components/src/components/footer/footer-nav-group.ts
@@ -22,6 +22,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Footer nav group.
  *
  * @element dds-footer-nav-group
+ * @slot title - The title content.
  */
 @customElement(`${ddsPrefix}-footer-nav-group`)
 class DDSFooterNavGroup extends StableSelectorMixin(LitElement) {

--- a/packages/web-components/src/components/footer/footer.ts
+++ b/packages/web-components/src/components/footer/footer.ts
@@ -35,6 +35,9 @@ export enum FOOTER_SIZE {
  * The top-level element in footer.
  *
  * @element dds-footer
+ * @slot brand - The brand content.
+ * @slot legal-nav - The legal nav content.
+ * @slot locale-button - The locale button content.
  */
 @customElement(`${ddsPrefix}-footer`)
 class DDSFooter extends StableSelectorMixin(LitElement) {

--- a/packages/web-components/src/components/image/image.ts
+++ b/packages/web-components/src/components/image/image.ts
@@ -17,7 +17,10 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
 
 /**
  * Image.
+ *
  * @element dds-image
+ * @slot long-description - The long description content.
+ * @slot icon - The icon content.
  */
 @customElement(`${ddsPrefix}-image`)
 class DDSImage extends LitElement {

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-image-viewer.ts
@@ -20,6 +20,8 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * The image content of lightbox media viewer.
  *
  * @element dds-lightbox-image-viewer
+ * @slot title - The title content.
+ * @slot description - The description content.
  */
 @customElement(`${ddsPrefix}-lightbox-image-viewer`)
 class DDSLightboxImageViewer extends DDSLightboxMediaViewerBody {

--- a/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
+++ b/packages/web-components/src/components/lightbox-media-viewer/lightbox-video-player.ts
@@ -23,6 +23,8 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * The video content of lightbox media viewer.
  *
  * @element dds-lightbox-video-player
+ * @slot title - The title content.
+ * @slot description - The description content.
  */
 @customElement(`${ddsPrefix}-lightbox-video-player`)
 class DDSLightboxVideoPlayer extends DDSLightboxMediaViewerBody {

--- a/packages/web-components/src/components/link-list/link-list.ts
+++ b/packages/web-components/src/components/link-list/link-list.ts
@@ -44,6 +44,7 @@ export enum LINK_LIST_TYPE {
  * Link list.
  *
  * @element dds-link-list
+ * @slot heading - The heading content.
  */
 @customElement(`${ddsPrefix}-link-list`)
 class DDSLinkList extends LitElement {

--- a/packages/web-components/src/components/link-with-icon/link-with-icon.ts
+++ b/packages/web-components/src/components/link-with-icon/link-with-icon.ts
@@ -21,6 +21,8 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Link with icon.
  *
  * @element dds-link-with-icon
+ * @slot icon - The icon.
+ * @slot icon-left - The CTA icon to place at the left.
  */
 @customElement(`${ddsPrefix}-link-with-icon`)
 class DDSLinkWithIcon extends StableSelectorMixin(DDSLink) {

--- a/packages/web-components/src/components/locale-modal/locale-modal.ts
+++ b/packages/web-components/src/components/locale-modal/locale-modal.ts
@@ -29,6 +29,8 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Locale modal.
  *
  * @element dds-locale-modal
+ * @slot regions-selector - The area for the regions selector.
+ * @slot locales-selector - The area for the locales selector.
  */
 @customElement(`${ddsPrefix}-locale-modal`)
 // `BXModal` extends `HostListenerMixin`

--- a/packages/web-components/src/components/masthead/masthead-search-composite.ts
+++ b/packages/web-components/src/components/masthead/masthead-search-composite.ts
@@ -22,6 +22,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  * Component that rendres masthead search from search results, etc. data.
  *
  * @element dds-masthead-search-composite
+ * @slot search - The search box content.
  */
 @customElement(`${ddsPrefix}-masthead-search-composite`)
 class DDSMastheadSearchComposite extends ThrottedInputMixin(HybridRenderMixin(LitElement)) {

--- a/packages/web-components/src/components/masthead/masthead.ts
+++ b/packages/web-components/src/components/masthead/masthead.ts
@@ -21,7 +21,7 @@ const { stablePrefix: ddsPrefix } = ddsSettings;
  *
  * @element dds-masthead
  * @slot brand - The left hand area.
- * @slot nav - The nav area.
+ * @slot nav - The nav content.
  * @slot profile - The right hand area.
  */
 @customElement(`${ddsPrefix}-masthead`)

--- a/packages/web-components/src/components/quote/quote.ts
+++ b/packages/web-components/src/components/quote/quote.ts
@@ -54,6 +54,8 @@ const slotExistencePropertyNames = {
  * Quote.
  *
  * @element dds-quote
+ * @slot copy - The copy content.
+ * @slot cta - The footer (CTA) content.
  */
 @customElement(`${ddsPrefix}-quote`)
 class DDSQuote extends StableSelectorMixin(LitElement) {


### PR DESCRIPTION
### Description

Adds JSDoc comments for named slots so Web Component Analyzer can harvest them and show them in our docs.

Also fixed the missing doc for `<dds-content-block-simple>`.

### Changelog

**New**

- JSDoc comments for named slots in several components.

**Changed**

- A fix for missing doc for `<dds-content-block-simple>`.