### PR TITLE
docs(svg): updating documentation for web components and svg imagery

### DIFF
--- a/packages/web-components/src/components/button-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/button-group/__stories__/README.stories.mdx
@@ -36,8 +36,18 @@ or with [JSPM](https://jspm.org)
 
 ```html
 <dds-button-group>
-  <dds-button-group-item href="https://example.com">Lorem ipsum ${ArrowRight20({ slot: 'icon' })}</dds-button-group-item>
-  <dds-button-group-item href="https://example.com">Dolor sit amet ${ArrowRight20({ slot: 'icon' })} </dds-button-group-item>
+  <dds-button-group-item href="https://example.com">
+    Lorem ipsum
+    <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+      <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+    </svg>
+  </dds-button-group-item>
+  <dds-button-group-item href="https://example.com">
+    Dolor sit amet
+    <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+      <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+    </svg>
+  </dds-button-group-item>
 </dds-button-group>
 ```
 

--- a/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-group/__stories__/README.stories.mdx
@@ -20,7 +20,6 @@ Here's a quick example to get you started.
 import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group';
 import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item';
 import '@carbon/ibmdotcom-web-components/es/components/card/card-footer';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 ```
 
 or with [JSPM](https://jspm.org)
@@ -42,13 +41,17 @@ or with [JSPM](https://jspm.org)
       Phasellus at elit sollicitudin, sodales nulla quis, consequat libero.
     </p>
     <dds-card-footer slot="footer">
-      ${ArrowRight20({ slot: 'icon' })}
+      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
     </dds-card-footer>
   </dds-card-group-item>
   <dds-card-group-item href="https://example.com" color-scheme="inverse">
     <div slot="heading">Top level card link</div>
     <dds-card-footer slot="footer" color-scheme="inverse">
-      ${ArrowRight20({ slot: 'icon' })}
+      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
     </dds-card-footer>
   </dds-card-group-item>
 </dds-card-group>

--- a/packages/web-components/src/components/card-link/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card-link/__stories__/README.stories.mdx
@@ -18,7 +18,6 @@ Here's a quick example to get you started.
 
 ```javascript
 import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 ```
 
 or with [JSPM](https://jspm.org)
@@ -34,7 +33,9 @@ or with [JSPM](https://jspm.org)
 ```html
 <dds-card-link href="https://example.com">
   <p>Copy text</p>
-  <svg slot="footer" />
+  <svg slot="footer" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+    <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+  </svg>
 </dds-card-link>
 ```
 

--- a/packages/web-components/src/components/card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/card/__stories__/README.stories.mdx
@@ -18,7 +18,6 @@ Here's a quick example to get you started.
 
 ```javascript
 import '@carbon/ibmdotcom-web-components/es/components/card/card';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 ```
 
 or with [JSPM](https://jspm.org)
@@ -37,7 +36,9 @@ or with [JSPM](https://jspm.org)
     <slot slot="heading">Lorem ipsum dolor sit amet</slot>
     <dds-card-footer slot="footer">
       Card cta text
-      <svg slot="icon"></svg>
+      <svg slot="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
     </dds-card-footer>
 </dds-card>
 ```

--- a/packages/web-components/src/components/feature-card-block-large/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card-block-large/__stories__/README.stories.mdx
@@ -18,7 +18,6 @@ Here's a quick example to get you started.
 
 ```javascript
 import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-large/feature-card-block-large';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 ```
 
 or with [JSPM](https://jspm.org)
@@ -35,7 +34,9 @@ or with [JSPM](https://jspm.org)
 <dds-feature-card-block-large href="https://example.com">
   <img />
   <h3>Copy text</h3>
-  ${ArrowRight20({ slot: 'footer' })}
+  <svg slot="footer" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+    <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+  </svg>
 </dds-feature-card-block-large>
 ```
 

--- a/packages/web-components/src/components/feature-card-block-medium/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card-block-medium/__stories__/README.stories.mdx
@@ -18,7 +18,6 @@ Here's a quick example to get you started.
 
 ```javascript
 import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-medium/feature-card-block-medium';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 ```
 
 or with [JSPM](https://jspm.org)
@@ -33,11 +32,15 @@ or with [JSPM](https://jspm.org)
 
 ```html
 <dds-feature-card-block-medium>
-  <dds-feature-card-block-medium-heading slot="heading">${blockHeading}</dds-feature-card-block-medium-heading>
-  <dds-feature-card-block-medium-card href="${ifNonNull(href" || undefined)}>
-    <dds-image slot="image" alt="${ifNonNull(alt)}" default-src="${ifNonNull(defaultSrc)}"></dds-image>
-    <slot slot="heading">${heading}</slot>
-    ${ArrowRight20({ slot: 'footer' })}
+  <dds-feature-card-block-medium-heading slot="heading">
+    How is artificial intelligence used today in your industry?
+  </dds-feature-card-block-medium-heading>
+  <dds-feature-card-block-medium-card href="https://example.com">
+    <dds-image slot="image" alt="Image alt text" default-src="https://dummyimage.com/672x672/ee5396/161616&amp;amp;text=1x1"></dds-image>
+    <slot slot="heading">Explore AI use cases in all industries</slot>
+    <svg slot="footer" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+      <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+    </svg>
   </dds-feature-card-block-medium-card>
 </dds-feature-card-block-medium>
 ```

--- a/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/feature-card/__stories__/README.stories.mdx
@@ -18,7 +18,6 @@ Here's a quick example to get you started.
 
 ```javascript
 import '@carbon/ibmdotcom-web-components/es/components/feature-card/feature-card';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 ```
 
 or with [JSPM](https://jspm.org)
@@ -35,7 +34,9 @@ or with [JSPM](https://jspm.org)
 <dds-feature-card href="https://example.com">
   <img />
   <h3>Copy text</h3>
-  ${ArrowRight20({ slot: 'footer' })}
+  <svg slot="footer" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+    <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+  </svg>
 </dds-feature-card>
 ```
 

--- a/packages/web-components/src/components/link-list/__stories__/README.stories.mdx
+++ b/packages/web-components/src/components/link-list/__stories__/README.stories.mdx
@@ -19,7 +19,6 @@ Here's a quick example to get you started.
 ```javascript
 import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list';
 import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list-item';
-import ArrowRight20 from 'carbon-web-components/es/icons/arrow--right/20';
 import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link';
 ```
 
@@ -40,7 +39,9 @@ or with [JSPM](https://jspm.org)
   <dds-link-list-item>
     <dds-card-link href="https://example.com">
       <p>Copy text</p>
-      <svg slot="footer"></svg>
+      <svg slot="footer" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20">
+        <path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+      </svg>
     </dds-card-link>
   </dds-link-list-item>
 </dds-link-list>


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The exmaples shown originally were a bit misleading as embedding web
component markup on HTML would not yield an SVG when imported. This
shows how to use an SVG inlined and defining its slot when using in
conjunction with the IBM.com Library web components.

### Changelog

**Changed**

- Multiple READMEs for Web Components
- missing import for `feature-card-block-medium`