### PR TITLE
docs(video-player): updating README

### DIFF
--- a/packages/react/src/components/VideoPlayer/README.stories.mdx
+++ b/packages/react/src/components/VideoPlayer/README.stories.mdx
@@ -27,6 +27,7 @@ Here's a quick example to get you started.
 @include carbon--font-face-mono();
 @include carbon--font-face-sans();
 @import '@carbon/ibmdotcom-styles/scss/components/video-player/video-player';
+@import '@carbon/ibmdotcom-styles/scss/components/image/image';
 ```
 
 > 💡 Only import fonts once per usage


### PR DESCRIPTION
### Description

The `Image` SCSS is required to make the overlay display the Play icon. I caught this bug on the Services page. 

**Without the import**
<img width="1160" alt="Screen Shot 2020-10-05 at 10 46 04" src="https://user-images.githubusercontent.com/42848561/95096079-35ddf600-0702-11eb-9558-1e7ca8621048.png">

**With the import**

<img width="1114" alt="Screen Shot 2020-10-05 at 11 59 59" src="https://user-images.githubusercontent.com/42848561/95096160-4db57a00-0702-11eb-9013-dd984c1e2b21.png">

### Changelog

**New**

- new import in the code sample at the `VideoPlayer` README.