### PR TITLE
fix(masthead): fix menu

### DIFF
--- a/packages/web-components/src/components/masthead/masthead.scss
+++ b/packages/web-components/src/components/masthead/masthead.scss
@@ -15,6 +15,21 @@
 @import '../../globals/scss/vars';
 @import '../../globals/scss/box-sizing';
 
+// The masthead nav overflow feature made tweaks to overflow style so it can keep track of overflowed content.
+// It works with mega menu that "floats",
+// but Web Components masthead menu with classic menu style still relies on the overflow area being visible.
+:host(#{$dds-prefix}-masthead) {
+  .#{$prefix}--header__search {
+    @include carbon--breakpoint(md) {
+      overflow-x: visible;
+    }
+  }
+
+  .#{$prefix}--header__nav-container {
+    overflow-x: visible;
+  }
+}
+
 :host(#{$dds-prefix}-masthead-menu-button) {
   @extend :host(#{$prefix}-header-menu-button);
 


### PR DESCRIPTION
### Related Ticket(s)

Refs #4177.

### Description

The masthead nav overflow feature made tweaks to overflow style so it can keep track of overflowed content. It works with mega menu that "floats", but Web Components masthead menu with classic menu style still relies on the overflow area being visible. Introduces Web Components-specific style to fix that.

### Changelog

**Changed**

- Fix to masthead style so the overflow area is visible in Web Components, as masthead nav menu relies on that style.