### PR TITLE
feat(masthead): add custom profile login url

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import cx from 'classnames';
+import { DDS_CUSTOM_PROFILE_LOGIN } from '../../internal/FeatureFlags';
 import ddsSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import { globalInit } from '@carbon/ibmdotcom-services/es/services/global/global';
 import Header from '../../internal/vendor/carbon-components-react/components/UIShell/Header';
@@ -268,6 +269,13 @@ const Masthead = ({
                           ? profileData.signedin
                           : profileData.signedout
                       }
+                      {...(mastheadProps.customProfileLogin &&
+                      DDS_CUSTOM_PROFILE_LOGIN
+                        ? {
+                            customProfileLogin:
+                              mastheadProps.customProfileLogin,
+                          }
+                        : {})}
                       navType={navType}
                     />
                   </HeaderGlobalBar>
@@ -328,6 +336,11 @@ Masthead.propTypes = {
    * `true` to render IBM Profile Menu component.
    */
   hasProfile: PropTypes.bool,
+
+  /**
+   * Custom login url in masthead profile menu (experimental)
+   */
+  customProfileLogin: PropTypes.string,
 
   /**
    * `true` to render SearchBar component.

--- a/packages/react/src/components/Masthead/MastheadProfile.js
+++ b/packages/react/src/components/Masthead/MastheadProfile.js
@@ -20,6 +20,7 @@ const MastheadProfile = ({
   overflowMenuProps,
   overflowMenuItemProps,
   profileMenu,
+  customProfileLogin,
 }) => {
   /**
    * Masthead profile menu
@@ -27,14 +28,18 @@ const MastheadProfile = ({
    * @returns {*} Masthead profile menu
    */
   const profileNav = profileMenu.map((item, i) => {
+    const loginUrl =
+      customProfileLogin && item.id === 'signin'
+        ? customProfileLogin
+        : item.url;
+
     return (
       <OverflowMenuItem
         {...overflowMenuItemProps}
         itemText={item.title}
-        href={item.url}
+        href={loginUrl}
         hasDivider={i > 0}
         key={i}
-        primaryFocus
       />
     );
   });
@@ -68,6 +73,11 @@ MastheadProfile.propTypes = {
       url: PropTypes.string,
     })
   ),
+
+  /**
+   * Custom login url in masthead profile menu (experimental)
+   */
+  customProfileLogin: PropTypes.string,
 };
 
 export default MastheadProfile;

--- a/packages/react/src/components/Masthead/README.stories.mdx
+++ b/packages/react/src/components/Masthead/README.stories.mdx
@@ -58,8 +58,8 @@ Add the following line in your `.env` file at the root of your project.
 
 ## Using L1 nav
 
-To use L1 nav, set `mastheadL1Data` prop. `mastheadL1Data` prop should be an object that contains the navigation data of L1 nav:
-
+To use L1 nav, set `mastheadL1Data` prop. `mastheadL1Data` prop should be an
+object that contains the navigation data of L1 nav:
 
 ```javascipt
 const mastheadL1Data = {
@@ -150,6 +150,32 @@ const platformData = {
 
 <Masthead platform={platformData} navigation="default" />;
 ```
+
+## customeProfileLogin
+
+This allows setting a user-defined login URL. This is currently an experimental
+feature. Please see the [feature flags](#feature-flags) section for usage
+information.
+
+In order to utilize this feature, the `profileMenu.signedout` login object must
+contain an `id: signin` entry in the corresponding translation data file. See
+[here](https://github.ibm.com/webstandards/ibm-dotcom-translations/blob/master/translations/masthead-footer/jsononly/usen.json#L1467)
+for an example.
+
+#### Feature Flags
+
+To utilize the following features, set the following variables to `true` within
+your `.env` file or your application build settings.
+
+```
+DDS_CUSTOM_PROFILE_LOGIN=true
+```
+
+> See
+> [feature-flags.md](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/patterns-react/docs/feature-flags.md)
+> and
+> [.env.example](https://github.com/carbon-design-system/ibm-dotcom-library/blob/master/packages/patterns-react/.env.example)
+> for more information
 
 ## Stable selectors
 

--- a/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
+++ b/packages/react/src/components/Masthead/__stories__/Masthead.stories.js
@@ -6,6 +6,7 @@
  */
 
 import { boolean, select, text } from '@storybook/addon-knobs';
+import { DDS_CUSTOM_PROFILE_LOGIN } from '../../../internal/FeatureFlags';
 import inPercy from '@percy-io/in-percy';
 import Masthead from '../Masthead';
 import mastheadKnobs from './data/Masthead.stories.knobs.js';
@@ -46,6 +47,14 @@ Default.story = {
                 setTimeout(resolve, 300000);
               });
 
+        const customProfileLogin = DDS_CUSTOM_PROFILE_LOGIN
+          ? text(
+              'custom profile login url (customProfileLogin)',
+              'https://www.example.com/',
+              groupId
+            )
+          : null;
+
         return {
           navigation: select(
             'navigation data (navigation)',
@@ -66,6 +75,7 @@ Default.story = {
             true,
             groupId
           ),
+          customProfileLogin,
           hasSearch: boolean(
             'show the search functionality (hasSearch)',
             true,

--- a/packages/react/src/components/SimpleBenefits/README.stories.mdx
+++ b/packages/react/src/components/SimpleBenefits/README.stories.mdx
@@ -108,7 +108,7 @@ Add the following line in your `.env` file at the root of your project.
 
 #### Feature Flags
 
-To utilize the following features, set the following variable's to `true` within
+To utilize the following features, set the following variables to `true` within
 your `.env` file or your application build settings.
 
 ```

--- a/packages/react/src/internal/FeatureFlags.js
+++ b/packages/react/src/internal/FeatureFlags.js
@@ -25,6 +25,14 @@ export const DDS_CARD_WITH_PICTOGRAM =
   process.env.DDS_CARD_WITH_PICTOGRAM === 'true' || DDS_FLAGS_ALL || false;
 
 /**
+ * Feature flag to enable custom login url in masthead profile menu
+ *
+ * @type {boolean}
+ */
+export const DDS_CUSTOM_PROFILE_LOGIN =
+  process.env.DDS_CUSTOM_PROFILE_LOGIN === 'true' || DDS_FLAGS_ALL || false;
+
+/**
  * Feature flag for the optional language selector in the footer
  *
  * @type {boolean}


### PR DESCRIPTION
### Related Ticket(s)

#3854 

### Description

Adds custom login URL to masthead profile menu. This is an experimental feature.

### Changelog

**New**

- masthead profile login url can be user defined

**Removed**

- deprecated `primaryFocus` prop

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
