### PR TITLE
docs(rtl): adding documentation on how to enable RTL

### DIFF
--- a/docs/enable-rtl.md
+++ b/docs/enable-rtl.md
@@ -1,0 +1,113 @@
+# Enable RTL
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Overview](#overview)
+- [Setting the `<html dir>` attribute](#setting-the-html-dir-attribute)
+- [Enabling RTLCSS](#enabling-rtlcss)
+  - [Webpack](#webpack)
+  - [Gulp](#gulp)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
+
+## Overview
+
+The IBM.com Library supports right-to-left rendering in all components. However,
+in addition to setting the direction (`dir`) attribute in the `<html>` element,
+some of our components also utilizes directives from the 
+[RTLCSS framework](https://rtlcss.com/). 
+
+## Setting the `<html dir>` attribute
+
+To set the overall document text direction to right-to-left, the following
+can be set in the top of the `html` markup:
+
+```html
+<html dir="rtl">
+```
+
+For more details, read more at [w3c internationalization](https://www.w3.org/International/questions/qa-html-dir).
+
+## Enabling RTLCSS
+
+### Webpack
+
+#### Install `rtlcss`
+
+```bash
+$ yarn add rtlcss --dev
+```
+
+or 
+
+```bash
+$ npm install rtlcss --save-dev
+```
+
+#### Add `rtlcss` to webpack config
+
+```
+const rtlcss = require('rtlcss');
+
+const enableRtl = true; // this can be set manually, environment variable, etc.
+
+...webpack module rules...
+{
+  test: /\.scss$/,  
+  use: [
+    ...other loaders...
+    {
+      loader: "postcss-loader",
+      options: {
+        plugins: () => {
+          const autoPrefixer = require("autoprefixer")({
+            overrideBrowserslist: ["last 1 version", "ie >= 11"],
+          });
+          return enableRtl
+            ? [autoPrefixer, rtlcss]
+            : [autoPrefixer];
+        },
+      },
+    },    
+  ],
+}
+...
+```
+
+> NOTE: Application configuration settings may vary. This is a reduced
+> example of where `rtlcss` can be included in a webpack build 
+> configuration
+
+To learn more, visit [RTLCSS: Getting Started](https://rtlcss.com/learn/).
+
+### Gulp
+
+#### Install `gulp-rtlcss`
+
+```bash
+$ yarn add gulp-rtlcss --dev
+```
+
+or 
+
+```bash
+$ npm install gulp-rtlcss --save-dev
+```
+
+#### Add `rtlcss` to gulp config
+
+```javascript
+const gulp = require('gulp');
+const rtlcss = require('gulp-rtlcss');
+ 
+gulp.task('default', function () {
+    return gulp.src('styles.css')
+        .pipe(rtlcss())
+        .pipe(gulp.dest('dist'));
+});
+```
+
+Visit [gulp-rtlcss](https://github.com/jjlharrison/gulp-rtlcss) for more information.

--- a/docs/enable-rtl.md
+++ b/docs/enable-rtl.md
@@ -1,4 +1,4 @@
-# Enable RTL
+# Enable Right-to-Left (RTL)
 <!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -81,4 +81,8 @@ div[role='main'] {
       list-style: circle;
     }
   }
+
+  ol {
+    list-style: decimal;
+  }
 }

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -14,18 +14,14 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { CURRENT_THEME } from '@carbon/storybook-addon-theme/es/shared';
 import Container from './Container';
 
-const SORT_ORDER_GROUP = [
-  'Overview',
-  'Components',
-  'Patterns (Sections)',
-  'Patterns (Blocks)',
-];
+const SORT_ORDER_GROUP = ['Overview', 'Components'];
 
 const SORT_ORDER = [
   'overview-getting-started--page',
   'overview-building-for-ibm-dot-com--page',
   'overview-environment-variables--page',
   'overview-feature-flags--page',
+  'overview-enable-right-to-left-rtl--page',
   'overview-contributing-to-the-react-package--page',
 ];
 

--- a/packages/react/docs/enable-rtl.stories.mdx
+++ b/packages/react/docs/enable-rtl.stories.mdx
@@ -1,0 +1,6 @@
+import { Description, Meta } from '@storybook/addon-docs/blocks';
+import readme from '../../../docs/enable-rtl.md';
+
+<Meta title="Overview|Enable Right-to-Left (RTL)" />
+
+<Description markdown={readme} />

--- a/packages/web-components/docs/enable-rtl.stories.mdx
+++ b/packages/web-components/docs/enable-rtl.stories.mdx
@@ -1,0 +1,6 @@
+import { Description, Meta } from '@storybook/addon-docs/blocks';
+import readme from '../../../docs/enable-rtl.md';
+
+<Meta title="Overview/Enable Right-to-Left (RTL)" />
+
+<Description markdown={readme} />


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

We have been seeing issues appear where RTL is not configured properly. This is due to adopters not enabling `rtlcss` in their applications, which will have applications render incorrectly if only `<html dir="rtl">` is set since some of our components use `rtlcss` directives.

### Changelog

**New**

- Documentation on enabling RTL
- Added documentation to `React` and `Web Components` storybooks
