### PR TITLE
fix(masthead): update platform name responsive css

### DIFF
--- a/packages/styles/scss/components/masthead/_masthead-search.scss
+++ b/packages/styles/scss/components/masthead/_masthead-search.scss
@@ -40,7 +40,7 @@
     background-color: #dcdcdc;
   }
 
-  @include carbon--breakpoint-down(lg) {
+  @include carbon--breakpoint-down(800px) {
     display: none;
   }
 }


### PR DESCRIPTION
### Related Ticket(s)

#4140 

### Description

Fix masthead platform name to remain visible until hamburger menu appears. Note this issue can be reproduced in all browsers, not only tablet/mobile devices.

![Oct-07-2020 11-58-03](https://user-images.githubusercontent.com/909118/95356261-78373c80-0894-11eb-9b0e-c7d0ac2c432c.gif)


### Changelog

**Changed**

- update responsive css for masthead platform name

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
